### PR TITLE
Fixing container navigation

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -45,9 +45,6 @@ const T_BLOB          = 16;
 const T_SEXP          = 17;
 const T_LIST          = 18;
 const T_STRUCT        = 19;
-const T_SEXP_CLOSE    = 20;
-const T_LIST_CLOSE    = 21;
-const T_STRUCT_CLOSE  = 22;
 
 const CH_CR =  13; // '\r'
 const CH_NL =  10; // '\n'
@@ -128,9 +125,6 @@ export function get_ion_type(t: number) : IonType {
     case T_SEXP:          return IonTypes.SEXP;
     case T_LIST:          return IonTypes.LIST;
     case T_STRUCT:        return IonTypes.STRUCT;
-    case T_SEXP_CLOSE:    return undefined;
-    case T_LIST_CLOSE:    return undefined;
-    case T_STRUCT_CLOSE:  return undefined;
     default:              return undefined;
   }
 }
@@ -292,7 +286,7 @@ export class ParserTextRaw {
   private _read_sexp_values() {
     var ch = this._read_after_whitespace(true);
     if (ch == CH_CP) {
-      this._value_push( T_SEXP_CLOSE );
+      this._value_push( EOF );
     }
     else {
       this._unread(ch);
@@ -305,7 +299,7 @@ export class ParserTextRaw {
     var ch = this._read_after_whitespace(true);
     if (ch == CH_CS) {
       // degenerate case of an empty list
-      this._value_push( T_LIST_CLOSE );
+      this._value_push( EOF );
     }
     else {
       // otherwise we read a value and continue
@@ -330,7 +324,7 @@ export class ParserTextRaw {
         op = this._read_string2;
         break;
       case CH_CC :
-        this._value_push( T_STRUCT_CLOSE );
+        this._value_push( EOF );
         return;
       default : 
         if (IonText.is_letter(ch)) {
@@ -357,7 +351,7 @@ export class ParserTextRaw {
     if (ch == CH_CM) {
       ch = this._read_after_whitespace(true);
       if (ch == CH_CS) {
-        this._value_push( T_LIST_CLOSE );
+        this._value_push( EOF );
       }
       else {
         this._unread(ch);
@@ -366,7 +360,7 @@ export class ParserTextRaw {
       }
     }
     else if (ch == CH_CS) {
-      this._value_push( T_LIST_CLOSE );
+      this._value_push( EOF );
     }
     else {
       this._error("expected ',' or ']'");
@@ -378,7 +372,7 @@ export class ParserTextRaw {
     if (ch == CH_CM) {
       ch = this._read_after_whitespace(true);
       if (ch == CH_CC) {
-        this._value_push(T_STRUCT_CLOSE );
+        this._value_push(EOF );
       }
       else {
         this._unread(ch);
@@ -386,7 +380,7 @@ export class ParserTextRaw {
       }
     }
     else if (ch == CH_CC) {
-      this._value_push( T_STRUCT_CLOSE );
+      this._value_push( EOF );
     }
     else {
       this._error("expected ',' or '}'");

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -35,7 +35,7 @@ import { Timestamp } from "./IonTimestamp";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
 
-const BOC = -2; // cloned from IonParserTextRaw
+const BEGINNING_OF_CONTAINER = -2; // cloned from IonParserTextRaw
 const EOF = -1;
 const T_IDENTIFIER = 9;
 const T_STRUCT = 19;
@@ -91,7 +91,7 @@ export class TextReader implements Reader {
     if (this._raw_type === EOF) {
       return undefined;
     }
-    if (this._type && this._type.container) {
+    if (this._raw_type !== BEGINNING_OF_CONTAINER && this._type && this._type.container) {
       this.skip_past_container();
     }
     let p: ParserTextRaw = this._parser;
@@ -126,7 +126,7 @@ export class TextReader implements Reader {
     if (this.isNull()) {
       throw new Error("Can't step into a null container");
     }
-    this._raw_type = BOC;
+    this._raw_type = BEGINNING_OF_CONTAINER;
     this._depth++;
   }
 

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -41,77 +41,13 @@ define(
     var skipList = [
       'clobsWithWhitespace.ion',
       'decimalsWithUnderscores.ion',
-      'equivs/annotatedIvms.ion',
       'equivs/binaryInts.ion',
       'equivs/decimalsWithUnderscores.ion',
       'equivs/intsWithUnderscores.ion',
       'intBinary.ion',
       'intsWithUnderscores.ion',
-      'localSymbolTables.ion',
-      'localSymbolTableImportZeroMaxId.ion',
-      'message2.ion',
-      'non-equivs/annotatedIvms.ion',
-      'non-equivs/annotations.ion',
-      'non-equivs/blobs.ion',
-      'non-equivs/bools.ion',
-      'non-equivs/clobs.ion',
-      'non-equivs/decimals.ion',
-      'non-equivs/documents.ion',
-      'non-equivs/floats.ion',
-      'non-equivs/floatsVsDecimals.ion',
-      'non-equivs/ints.ion',
-      'non-equivs/lists.ion',
-      'non-equivs/strings.ion',
-      'non-equivs/structs.ion',
-      'non-equivs/symbolTables.ion',
-      'non-equivs/symbols.ion',
-      'non-equivs/timestamps.ion',
-      'nonNulls.ion',
-      'nulls.ion',
-      'operators.ion',
-      'sexpAnnotationQuotedOperator.ion',
-      'sexps.ion',
       'stringsWithWhitespace.ion',
-      'structFieldAnnotationsUnquotedThenQuoted.ion',
-      'structs.ion',
-      'subfieldVarUInt.ion',
-      'subfieldVarUInt15bit.ion',
-      'subfieldVarUInt16bit.ion',
-      'subfieldVarUInt32bit.ion',
-      'testfile0.ion',
-      'testfile1.ion',
-      'testfile3.ion',
-      'testfile4.ion',
-      'testfile5.ion',
-      'testfile6.ion',
-      'testfile7.ion',
-      'testfile8.ion',
-      'testfile9.ion',
-      'testfile10.ion',
-      'testfile11.ion',
-      'testfile12.ion',
-      'testfile13.ion',
-      'testfile14.ion',
-      'testfile15.ion',
-      'testfile16.ion',
-      'testfile19.ion',
-      'testfile20.ion',
-      'testfile21.ion',
       'testfile22.ion',
-      'testfile23.ion',
-      'testfile24.ion',
-      'testfile25.ion',
-      'testfile26.ion',
-      'testfile28.ion',
-      'testfile29.ion',
-      'testfile30.ion',
-      'testfile31.ion',
-      'testfile33.ion',
-      'testfile34.ion',
-      'testfile35.ion',
-      'testfile37.ion',
-      'timestamp/equivTimeline/leapDayRollover.ion',
-      'timestamp/equivTimeline/timestamps.ion',
       'utf16.ion',
       'utf32.ion',
     ];
@@ -147,12 +83,14 @@ define(
         if (typeof(next) === 'undefined') {
           if (reader.depth() > 0) {
             // End of container
+            console.log("Stepping out");
             reader.stepOut();
           } else {
             // End of data
             break;
           }
         } else if (next.container && !reader.isNull()) {
+          console.log("Stepping in");
           reader.stepIn();
         }
       }


### PR DESCRIPTION
The parser expects the tokenizer (class ParserTextRaw) to return an EOF value when it reaches the end of a container, but the tokenizer actually returns distinct values for each type of container end (end-of-struct, end-of-list, etc.). This change aligns the interface between the two by removing the specific end-of-container values (which are never read) in favor of the existing EOF value.

As you can see, this fixes a large amount of tests