### PR TITLE
build(npm): Update build task to perform all steps (es6, es5 and npm)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,7 +92,7 @@ module.exports = function(grunt) {
       main: {
         files: [
           { expand: true,
-            src: ['dist/amd/es6/*.js'],
+            src: ['dist/amd/es5/*.js'],
             dest: 'browser/scripts/ion/',
             flatten: true
           }
@@ -125,9 +125,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('remap-istanbul');
   grunt.loadNpmTasks('intern');
 
-  grunt.registerTask('build', ['clean', 'ts:amd-es6', 'ts:commonjs-es6','copy:main']);
-  grunt.registerTask('build', ['clean', 'ts:amd-es6','copy:main']);
-  grunt.registerTask('toES5', ['build', 'babel']);
+  grunt.registerTask('build', ['clean', 'ts:amd-es6', 'ts:commonjs-es6','babel', 'copy:main']);
   grunt.registerTask('test', ['build', 'intern:es6']);
   grunt.registerTask('doc', ['test', 'typedoc']);
   grunt.registerTask('coverage', ['doc', 'remapIstanbul']);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "JSON",
     "data format"
   ],
-  "author": "The Ion Team <ion-team@amazon.com> (https://amznlabs.github.io/ion-docs/)",
+  "author": "The Ion Team <ion-team@amazon.com> (https://amzn.github.io/ion-docs/index.html)",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/amzn/ion-js/issues"


### PR DESCRIPTION
Build task now generates es6, es5, and npm files. Ready for 1.0.0 version on NPM

BREAKING CHANGE: Not really breaking, but adding it so that we get 1.0.0 from semantic-release