### PR TITLE
Fix #66: Zulu timestamps fails with Error: Invalid decimal 00.000Z

### DIFF
--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -30,7 +30,6 @@
 //    undefined, empty or a null image it returns the timestamp NULL.
 
 import { Decimal } from "./IonDecimal";
-import { is_digit } from "./IonText";
 import { isNumber } from "./IonUtilities";
 import { isString } from "./IonUtilities";
 import { isUndefined } from "./IonUtilities";
@@ -178,7 +177,7 @@ function to_4_digits(v: number) : string {
 function read_unknown_digits(str: string, pos: number) : string {
   let i: number = pos;
   for (; i < str.length; i++) {
-    if (!isNumber(str.charCodeAt(i))) {
+    if (!isNumber(parseInt(str[i], 10))) {
       break;
     }
   }
@@ -501,7 +500,10 @@ export class Timestamp {
           break;
         // 1234-67-89T12:45:78.dddd
         case States.FRACTIONAL_SECONDS:
-          seconds = Decimal.parse(str.substr(17, pos - 17));
+          const START_POSITION_OF_SECONDS = 17;
+
+          seconds = Decimal.parse(str.substring(START_POSITION_OF_SECONDS, pos));
+
           break;
         case States.OFFSET:
           break;

--- a/src/IonUtilities.ts
+++ b/src/IonUtilities.ts
@@ -15,7 +15,7 @@
  * A collection of general language-level helper methods.
  */
 export function isNumber(value: any) : value is number {
-  return typeof(value) == 'number';
+  return typeof(value) == 'number' && !isNaN(value);
 }
 
 export function isString(value: any) : value is string {

--- a/tests/unit/IonTimestampTest.js
+++ b/tests/unit/IonTimestampTest.js
@@ -17,18 +17,21 @@
     const assert = require('intern/chai!assert');
     const ion = require('dist/amd/es6/Ion');
 
-    var suite = {
+    let suite = {
       name: 'Timestamp'
     };
 
-    var parseTest = function(name, timestamp) {
+    const parseTest = function(name, timestamp) {
       suite[name] = function() {
         ion.Timestamp.parse(timestamp);
       }
-    }
+    };
 
     parseTest('Parses year', '2017T');
     parseTest('Parses month', '2017-02T');
+    // Seconds are optional, but local offset is not.
+    parseTest('Parses date and time with only hour and minutes', '2007-02-23T12:14Z');
+    parseTest('Parses timestamp: The same instant in UTC ("zero" or "zulu")', '2017-05-01T01:00:00.000Z');
 
     registerSuite(suite);
   }


### PR DESCRIPTION
This is a fix for #66.