### PR TITLE
docs(api): Moved to ghpages. Keeping docs folder till we verify ghpages works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,17 @@ node_js:
 before_script:
   - npm prune
 script: 
-  - npm run test
+  - npm run release
 after_success:
   - 'if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then npm run semantic-release; fi'
   - 'if [ "$TRAVIS_BRANCH" != "master" ]; then exit 0; fi'
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+deploy:
+  provider: pages
+  skip_clean: true
+  local_dir: doc
+  github_token: $GH_TOKEN
+  on: 
+    branch: master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,14 +196,22 @@ module.exports = function(grunt) {
 
 
   // Tests
-  grunt.registerTask('test', ['build', 'intern:es6']);
-  grunt.registerTask('test:coverage', ['test', 'remapIstanbul']);
+  grunt.registerTask('test', ['build', 'intern:es6']);     // build and test
+  grunt.registerTask('test:run', ['intern:es6']);          // run test do not build
+  grunt.registerTask('test:coverage', ['remapIstanbul']);  // depends on `test:run`. Generates html output
 
   // Documentation
+  grunt.registerTask('nojekyll', 'Write an empty .nojekyll file to allow typedoc html output to be rendered',
+    function(){ 
+      grunt.file.write('docs/.nojekyll', '');
+    });
+
   grunt.registerTask('doc', ['typedoc']);
 
 
+  // release target used by Travis 
+  grunt.registerTask('release', ['build', 'test:run', 'test:coverage', 'typedoc', 'nojekyll']);
 
-
+  // default for development
   grunt.registerTask('default', ['test']);
 };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 <p align="right">
- <a title="" href="https://api.travis-ci.org/amzn/ion-js.svg?branch=master">
- <img src="https://api.travis-ci.org/amzn/ion-js.svg?branch=master"/>
- </a>
+ <a title="npm-version" href="https://www.npmjs.com/package/ion-js"><img src="https://img.shields.io/npm/v/ion-js.svg"/></a>
+ <a title="license" href="https://github.com/amzn/ion-js/blob/master/LICENSE"><img src="https://img.shields.io/hexpm/l/plug.svg"/></a>
+
+</p>
+<p align="right">
+ <a title="travis" href="https://travis-ci.org/amzn/ion-js"><img src="https://api.travis-ci.org/amzn/ion-js.svg?branch=master"/></a>
+ <a title="docs" href="https://amzn.github.io/ion-js/api/index.html"><img src="https://img.shields.io/badge/docs-api-green.svg?style=flat-square"/></a>
+ <a title="semantic-release" href="https://github.com/amzn/ion-js/releases"><img src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square"/></a>
 </p>
 
 # About 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "commit": "git-cz",
     "test": "grunt test",
+    "release": "grunt release",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {


### PR DESCRIPTION
+ Added new target for release to be run on travis
+ Added travis config to deploy to gh_pages (currently using my personal token, waiting on decision to update the token to something else) 
+ Added Shields on README.md that link to API Docs, Travis build and Releases 