### PR TITLE
build using semantic-release and friends

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
+# Use `npm pack` to create a tgz file. View the contents of the .tgz to test your .npmignore
+docs
+ion-tests 
+tests
+.baseDir*
+.travis.yml
+_config.yml
+.nojekyll 
+.gitmodules
+.tscache
+.idea
+browser
+src
+*.map
+Gruntfile.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
-
 language: node_js
-
-node_js: 
-  - "node"
-
-script: grunt all
-
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '7'
+before_script:
+  - npm prune
+script: 
+  - npm run test
+after_success:
+  - 'if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then npm run semantic-release; fi'
+  - 'if [ "$TRAVIS_BRANCH" != "master" ]; then exit 0; fi'
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,6 +72,15 @@ module.exports = function(grunt) {
           module: "amd",
           declaration: true
         }
+      },
+      'commonjs-es6': {
+        src: ['src/**/*.ts'],
+        outDir: 'dist/commonjs/es6',
+        options: {
+          target: "es6",
+          module: "commonjs",
+          declaration: true
+        }
       }
     },
       /**
@@ -100,11 +109,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('remap-istanbul');
   grunt.loadNpmTasks('intern');
 
-  grunt.registerTask('build', ['clean', 'ts:amd-es6','copy:main']);
+  grunt.registerTask('build', ['clean', 'ts:amd-es6', 'ts:commonjs-es6','copy:main']);
   grunt.registerTask('test', ['build', 'intern:es6']);
   grunt.registerTask('doc', ['test', 'typedoc']);
   grunt.registerTask('coverage', ['doc', 'remapIstanbul']);
   grunt.registerTask('all', ['coverage']);
+
+
+  // NPM
+  grunt.registerTask('build:npm', ['ts:commonjs-es6']);
 
   grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -1,29 +1,37 @@
 {
   "name": "ion-js",
-  "version": "0.9.0",
+  "version": "0.0.0-development",
   "description": "A JavaScript implementation of the Ion data interchange format",
-  "main": "dist/amd/ed6/Ion.js",
-  "types": "dist/amd/ed6/Ion.d.ts",
-  "directories": {
-    "test": "test"
-  },
+  "main": "dist/commonjs/es6/Ion.js",
+  "types": "dist/commonjs/es6/Ion.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "commit": "git-cz",
+    "test": "grunt test",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/amzn/ion-js.git"
+    "url": "https://github.com/amzn/ion-js.git"
   },
-  "keywords" : [ 
-    "ion", "JSON", "data format"
-  ], 
+  "keywords": [
+    "ion",
+    "JSON",
+    "data format"
+  ],
   "author": "The Ion Team <ion-team@amazon.com> (https://amznlabs.github.io/ion-docs/)",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/amzn/ion-js/issues"
   },
   "homepage": "https://github.com/amzn/ion-js#readme",
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-conventional-changelog"
+    }
+  },
   "devDependencies": {
+    "commitizen": "^2.9.6",
+    "cz-conventional-changelog": "^2.0.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
@@ -34,6 +42,7 @@
     "intern": "^3.4.1",
     "remap-istanbul": "^0.9.1",
     "typedoc": "^0.5.8",
-    "typescript": "^2.2.1"
+    "typescript": "^2.2.1",
+    "semantic-release": "^6.3.6"
   }
 }


### PR DESCRIPTION
Added semantic-release and commitizen to automate release to NPM on `master` branch 
Generating commonjs modules required for NPM 
Added `.npmignore` to exclude files during packaging of NPM module. 
