### PR TITLE
Binary Timestamp Bug Fix

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -489,8 +489,11 @@ function read_timestamp_value(span: Span, len: number) : Timestamp {
       minutes = read_var_unsigned_int(span);
       if (span.position() >= end) break;
       
-      seconds = read_decimal_value(span, end - span.position());
+      seconds = read_var_unsigned_int(span);
       precision = Precision.SECONDS;
+      if (span.position() >= end) break;
+
+      seconds += read_decimal_value(span, end - span.position());
       break;
     }
   }   

--- a/tests/intern-debug.js
+++ b/tests/intern-debug.js
@@ -30,5 +30,6 @@ define({
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',
     'tests/unit/IonBinaryWriterTest',
+    'tests/unit/IonBinaryTimestampTest',
   ],
 });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -30,5 +30,6 @@ define({
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',
     'tests/unit/IonBinaryWriterTest',
+    'tests/unit/IonBinaryTimestampTest',
   ],
 });

--- a/tests/unit/IonBinaryTimestampTest.js
+++ b/tests/unit/IonBinaryTimestampTest.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+define([
+    'intern',
+    'intern!object',
+    'intern/chai!assert',
+    'dist/amd/es6/IonTests',
+  ],
+  function(intern, registerSuite, assert, ion) {
+
+    var suite = {
+      name: 'BinaryTimestamp'
+    };
+
+    suite['Binary Timestamp Round Trip'] = function() {
+      // First part - writing timestamp into binary datagram
+      var Ion = ion;
+      var writer = Ion.makeBinaryWriter();
+      var timestamp = new Ion.Timestamp(5, 0, 2017, 06, 07, 18, 29, '17.901');
+      writer.writeStruct();
+      writer.writeFieldName('test_timestamp');
+      writer.writeTimestamp(timestamp);
+      writer.endContainer();
+      writer.close();
+      var binaryData = writer.getBytes();
+
+      /* Datagram content
+       * {
+       *     test_timestamp:2017-06-07T18:29:17.901Z
+       * }
+       */
+
+      // Second part - reading timestamp from binary datagram created above
+      var reader = Ion.makeReader(binaryData);
+      reader.next();
+      reader.stepIn();
+      reader.next();
+      var timestampValue = reader.timestampValue();
+
+      assert.equal(timestamp.toString(), timestampValue.toString());
+    }
+
+    registerSuite(suite);
+  }
+);


### PR DESCRIPTION
The existing implementation parses the seconds portion of the timestamp as a whole decimal number, whereas the seconds portion is actually encoded as an integer portion plus an fractional portion. Therefore, the seconds portion should be first parsed as an integer, and if there is additional data in the span (i.e. the fraction portion), the remaining data should then be parsed as a decimal number same as the existing implementation.