### PR TITLE
feat: Add 'raw_token' reader option

### DIFF
--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -39,12 +39,13 @@ const e = {
 export interface Options {
   catalog: Catalog;
   sourceType: string;
+  raw_tokens: boolean;
 }
 
 /**
- * Returns the `buf` type as binary or text. 
- * 
- * @param buffer we want to check its type 
+ * Returns the `buf` type as binary or text.
+ *
+ * @param buffer we want to check its type
  * @returns either `'binary'` or `'text'`
  */
 function get_buf_type(buf: Span) {
@@ -57,7 +58,7 @@ function makeBinaryReader(span: Span, options: Options) : BinaryReader {
 }
 
 function makeTextReader(span: Span, options: Options) : TextReader {
-  return new TextReader(span, options && options.catalog);
+  return new TextReader(span, options && options.catalog, options && options.raw_tokens);
 }
 
 /**
@@ -133,4 +134,4 @@ export { SharedSymbolTable } from "./IonSharedSymbolTable";
 export { Timestamp } from "./IonTimestamp";
 export { toBase64 } from "./IonText";
 export { TypeCodes } from "./IonBinary";
-
+export { get_ion_type } from "./IonParserTextRaw";

--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -23,6 +23,7 @@ import { TextWriter } from "./IonTextWriter";
 import { Writeable } from "./IonWriteable";
 import { BinaryWriter } from "./IonBinaryWriter";
 import { LocalSymbolTable, defaultLocalSymbolTable } from "./IonLocalSymbolTable";
+import { ParserTextRaw } from "./IonParserTextRaw";
 
 const e = {
   name: "IonError",
@@ -61,6 +62,12 @@ function makeBinaryReader(span: BinarySpan, options: Options) : BinaryReader {
 
 function makeTextReader(span: StringSpan, options: Options) : TextReader {
   return new TextReader(span, options && options.catalog, options && options.raw_tokens);
+}
+
+export function makeTextTokenizer(source: string) : ParserTextRaw {
+  let span = new StringSpan(source);
+  let reader = new TextReader(span, undefined /* catalog */, true /* raw */);
+  return reader.raw_parser();
 }
 
 /**
@@ -118,8 +125,3 @@ export { Timestamp } from "./IonTimestamp";
 export { toBase64 } from "./IonText";
 export { TypeCodes } from "./IonBinary";
 export { getIonType } from "./IonParserTextRaw";
-// Local Variables:
-// mode: c++
-// c-basic-offset:2
-// indent-tabs-mode:nil
-// End:

--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -32,7 +32,7 @@ import { makeSymbolTable } from "./IonSymbols";
 import { ParserBinaryRaw } from "./IonParserBinaryRaw";
 import { Reader } from "./IonReader";
 import { SharedSymbolTable } from "./IonSharedSymbolTable";
-import { Span } from "./IonSpan";
+import { BinarySpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
@@ -87,7 +87,7 @@ export class BinaryReader implements Reader {
   private _symtab: LocalSymbolTable;
   private _raw_type: number;
 
-  constructor(source: Span, catalog: Catalog) {
+  constructor(source: BinarySpan, catalog: Catalog) {
     this._parser   = new ParserBinaryRaw(source);
     this._cat      = catalog || new Catalog();
     this._symtab   = defaultLocalSymbolTable();
@@ -178,7 +178,7 @@ export class BinaryReader implements Reader {
       }
     }
     else if (get_ion_type(t._raw_type).scalar) {
-      // BLOB is a scalar by you don't want to just use the string 
+      // BLOB is a scalar by you don't want to just use the string
       // value otherwise all other scalars are fine as is
       if (t._raw_type === TB_SYMBOL) {
         n = p.numberValue();
@@ -248,4 +248,3 @@ export class BinaryReader implements Reader {
     return s;
   }
 }
-

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -15,7 +15,7 @@
 // IonParserBinaryRaw
 //
 // Handles parsing the Ion from a binary span.
-// Returns on any value with value type. The 
+// Returns on any value with value type. The
 //
 // members of ParserBinaryRaw:
 //    _in    = source span
@@ -42,7 +42,7 @@
 //    stringValue
 //    decimalValue
 //    timestampValue
-//    byteValue 
+//    byteValue
 
 import * as IonBinary from "./IonBinary";
 
@@ -52,7 +52,7 @@ import { IonTypes } from "./IonTypes";
 import { IVM } from "./IonConstants";
 import { LongInt } from "./IonLongInt";
 import { Precision } from "./IonPrecision";
-import { Span } from "./IonSpan";
+import { BinarySpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
 
 const DEBUG_FLAG = true;
@@ -122,7 +122,7 @@ function decode_type_stack_len(ts) {
 }
 
 const VINT_SHIFT =    7;
-const VINT_MASK  = 0x7f; 
+const VINT_MASK  = 0x7f;
 const VINT_FLAG  = 0x80;
 
 function high_nibble(tb) {
@@ -139,7 +139,7 @@ const UNICODE_MAX_THREE_BYTE_SCALAR     = 0x0000FFFF; // 4 + 6+6    = 16 / 3 = 5
 const UNICODE_MAX_FOUR_BYTE_SCALAR      = 0x0010FFFF; // 3 + 6+6+6  = 21 / 4 = 5.25 bits per byte
 const UNICODE_THREE_BYTES_OR_FEWER_MASK = 0xFFFF0000; // if any bits under the f's are set the scalar is either 4 bytes long, or invalid (negative or too large)
 
-const UNICODE_ONE_BYTE_MASK             = 0x7F;       // 8-1 = 7 bits    
+const UNICODE_ONE_BYTE_MASK             = 0x7F;       // 8-1 = 7 bits
 const UNICODE_ONE_BYTE_HEADER           = 0x00;       // the high bit is off
 const UNICODE_TWO_BYTE_MASK             = 0x1F;       // 8-3 = 5 bits
 const UNICODE_TWO_BYTE_HEADER           = 0xC0;       // 8 + 4 = 12 = 0xC0
@@ -164,10 +164,10 @@ function utf8_is_multibyte_char(scalar : number) : boolean {
 }
 
 function utf8_length_from_first_byte(scalar: number) : number {
-  // shift the top 4 bits to the bottom 
+  // shift the top 4 bits to the bottom
   // these have all the valid alternatives for
   // the first byte of the UTF8 sequence
-  switch (scalar >> 4) {  
+  switch (scalar >> 4) {
     case  0: // 0000
     case  1: // 0001
     case  2: // 0010
@@ -192,7 +192,7 @@ function utf8_length_from_first_byte(scalar: number) : number {
   }
 }
 
-function read_utf8_tail(span: Span, c: number, len: number) : number {
+function read_utf8_tail(span: BinarySpan, c: number, len: number) : number {
   switch (len) {
     case 1:
         break;
@@ -217,7 +217,7 @@ function read_utf8_tail(span: Span, c: number, len: number) : number {
   return c;
 }
 
-function read_var_unsigned_int(span: Span) : number {
+function read_var_unsigned_int(span: BinarySpan) : number {
   var b, v;
 
   do {
@@ -230,7 +230,7 @@ function read_var_unsigned_int(span: Span) : number {
   return v;
 }
 
-function read_var_unsigned_int_past(span: Span, pos: number, limit: number) : number {
+function read_var_unsigned_int_past(span: BinarySpan, pos: number, limit: number) : number {
   var b, v;
 
   while (pos < limit) {
@@ -244,18 +244,18 @@ function read_var_unsigned_int_past(span: Span, pos: number, limit: number) : nu
   return v;
 }
 
-function read_var_signed_int(span: Span) : number { 
-  var b, 
-      v = 0, 
+function read_var_signed_int(span: BinarySpan) : number {
+  var b,
+      v = 0,
       shift = 6,      // the first byte has only 6 bits so if we shift it we shift 6 (7 after than)
       is_neg = false;
-  
+
   b = span.next();
   if ((b & 0x40) !== 0) {
     b = (b & (0x3f | 0x80));  // clears the sign bit
     is_neg = true;
   }
-  
+
   // shift in all but the last byte (we've already read the first)
   while ((b & 0x80) === 0) {
     v = (v << shift);
@@ -265,21 +265,21 @@ function read_var_signed_int(span: Span) : number {
   }
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) undefined;
-  
+
   if (shift > 0) {
     v = (v << shift);
   }
   v = v | (b & 0x7f);
-  
+
   // now we put the sign on, if it's needed
   if (is_neg) v = - v;
-  
+
   return v;
 }
 
-function read_var_signed_longint(span: Span) : LongInt {
-  var b, 
-      v = 0, 
+function read_var_signed_longint(span: BinarySpan) : LongInt {
+  var b,
+      v = 0,
       bytes = [],
       dst = [],
       bit_count, byte_count,
@@ -287,13 +287,13 @@ function read_var_signed_longint(span: Span) : LongInt {
       dst_idx, src_idx,
       src_offset, dst_offset,
       is_neg = false;
-  
+
   b = span.next();
   if ((b & 0x40) !== 0) {
     b = (b & (0x3f | 0x80));  // clears the sign bit
     is_neg = true;
   }
-  
+
   // shift in all but the last byte (we've already read the first)
   while ((b & 0x80) === 0) {
     bytes.push(b & 0x7f);
@@ -302,21 +302,21 @@ function read_var_signed_longint(span: Span) : LongInt {
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) return undefined;
   bytes.push(b & 0x7f);
-  
+
   // now we need to compress the bytes
   bit_count = 6 + (bytes.length - 1) * 7;
   byte_count = Math.floor((bit_count + 1) / 8) + 1;
-  
+
   dst_idx = byte_count - 1;
   src_idx = bytes.length - 1;
-  
+
   src_offset = 0;
   dst_offset = 0;
-  
+
   dst = [];
   dst[dst_idx] = 0;
   bits_to_copy = bit_count;
-  
+
   while (bits_to_copy > 0) {
     to_copy = 7 - src_offset;
     if (to_copy > bits_to_copy) to_copy = bits_to_copy;
@@ -344,12 +344,12 @@ function read_var_signed_longint(span: Span) : LongInt {
   return LongInt.fromBytes(bytes, is_neg ? -1 : 1);
 }
 
-function read_signed_int(span: Span, len: number) : number { 
+function read_signed_int(span: BinarySpan, len: number) : number {
   var v = 0, b, is_neg = false;
 
   // they have to tell us the length
   if (len < 1) return 0;
-  
+
   // the first byte get special treatment since it holds the sign
   b = span.next();
   len--; // we count the bytes as we read them
@@ -358,58 +358,58 @@ function read_signed_int(span: Span, len: number) : number {
     is_neg = true;
   }
   v = (b & 0xff);
-  
+
   // shift in all but the last byte (we've already read the first)
   while (len > 0) {
-    b = span.next(); 
+    b = span.next();
     len--;
     v = v << 8;
     v = v | (b & 0xff);
   }
-  
+
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) return undefined;
 
   // now we put the sign on, if it's needed
   if (is_neg) v = - v;
-  
+
   return v;
 }
 
-function read_signed_longint(span: Span, len: number) : LongInt {
+function read_signed_longint(span: BinarySpan, len: number) : LongInt {
   var v = [], b, signum = 1;
 
   // they have to tell us the length
   if (len < 1) return LongInt.ZERO;
-  
+
   // shift in all but the last byte (we've already read the first)
   while (len > 0) {
-    b = span.next(); 
+    b = span.next();
     len--;
     v.push(b & 0xff);
   }
 
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) undefined;
-  
+
   // check the sign
   if (v[0] & 0x80) {
     signum = -1;
     v[0] = v[0] & 0x7f; // remove the sign bit, we don't need it any longer
   }
-  
+
   return LongInt.fromBytes(v, signum);
 }
 
-function read_unsigned_int(span: Span, len: number) : number {
+function read_unsigned_int(span: BinarySpan, len: number) : number {
   var v = 0, b;
 
   // they have to tell us the length
   if (len < 1) return 0;
-  
+
   // shift in all but the last byte (we've already read the first)
   while (len > 0) {
-    b = span.next(); 
+    b = span.next();
     len--;
     v = v << 8;
     v = v | (b & 0xff);
@@ -417,48 +417,48 @@ function read_unsigned_int(span: Span, len: number) : number {
 
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) undefined;
-  
+
   return v;
 }
 
-function read_unsigned_longint(span: Span, len: number, signum: number) : LongInt {
+function read_unsigned_longint(span: BinarySpan, len: number, signum: number) : LongInt {
   var v = [], b;
 
   // they have to tell us the length
   if (len < 1) throw new Error("no length supplied");
-  
+
   // shift in all but the last byte (we've already read the first)
   while (len > 0) {
-    b = span.next(); 
+    b = span.next();
     len--;
     v.push(b & 0xff);
   }
 
   // if we run off the end the bytes will all by EOF, so we can just check once
   if (b === EOF) return undefined;
-  
+
   return LongInt.fromBytes(v, signum);
 }
 
-function read_decimal_value(span: Span, len: number) : Decimal {
+function read_decimal_value(span: BinarySpan, len: number) : Decimal {
   var pos, digits, exp, d;
 
   // so it's a normal value
   pos = span.position();
   exp = read_var_signed_longint(span);
-  
+
   len = len - (span.position() - pos);
   digits = read_signed_longint(span, len);
-  
+
   d = new Decimal(digits, exp);
-  
+
   return d;
 }
 
-function read_timestamp_value(span: Span, len: number) : Timestamp {
+function read_timestamp_value(span: BinarySpan, len: number) : Timestamp {
   var v, pos, end,
-      precision, offset, 
-      year, month, day, 
+      precision, offset,
+      year, month, day,
       hour, minutes, seconds;
 
   if (len < 1) {
@@ -473,22 +473,22 @@ function read_timestamp_value(span: Span, len: number) : Timestamp {
       year = read_var_unsigned_int(span);
       precision = Precision.YEAR;
       if (span.position() >= end) break;
-      
+
       month = read_var_unsigned_int(span);
       precision = Precision.MONTH;
       if (span.position() >= end) break;
-      
+
       day = read_var_unsigned_int(span);
       precision = Precision.DAY;
       if (span.position() >= end) break;
-      
+
       hour = read_var_unsigned_int(span);
       precision = Precision.HOUR_AND_MINUTE;
       if (span.position() >= end) break;
-      
+
       minutes = read_var_unsigned_int(span);
       if (span.position() >= end) break;
-      
+
       seconds = read_var_unsigned_int(span);
       precision = Precision.SECONDS;
       if (span.position() >= end) break;
@@ -496,16 +496,16 @@ function read_timestamp_value(span: Span, len: number) : Timestamp {
       seconds += read_decimal_value(span, end - span.position());
       break;
     }
-  }   
+  }
   v = new Timestamp(precision, offset, year, month, day, hour, minutes, seconds);
   return v;
 }
 
 var from_char_code_fn = String.fromCharCode;
 
-function read_string_value(span: Span, len: number) : string {
+function read_string_value(span: BinarySpan, len: number) : string {
   var s, b, char_len, chars = [];
-  
+
   if (len < 1) return ""; // avoids an edge case failure in the apply below
 
   while (len > 0) {
@@ -543,7 +543,7 @@ export class ParserBinaryRaw {
   private buf_as_bytes = new Uint8Array(this.buf);    //        we could new them locally in normal_float_to_bytes
   private buf_as_double = new Float64Array(this.buf); //        but that seems wasteful. ... hmmm
 
-  private _in: Span;
+  private _in: BinarySpan;
   private _raw_type: number = EOF;
   private _len: number = -1;
   private _curr = undefined;
@@ -555,11 +555,11 @@ export class ParserBinaryRaw {
   private _ts = [ TB_DATAGRAM ];
   private _in_struct: boolean = false;
 
-  constructor(source: Span) {
+  constructor(source: BinarySpan) {
     this._in = source;
   }
 
-  private read_binary_float(span: Span, len: number) : Float64Array {
+  private read_binary_float(span: BinarySpan, len: number) : Float64Array {
     var ii;
     if (len === IonBinary.LEN_NULL) return undefined;
     if (len === 0) return ZERO_POINT_ZERO;
@@ -571,7 +571,7 @@ export class ParserBinaryRaw {
     return this.buf_as_double;
   }
 
-  private clear_value() : void { 
+  private clear_value() : void {
     this._raw_type = EOF;
     this._curr     = undefined;
     this._a        = empty_array;
@@ -591,8 +591,8 @@ export class ParserBinaryRaw {
         if (high_nibble(tb) === IonBinary.TB_STRUCT) {
           // special case of a struct with a length of 1 (which
           // is otherwise not possible since the minimum value
-          // length is 1 and struct fields have a field name as 
-          // well so the min field length is 2 - 1 marks this as 
+          // length is 1 and struct fields have a field name as
+          // well so the min field length is 2 - 1 marks this as
           // an ordered struct (fields are in fid order)
           t._len = read_var_unsigned_int(t._in);
         }
@@ -674,7 +674,7 @@ export class ParserBinaryRaw {
     let t: ParserBinaryRaw = this;
 
     var a, b, pos, limit, arr;
-    if ((pos = t._as) < 0) return;  // nothing to do, 
+    if ((pos = t._as) < 0) return;  // nothing to do,
     arr = [];
     limit = t._ae;
     a = 0;
@@ -703,7 +703,7 @@ export class ParserBinaryRaw {
       case IonBinary.TB_INT:
         if (t._len === 0) {
           c = 0;
-        } 
+        }
         else if (t._len < MAX_BYTES_FOR_INT_IN_NUMBER) {
           c = read_unsigned_int(t._in, t._len);
         }
@@ -714,7 +714,7 @@ export class ParserBinaryRaw {
       case IonBinary.TB_NEG_INT:
         if (t._len === 0) {
           c = 0;
-        } 
+        }
         else if (t._len < MAX_BYTES_FOR_INT_IN_NUMBER) {
           c = -read_unsigned_int(t._in, t._len);
         }
@@ -732,7 +732,7 @@ export class ParserBinaryRaw {
       case IonBinary.TB_DECIMAL:
         if (t._len === 0) {
           c = Decimal.ZERO;
-        } 
+        }
         else {
           c = read_decimal_value(t._in, t._len);
         }
@@ -787,7 +787,7 @@ export class ParserBinaryRaw {
     switch(t._raw_type) {
       case IonBinary.TB_STRUCT:
       case IonBinary.TB_LIST:
-      case IonBinary.TB_SEXP: 
+      case IonBinary.TB_SEXP:
         break;
       default:
         throw new Error("you can only 'stepIn' to a container");
@@ -811,12 +811,12 @@ export class ParserBinaryRaw {
     t._in_struct = (parent_type === IonBinary.TB_STRUCT);
     t.clear_value();
 
-    // check to see if there is any of the container left in the 
+    // check to see if there is any of the container left in the
     // input span and skip over it if there is
     r = t._in.getRemaining();
     t._in.skip(r);
-    
-    // then reset what is remaining (remember we already 
+
+    // then reset what is remaining (remember we already
     // subtracted out the length of the just finished container
     t._in.setRemaining(l);
   }
@@ -855,7 +855,7 @@ export class ParserBinaryRaw {
   }
 
   numberValue() : number {
-    var n = undefined, 
+    var n = undefined,
         t = this;
     if (!t.isNull()) {
       t.load_value();
@@ -869,7 +869,7 @@ export class ParserBinaryRaw {
         case IonBinary.TB_DECIMAL:
           n = t._curr.getNumber();
           break;
-        default: 
+        default:
           break; // return undefined or ION.error("can't convert to number");
       }
     }
@@ -890,7 +890,7 @@ export class ParserBinaryRaw {
       case IonBinary.TB_SYMBOL:
       case IonBinary.TB_STRING:
         break;
-      default: 
+      default:
         return s; // return undefined or ION.error("can't convert to number");
     }
     if (t.isNull()) {
@@ -933,7 +933,7 @@ export class ParserBinaryRaw {
   }
 
   decimalValue() : Decimal {
-    var n = undefined, 
+    var n = undefined,
         t = this;
     if (!t.isNull() && t._raw_type === IonBinary.TB_DECIMAL) {
       t.load_value();
@@ -943,7 +943,7 @@ export class ParserBinaryRaw {
   }
 
   timestampValue() : Timestamp {
-    var n = undefined, 
+    var n = undefined,
         t = this;
     if (!t.isNull() && t._raw_type === IonBinary.TB_TIMESTAMP) {
       t.load_value();
@@ -962,7 +962,7 @@ export class ParserBinaryRaw {
         t.load_value();
         bytes = t._curr;
         break;
-      default: 
+      default:
         break;
     }
     return bytes;

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -51,13 +51,13 @@ const CH_NL =  10; // '\n'
 const CH_BS =  92; // '\\'
 const CH_FORWARD_SLASH = "/".charCodeAt(0); // 47
 const CH_AS =  42; // '*'
-const CH_SQ =  39; // '\'' 
+const CH_SQ =  39; // '\''
 const CH_DOUBLE_QUOTE = "\"".charCodeAt(0); // 34
 const CH_CM =  44; // ';'
 const CH_OP =  40; // '('
 const CH_CP =  41; // ')'
 const CH_LEFT_CURLY: number = "{".charCodeAt(0); // 123
-const CH_CC = 125; // '}' 
+const CH_CC = 125; // '}'
 const CH_OS =  91; // '['
 const CH_CS =  93; // ']'
 const CH_CL =  58; // ':'
@@ -116,7 +116,7 @@ export function get_ion_type(t: number) : IonType {
     case T_TIMESTAMP:     return IonTypes.TIMESTAMP;
     case T_IDENTIFIER:    return IonTypes.SYMBOL;
     case T_OPERATOR:      return IonTypes.SYMBOL;
-    case T_STRING1:       return IonTypes.STRING;
+    case T_STRING1:       return IonTypes.SYMBOL;
     case T_STRING2:       return IonTypes.STRING;
     case T_STRING3:       return IonTypes.STRING;
     case T_CLOB2:         return IonTypes.CLOB;
@@ -161,7 +161,7 @@ function is_keyword(str: string) : boolean {
 }
 
 function get_hex_value(ch: number) : number {
-  switch(ch) { // quick and dirty - we need a better impl TODO 
+  switch(ch) { // quick and dirty - we need a better impl TODO
     case  48: return  0; // '0'
     case  49: return  1; // '1'
     case  50: return  2; // '2'
@@ -209,11 +209,12 @@ type ReadValueHelpers = {[index: number]: ReadValueHelper};
 export class ParserTextRaw {
   private _in: Span;
   private _ops: any[];
+  private _raw: boolean;
   private _value_type: any;
   private _value_null: boolean;
   private _value: any[];
-  private _start: number;
-  private _end: number;
+  private _start: number;        // when next() completes, points to first char
+  private _end: number;          // points just after last char
   private _esc_len: number;
   private _curr: number;
   private _curr_null: boolean;
@@ -223,10 +224,16 @@ export class ParserTextRaw {
   private _fieldname: string;
 
   private readonly _read_value_helper_helpers: ReadValueHelpers;
+  private readonly _read_token_helper_helpers: ReadValueHelpers;
 
-  constructor(source: Span) {
+  constructor(source: Span, raw_tokens_only: boolean) {
     this._in         = source; // should be a span
-    this._ops        = [ this._read_datagram_values ];
+    this._raw = raw_tokens_only
+    if (raw_tokens_only) {
+        this._ops = [this._read_token];
+    } else {
+        this._ops = [this._read_datagram_values];
+    }
     this._value_type = ERROR;
     this._value      = [];     // value gets a new array since it will modify it
     this._start      = -1;
@@ -237,11 +244,10 @@ export class ParserTextRaw {
     this._msg        = "";
 
     let helpers: ReadValueHelpers = {
-    //  -1 : this._read_value_helper_EOF,    //      == EOF
         40 : this._read_value_helper_paren,  // '('  == CH_OP
         91 : this._read_value_helper_square, // '['  == CH_OS
        123 : this._read_value_helper_curly, // '{'  == CH_LEFT_CURLY
-        43 : this._read_value_helper_plus,   // '+'  == CH_PS // we'll have to patch these two back in after 
+        43 : this._read_value_helper_plus,   // '+'  == CH_PS // we'll have to patch these two back in after
         45 : this._read_value_helper_minus,  // '-'  == CH_MS // we apply the operator characters fn
         39 : this._read_value_helper_single, // '\'' == CH_SQ
         34 : this._read_value_helper_double, // '\"' == CH_DQ
@@ -263,6 +269,18 @@ export class ParserTextRaw {
     helpers[CH_MS] = this._read_value_helper_minus; // '-'
 
     this._read_value_helper_helpers = helpers;
+
+    helpers = {};
+    set_helper("0123456789", this._read_value_helper_digit);
+    set_helper("_$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", this._read_value_helper_letter);
+    set_helper("!#%&*+-./;<=>?@^`|~()[]{},", this._read_value_helper_operator);
+    helpers[CH_CL] = this._read_token_helper_colon;
+    helpers[CH_PS] = this._read_value_helper_plus; // '+'
+    helpers[CH_MS] = this._read_value_helper_minus; // '-'
+    helpers[CH_SQ] = this._read_value_helper_single; // "'"
+    helpers[CH_DOUBLE_QUOTE] = this._read_value_helper_double; // '"'
+    helpers[CH_LEFT_CURLY] = this._read_value_helper_curly; // {
+    this._read_token_helper_helpers = helpers;
   }
 
   fieldName() : string {
@@ -271,6 +289,22 @@ export class ParserTextRaw {
 
   annotations() : string[] {
     return this._ann;
+  }
+
+  start() : number {
+    return this._start;
+  }
+
+  end() : number {
+    return this._end;
+  }
+
+  locator(start: number) : number[] {
+    return this._in.locator(start);
+  }
+
+  error_line(start: number, end: number) : any[] {
+    return this._in.error_line(start, end);
   }
 
   private _read_datagram_values() {
@@ -312,7 +346,7 @@ export class ParserTextRaw {
   }
 
   private _read_struct_values() {
-    var op = this._done_with_error, 
+    var op = this._done_with_error,
         ch = this._read_after_whitespace(true);
 
     switch (ch) {
@@ -328,7 +362,7 @@ export class ParserTextRaw {
       case CH_CC :
         this._value_push( EOF );
         return;
-      default : 
+      default :
         if (IonText.is_letter(ch)) {
           op = this._read_symbol;
         }
@@ -395,7 +429,7 @@ export class ParserTextRaw {
     switch (v) {
     case T_IDENTIFIER:
       if (is_keyword(s)) {
-        this._error( "can't use '"+s+"' as a fieldname without quotes");
+        this._tok_error( "can't use '"+s+"' as a fieldname without quotes");
         break;
       }
     case T_STRING1:
@@ -404,7 +438,7 @@ export class ParserTextRaw {
       this._fieldname = s;
       break;
     default:
-      this._error( "invalid fieldname" );
+      this._tok_error( "invalid fieldname" );
       break;
     }
   }
@@ -425,6 +459,21 @@ export class ParserTextRaw {
       let fn: ReadValueHelper = this._read_value_helper_helpers[ch];
       if (fn != undefined) {
         fn.call(this, ch, accept_operator_symbols, calling_op);
+      } else {
+        this._error("unexpected character '" + IonText.asAscii(ch) + "'");
+      }
+    }
+  }
+
+  private _read_token() : void {
+    let ch: number = this._read_after_whitespace(true);
+    if (ch == EOF) {  // since we can't index into our object with a value of -1
+        this._read_value_helper_EOF(ch, true, this._read_token);
+    } else {
+      this._start = this._in.position() - 1;
+      let fn: ReadValueHelper = this._read_token_helper_helpers[ch];
+      if (fn != undefined) {
+          fn.call(this, ch, true, this._read_token);
       } else {
         this._error("unexpected character '" + IonText.asAscii(ch) + "'");
       }
@@ -461,23 +510,29 @@ export class ParserTextRaw {
         this._ops.unshift( this._read_blob );
       }
     }
-    else { 
+    else {
       this._unread( ch2 );
-      this._value_push( T_STRUCT );
-      this._ops.unshift( this._read_struct_values ) 
+      if (this._raw) {
+        this._end = this._in.position();
+        this._value_push( T_OPERATOR );
+      } else {
+        this._value_push( T_STRUCT );
+        this._ops.unshift( this._read_struct_values );
+      }
     }
   }
 
   private _read_value_helper_plus( ch1, accept_operator_symbols: boolean, calling_op ) {
     var ch2 = this._peek("inf");
     this._unread(ch1); // in any case we'll leave this character for the next function to use
-    if (IonText.is_numeric_terminator(ch2)) {
+    if (ch2 != ERROR) {
       this._ops.unshift( this._read_plus_inf );
     }
     else if (accept_operator_symbols) {
-          this._ops.unshift( this._read_operator_symbol );
+      this._ops.unshift( this._read_operator_symbol );
     }
     else {
+      this._read(); // get the cursor pointed to the offending character
       this._error("unexpected '+'");
     }
   }
@@ -529,9 +584,9 @@ export class ParserTextRaw {
       op = this._read_string1;
     }
     op.call(this);
-    if (this._test_string_as_annotation(op)) {
-      // this was an annoation, so we need to try again for the actual value
-      this._ops.unshift( calling_op ); 
+    if (!this._raw && this._test_string_as_annotation(op)) {
+      // this was an annotation, so we need to try again for the actual value
+      this._ops.unshift( calling_op );
     }
   }
 
@@ -541,20 +596,37 @@ export class ParserTextRaw {
 
   private _read_value_helper_letter( ch1, accept_operator_symbols: boolean, calling_op ) {
     this._read_symbol();
-    if (this._test_symbol_as_annotation()) {
-      // this was an annoation, so we need to try again for the actual value
-      this._ops.unshift( calling_op );
+    if (this._raw) {
+      this._check_for_special_symbol();
+    } else {
+      if (this._test_symbol_as_annotation()) {
+        // this was an annotation, so we need to try again for the actual value
+        this._ops.unshift( calling_op );
+      }
     }
   }
 
   private _read_value_helper_operator( ch1, accept_operator_symbols: boolean, calling_op ) {
     if (accept_operator_symbols) {
-      this._unread(ch1)
-      this._ops.unshift( this._read_operator_symbol );
+      if (IonText.is_single_operator_char(ch1)) {
+        this._end = this._in.position();
+        this._value_push(T_OPERATOR);
+      } else {
+        this._ops.unshift( this._read_operator_symbol );
+      }
     }
     else {
        this._error( "unexpected operator character" );
     }
+  }
+
+  private _read_token_helper_colon( ch1, accept_operator_symbols: boolean, calling_op ) {
+    var ch = this._peek();
+    if (ch == CH_CL) {
+      this._read();
+    }
+    this._end = this._in.position();
+    this._value_push(T_OPERATOR);
   }
 
   private _done() {
@@ -578,7 +650,7 @@ export class ParserTextRaw {
         return;
       }
       if (IonText.is_digit(ch)) {
-        this._error("leading zero's are not allowed");
+        this._error("leading zeroes are not allowed");
       }
       ch = CH_0;
     }
@@ -590,6 +662,7 @@ export class ParserTextRaw {
     }
     if (!IonText.is_numeric_terminator(ch)) {
       if (ch == CH_d || ch == CH_D) {
+        t = T_DECIMAL;
         ch = this._read_exponent();
       }
       else if (ch == CH_e || ch == CH_E || ch == CH_f || ch == CH_F ) {
@@ -597,7 +670,7 @@ export class ParserTextRaw {
         ch = this._read_exponent();
       }
     }
-    if (!IonText.is_numeric_terminator(ch)) {
+    if (!this._raw && !IonText.is_numeric_terminator(ch)) {
       this._error( "invalid character after number" );
     }
     else {
@@ -613,8 +686,9 @@ export class ParserTextRaw {
       ch = this._read(); // read the first hex digits
       ch = this._read_required_hex_digits(ch);
     }
-    if (IonText.is_numeric_terminator(ch)) {
+    if (this._raw || IonText.is_numeric_terminator(ch)) {
       this._unread(ch);
+      this._end = this._in.position();
       this._value_push( T_HEXINT );
     }
     else {
@@ -630,10 +704,10 @@ export class ParserTextRaw {
     ch = this._read_required_digits(ch);
     return ch;
   }
- 
+
   private _read_plus_inf() {
     if (this._read() == CH_PS) {
-     this._read_inf_helper();
+      this._read_inf_helper();
     }
     else {
       this._error( "expected +inf" );
@@ -658,12 +732,13 @@ export class ParserTextRaw {
         return;
       }
     }
-    if (IonText.is_numeric_terminator( this._peek() )) {
-      this._end = this._in.position() - 1;
+    if (this._raw || IonText.is_numeric_terminator( this._peek() )) {
+      this._end = this._in.position();
       this._start = this._end - 4; // -4 to include the sign we've already read
-      this._value_push( T_FLOAT_SPECIAL ); 
+      this._value_push( T_FLOAT_SPECIAL );
     }
     else {
+      this._read(); // advance to point to the offending character
       this._error( "invalid numeric terminator after 'inf'" );
     }
   }
@@ -682,8 +757,8 @@ export class ParserTextRaw {
       }
       ch = this._read_optional_time(ch);  // no time unless you at least include month - TODO really !?
     }
-    ch = this._read_optional_time_offset(ch); // we only allow an offset 
-    if (IonText.is_numeric_terminator(ch)) {
+    ch = this._read_optional_time_offset(ch); // we only allow an offset
+    if (this._raw || IonText.is_numeric_terminator(ch)) {
       this._unread(ch);
       this._end = this._in.position();
       this._value_push( T_TIMESTAMP );
@@ -723,7 +798,7 @@ export class ParserTextRaw {
 
   private _read_symbol() : void {
     var ch;
-    this._start = this._in.position() - 1;  
+    this._start = this._in.position() - 1;
     for(;;) {
       ch = this._read();
       if (!IonText.is_letter_or_digit(ch)) break;
@@ -737,37 +812,38 @@ export class ParserTextRaw {
     var ch;
     for(;;) {
       ch = this._read();
-      if (!IonText.is_operator_char(ch))  break;
+      if (!IonText.is_operator_char(ch) || IonText.is_single_operator_char(ch)) {
+        this._unread(ch);
+        break;
+      }
     }
-    this._end = this._in.position() - 1;
-    this._unread(ch);
+    this._end = this._in.position();
     this._value_push( T_OPERATOR );
   }
 
   private _read_string1() : void {
     this._read_string_helper(CH_SQ, false);
-    this._end = this._in.position() - 1;
+    this._end = this._in.position();
     this._value_push( T_STRING1 );
   }
 
   private _read_string2() : void {
     this._read_string_helper(CH_DOUBLE_QUOTE, false);
-    this._end = this._in.position() - 1;
+    this._end = this._in.position();
     this._value_push( T_STRING2 );
   }
 
   private _read_string3() : void {
     var ch;
+    this._start = this._in.position() - 1;
     if (this._read() != CH_SQ || this._read() != CH_SQ) {
       this._error( "expected triple quote" );
     }
-    this._start = this._in.position();
     for(;;) {  // read sequence of triple quoted strings
       for(;;) { // read single quoted strings until we see the triple quoted terminator
         this._read_string_helper(CH_SQ, true);
         // if it's not a triple quote, it's just content
         if (this._read() == CH_SQ && this._read() == CH_SQ) {
-          this._end = this._in.position() - 3;
           break;
         }
       }
@@ -782,12 +858,12 @@ export class ParserTextRaw {
       this._read(); // consume the 2 pending single quotes
       this._read();
     }
+    this._end = this._in.position();
     this._value_push( T_STRING3 );
   }
 
   private _read_string_helper = function(terminator: number, allow_new_line: boolean) : void {
     var ch;
-    this._start = this._in.position();
     for (;;) {
       ch = this._read();
       if (ch == CH_BS) {
@@ -797,7 +873,7 @@ export class ParserTextRaw {
         break;
       }
       else if (!is_valid_string_char(ch, allow_new_line)) {
-        this._error( "invalid character "+ch+" in string" );
+        this._error( "invalid character in string: " + String.fromCharCode(ch));
         break;
       }
     }
@@ -862,12 +938,13 @@ export class ParserTextRaw {
   }
 
   private _test_symbol_as_annotation() : boolean {
-    var s, ii, ch, kwt, 
+    var s, ii, ch, kwt,
         is_ann = true,
         t = this._value_pop();
     if (t != T_IDENTIFIER) this._error("expecting symbol here");
     s = this.get_value_as_string(t);
     kwt = get_keyword_type(s);
+    var ch2 = this._peek();  // so we don't confuse eg, "null .foo" with typed null
     ch = this._read_after_whitespace(true);
     if (ch == CH_CL && this._peek() == CH_CL) {
       if (kwt != undefined) this._error("the keyword '"+s+"' can't be used as an annotation without quotes");
@@ -882,8 +959,7 @@ export class ParserTextRaw {
       is_ann = false;
       if (kwt === T_NULL) {
         this._value_null = true;
-        ch = this._peek();
-        if (ch === CH_DT) {
+        if (ch2 === CH_DT) {
           this._read(); // consume the dot
           ch = this._read();
           if (IonText.is_letter(ch) !== true) {
@@ -892,11 +968,15 @@ export class ParserTextRaw {
           }
           this._read_symbol();
           if (this._value_pop() != T_IDENTIFIER) {
-            this._error("expected type name after 'null.'");
+            this._tok_error("expected type name after 'null.'");
             return undefined;
           }
           s = this.get_value_as_string(T_IDENTIFIER);
           kwt = get_type_from_name(s);
+          if (kwt === undefined) {
+            this._tok_error("expected type name after 'null.'");
+            return undefined;
+          }
         }
         this._start = -1;
         this._end = -1;
@@ -906,22 +986,72 @@ export class ParserTextRaw {
     return is_ann;
   }
 
+  // In raw mode handle typed nulls, booleans and 'nan', converting them to the
+  // proper type
+  private _check_for_special_symbol() {
+    var s, ii, ch, kwt,
+        is_ann = true,
+        t = this._value_pop();
+    if (t != T_IDENTIFIER) this._tok_error("expecting symbol here");
+    s = this.get_value_as_string(t);
+    kwt = get_keyword_type(s);
+    if (kwt === T_NULL) {
+      this._value_null = true;
+      ch = this._peek();
+      if (ch === CH_DT) {
+        this._read(); // consume the dot
+        ch = this._read();
+        if (IonText.is_letter(ch) !== true) {
+          this._error("expected type name after 'null.'");
+          return;
+        }
+        var save_start = this._start;
+        this._read_symbol();
+        if (this._value_pop() != T_IDENTIFIER) {
+          this._error("expected type name after 'null.'");
+          return;
+        }
+        s = this.get_value_as_string(T_IDENTIFIER);
+        kwt = get_type_from_name(s);
+        if (kwt === undefined) {
+          this._error("expected type name after 'null.'");
+          return;
+        }
+        this._start = save_start;
+        this._end = this._in.position();
+      }
+      this._value_push(T_NULL); // put the typed null value back on the stack
+    } else if (kwt === T_BOOL) {
+      this._value_push(T_BOOL);
+    } else if (kwt === T_FLOAT_SPECIAL) {
+      this._value_push(T_FLOAT_SPECIAL);
+    } else {
+      this._value_push(T_IDENTIFIER);
+    }
+  }
+
   private _read_clob_string2() : void {
     var t;
+    var save_start = this._start;
     this._read_string2();
     t = this._value_pop();
     if (t != T_STRING2) this._error("string expected");
+    this._start = save_start;
     this._value_push(T_CLOB2);
-    this._ops.unshift( this._read_close_double_brace );
+    this._read_close_double_brace();
+    this._end = this._in.position();
   }
 
   private _read_clob_string3() : void {
     var t;
+    var save_start = this._start;
     this._read_string3();
     t = this._value_pop();
     if (t != T_STRING3) this._error("string expected");
-    this._value_push(T_CLOB2);
-    this._ops.unshift( this._read_close_double_brace );
+    this._start = save_start;
+    this._value_push(T_CLOB3);
+    this._read_close_double_brace();
+    this._end = this._in.position();
   }
 
   private _read_blob() : void {
@@ -947,7 +1077,7 @@ export class ParserTextRaw {
         this._error( "invalid base64 value" );
       }
       else {
-        this._end = this._in.position() - 1;
+        this._end = this._in.position();
         this._value_push( T_BLOB );
       }
     }
@@ -981,7 +1111,7 @@ export class ParserTextRaw {
         if (s == "+inf")      n = Number.POSITIVE_INFINITY;
         else if (s == "-inf") n = Number.NEGATIVE_INFINITY;
         else if (s == "nan")  n = Number.NaN;
-        else throw new Error("can't convert to number"); 
+        else throw new Error("can't convert to number");
         break;
       default:
         throw new Error("can't convert to number");
@@ -1003,8 +1133,12 @@ export class ParserTextRaw {
     }
   }
 
+  get_raw_token() : string {
+    return this.get_value_as_string(T_BLOB);
+  }
+
   get_value_as_string(t: number) : string {
-    var ii, ch, s = "";
+    var start, end, ii, ch, s = "";
     switch (t) {
       case T_NULL:
       case T_BOOL:
@@ -1023,38 +1157,24 @@ export class ParserTextRaw {
         break;
       case T_STRING1:
       case T_STRING2:
+        s = this._get_string2(this._start, this._end);
+        break;
       case T_CLOB2:
-        for (ii=this._start; ii<this._end; ii++) {
-          ch = this._in.valueAt(ii);
-          if (ch == CH_BS) {
-            s += this._read_escape_sequence(ii, this._end);
-            ii += this._esc_len;
-          } 
-          else {
-            s += String.fromCharCode(ch);
-          }
-        }
+        start = this._start+2;
+        while (IonText.is_whitespace(this._in.valueAt(start))) start++;
+        end = this._end-2;
+        while (end > start && (IonText.is_whitespace(this._in.valueAt(end-1)))) end--;
+        s = this._get_string2(start, end);
         break;
       case T_CLOB3:
+        start = this._start+2;
+        while (IonText.is_whitespace(this._in.valueAt(start))) start++;
+        end = this._end-2;
+        while (end > start && (IonText.is_whitespace(this._in.valueAt(end-1)))) end--;
+        s = this._get_string3(start, end);
+        break;
       case T_STRING3:
-        for (ii=this._start; ii<this._end; ii++) {
-          ch = this._in.valueAt(ii);
-          if (ch == CH_SQ) {
-            if (ii+2<this._end && this._in.valueAt(ii+1) == CH_SQ && this._in.valueAt(ii+1) == CH_SQ) {
-              this._skip_triple_quote_gap(ii, this._end);
-            }
-            else {
-              s += "\'";
-            }
-          }
-          else if (ch == CH_BS) {
-            s += this._read_escape_sequence(ii, this._end);
-            ii += this._esc_len;
-          }
-          else {
-            s += String.fromCharCode(ch);
-          }
-        }
+        s = this._get_string3(this._start, this._end);
         break;
       default:
         this._error("can't get this value as a string");
@@ -1063,21 +1183,82 @@ export class ParserTextRaw {
     return s;
   }
 
+  private _get_string2(start: number, end: number): string {
+    start++;     // since we know it's a string2, chop off the quotes
+    end--;
+    var s = "";
+    for (var ii=start; ii<end; ii++) {
+      var ch = this._in.valueAt(ii);
+      if (ch == CH_BS) {
+        s += String.fromCharCode(this._read_escape_sequence(ii, this._end));
+        ii += this._esc_len;
+      }
+      else {
+        s += String.fromCharCode(ch);
+      }
+    }
+    return s;
+  }
+
+  private _get_string3(start: number, end: number): string {
+    var s = "";
+    var ii = 0;
+    start += 3;  // if it's really a string3, it must start and end with triples
+    end -= 3;
+    for (ii=start; ii<end; ii++) {
+      var ch = this._in.valueAt(ii);
+      if (ch == CH_SQ) {
+        if (ii+2<end && this._in.valueAt(ii+1) == CH_SQ && this._in.valueAt(ii+2) == CH_SQ) {
+          ii = this._skip_triple_quote_gap(ii, end);
+        }
+        else {
+          s += "\'";
+        }
+      }
+      else if (ch == CH_BS) {
+        s += String.fromCharCode(this._read_escape_sequence(ii, end));
+        ii += this._esc_len;
+      }
+      else {
+        s += String.fromCharCode(ch);
+      }
+    }
+    return s;
+  }
+
   private _skip_triple_quote_gap(ii: number, end: number) : number {
-    ii += 2; // skip the two quotes we peeked ahead to see
+    ii += 3; // skip triple quotes that we have confirmed exist at this point
     while (ii<end) {
       let ch: number = this._in.valueAt(ii);
       if (IonText.is_whitespace(ch)) {
-        // do nothing
+        ii++; // do nothing
       }
-      else if (ch == CH_SQ) {
-        ii+= 3;
-        if (ii > end || this._in.valueAt(ii-2) != CH_SQ || this._in.valueAt(ii-1) != CH_SQ) {
-          return ii;
+      else if (ch == CH_SQ && ii+2 < end && this._in.valueAt(ii+1) == CH_SQ &&
+                 this._in.valueAt(ii+1) == CH_SQ) {
+        return ii+2;
+      }
+      else if (ch == CH_FORWARD_SLASH && ii+1 < end &&
+               this._in.valueAt(ii+1) == CH_FORWARD_SLASH) {
+        ii += 2;
+        while (ii < end) {
+          ch = this._in.valueAt(ii++);
+          if (ch == CH_NL) break;
+        }
+      }
+      else if (ch == CH_FORWARD_SLASH && ii+1 < end &&
+               this._in.valueAt(ii+1) == CH_AS) {
+        ii += 2;
+        while (ii < end) {
+          ch = this._in.valueAt(ii++);
+          if (ch == CH_AS && ii < end && this._in.valueAt(ii) == CH_FORWARD_SLASH) {
+            ii++;
+            break;
+          }
         }
       }
       else {
-        this._error("unexpected character");
+        this._errorAt("unexpected character: " + String.fromCharCode(ch), ii, ii+1);
+        break;
       }
     }
     return ii;
@@ -1166,6 +1347,9 @@ export class ParserTextRaw {
   }
 
   next(): number {
+    if (this._raw) {
+      this._ops = [ this._read_token ];
+    }
     if (this._value_type === ERROR) {
       this._run();
     }
@@ -1267,12 +1451,12 @@ export class ParserTextRaw {
 
   private _peek(expected?: string) : number {
     var ch, ii=0;
-    if (expected === undefined || expected.length<1) { 
+    if (expected === undefined || expected.length<1) {
       ch = this._read();
       this._unread(ch);
       return ch;
     }
-    while (ii<expected.length) { 
+    while (ii<expected.length) {
       ch = this._read();
       if (ch != expected.charCodeAt(ii)) break;
       ii++;
@@ -1378,20 +1562,25 @@ export class ParserTextRaw {
     return ch;
   }
 
-  private _check_for_keywords() : void {
-    var len, s, v = this._value_pop();
-    if (v == T_IDENTIFIER) {
-      len = this._end - this._start;
-      if (len >= 3 && len <= 5) {
-        s = this.get_value_as_string(v);
-        v = get_keyword_type(s);
-      }
-    }
-    this._value_push(v);
+  // report an error relative to the most recently read character
+  private _error(msg: string) : void {
+    var pos = this._in.position();
+    this._errorAt(msg, pos-1, pos);
   }
 
-  private _error(msg: string) : void {
+  // report an error relatvie to the most recently read token
+  private _tok_error(msg: string) : void {
+    this._errorAt(msg, this._start, this._end);
+  }
+
+  // report an error relative to a specify subsequence
+  private _errorAt(msg: string, start: number, end: number) : void {
+    var locator = this.locator(start);
+    msg = msg + " at line " + locator[0] + ", column " + locator[1] + ":\n" +
+      this.error_line(start, end).join('\n');
+
     this._ops.unshift(this._done_with_error);
     this._error_msg = msg;
+    //throw new Error(msg); // uncomment to debug (or just make it be like this?)
   }
 }

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -267,9 +267,3 @@ export class BinarySpan {
     throw new Error("not implemented");
   }
 }
-
-// Local Variables:
-// mode: c++
-// c-basic-offset:2
-// indent-tabs-mode:nil
-// End:

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -13,62 +13,13 @@
  */
 
 import { EOF } from "./IonConstants";
-import { InvalidArgumentError } from "./IonErrors"
-
-const SPAN_TYPE_STRING = 0;
-const SPAN_TYPE_BINARY = 1;
-const SPAN_TYPE_SUB_FLAG = 2;
-const SPAN_TYPE_SUB_STRING = SPAN_TYPE_SUB_FLAG | SPAN_TYPE_STRING;
-const SPAN_TYPE_SUB_BINARY = SPAN_TYPE_SUB_FLAG | SPAN_TYPE_BINARY;
 
 const MAX_POS = 1024*1024*1024; // 1 gig
 const LINE_FEED = 10;
 const CARRIAGE_RETURN = 13;
 const DEBUG_FLAG = true;
 
-export abstract class Span {
-  protected readonly _type: number;
-
-  constructor(_type: number) {
-    this._type = _type;
-  }
-
-  abstract position() : number;
-
-  abstract next() : number;
-
-  abstract valueAt(index: number): number;
-
-  abstract getRemaining() : number;
-
-  abstract setRemaining(r: number) : void;
-
-  abstract is_empty(): boolean;
-
-  abstract skip(dist: number) : void;
-
-  abstract unread(ch: number) : void;
-
-  protected abstract clone(start: number, len: number): Span;
-
-  locator(pos: number) : number[] {
-    throw new Error("not implemented");
-  }
-
-  error_line(start: number, end: number) : any[] {
-    throw new Error("not implemented");
-  }
-
-  write(b: number) : never {
-    throw new Error("not implemented");
-  }
-
-  static error() {
-    throw new Error("span error");
-  }
-}
-
-class StringSpan extends Span {
+export class StringSpan {
   private _src : string;
   private _pos : number;
   private _start : number;
@@ -77,14 +28,14 @@ class StringSpan extends Span {
   private _old_line_start : number;
   private _line_start : number;
 
-  constructor(src: string, start: number, len: number) {
-    super(SPAN_TYPE_STRING);
+  constructor(src: string, start?: number, len?: number) {
     this._line = 1;
     this._src = src;
+    this._pos = 0;
     this._limit = src.length;
-    if (typeof start !== 'undefined') {
+    if (start !== undefined) {
       this._pos = start;
-      if (typeof len !== 'undefined') {
+      if (len !== undefined) {
         this._limit = start + len;
       }
     }
@@ -140,10 +91,10 @@ class StringSpan extends Span {
   }
 
   unread(ch: number) : void {
-    if (this._pos <= this._start) Span.error();
+    if (this._pos <= this._start) throw new Error("span error");
     this._pos--;
     if (ch < 0) {
-      if (this.is_empty() != true) Span.error();
+      if (this.is_empty() != true) throw new Error("span error");
       return;
     }
     // we can only unread across 1 new line
@@ -151,7 +102,7 @@ class StringSpan extends Span {
         this._line_start = this._old_line_start;
         this._line--;
     }
-    if (ch != this.peek()) Span.error();  // DEBUG
+    if (ch != this.peek()) throw new Error("span error");  // DEBUG
   }
 
   peek() : number {
@@ -181,9 +132,9 @@ class StringSpan extends Span {
 
   // Return the line and column number for a given character in the span
   locator(pos: number): number[] {
-    var line = 1, column = 1;
-    for (var i = 0; i < pos; i++) {
-      var ch = this.valueAt(i);
+    let line = 1, column = 1;
+    for (let i = 0; i < pos; i++) {
+      let ch = this.valueAt(i);
       if (ch == LINE_FEED) {
         line++;
         column = 1;
@@ -197,23 +148,23 @@ class StringSpan extends Span {
   // Return a string which displays the line containing the given token followed
   // by a line which places carats under the offending token
   error_line(start: number, end: number): any[] {
-    var line_start = start;
+    let line_start = start;
     while (line_start > 0 && this.valueAt(line_start-1) != LINE_FEED) {
       line_start--;
     }
-    var line_end = end;
+    let line_end = end;
     while (line_end < this._limit && this.valueAt(line_end) != LINE_FEED) {
       line_end++;
     }
-    var str = "";
-    for (var x = line_start; x < line_end; x++) {
+    let str = "";
+    for (let x = line_start; x < line_end; x++) {
       str += this.charAt(x);
     }
-    var pointer = "";
-    for (var x = line_start; x < start; x++) {
+    let pointer = "";
+    for (var y = line_start; y < start; y++) {
       pointer += " ";
     }
-    for (; x < end; x++) pointer += "^";
+    for (; y < end; y++) pointer += "^";
     return [str, pointer];
   }
 
@@ -226,21 +177,28 @@ class StringSpan extends Span {
   }
 }
 
-class BinarySpan extends Span {
+export class BinarySpan {
   private _src: number[];
   private _pos: number;
   private _start: number;
   private _limit: number;
 
   constructor(src: number[], start?: number, len?: number) {
-    super(SPAN_TYPE_BINARY);
     this._src = src;
     this._limit = src.length;
     this._start = start || 0;
-    if (typeof len !== 'undefined') {
+    if (len !== undefined) {
       this._limit = start + len;
     }
     this._pos = this._start;
+  }
+
+  error_line(start: number, end: number): any[] {
+    throw new Error("not implemented on binary spans");
+  }
+
+  locator(pos: number): number[] {
+    throw new Error("not implemented on binary spans");
   }
 
   position() : number {
@@ -260,7 +218,6 @@ class BinarySpan extends Span {
   }
 
   next(): number {
-    var b;
     if (this.is_empty()) {
       if (this._pos > MAX_POS) {
         throw new Error("span position is out of bounds");
@@ -268,18 +225,17 @@ class BinarySpan extends Span {
       this._pos++;
       return EOF;
     }
-    b = this._src[this._pos];
+    let b = this._src[this._pos];
     this._pos++;
     return (b & 0xFF);
   }
 
   unread(b: number) : void {
-    if (this._pos <= this._start) Span.error();
+    if (this._pos <= this._start) throw new Error("span error");
     this._pos--;
     if (b == EOF) {
-      if (this.is_empty() == false) Span.error();
+      if (this.is_empty() == false) throw new Error("span error");
     }
-    if (b != this.peek()) Span.error();    // DEBUG
   }
 
   peek(): number {
@@ -306,46 +262,14 @@ class BinarySpan extends Span {
     }
     return new BinarySpan(this._src, this._pos + start, actual_len);
   }
+
+  write(b: number) : never {
+    throw new Error("not implemented");
+  }
 }
 
-
-
-
-/**
- * Create a Span object that wraps src.
- * @see http://www.cs.cmu.edu/~wjh/papers/subseq.html
- *
- * @param src value to be stored inside a span, typically a string
- * @param start beginning index of src
- * @param len end index of src
- * @returns {Span}
- */
-export function makeSpan(src: any, start?: number, len?: number): Span {
-  if (src instanceof Span) {
-    return src as Span;
-  }
-  if (typeof start === 'undefined') {
-    start = 0;
-  }
-  if (typeof len === 'undefined') {
-    len = src.length;
-  }
-
-  let span: Span = undefined;
-  let src_type = typeof src;
-  if (src_type === 'undefined') {
-    throw new InvalidArgumentError("Given \'undefined\' as input");
-  } else if (src_type === 'string') {
-    span = new StringSpan(src, start, len);
-  } else if (src_type === 'object') {
-    // TODO: this seems fishy since isSpan is not defined on Span types!
-    // NB: Also seems fishy to create a binary span for input to text readers!
-    if (typeof (src.isSpan) === 'undefined') { // probably an array
-      span = new BinarySpan(src, start, len);
-    }
-  }
-  if (span === undefined) {
-    throw new InvalidArgumentError("invalid span source");
-  }
-  return span;
-}
+// Local Variables:
+// mode: c++
+// c-basic-offset:2
+// indent-tabs-mode:nil
+// End:

--- a/src/IonTests.ts
+++ b/src/IonTests.ts
@@ -21,3 +21,4 @@ export { LocalSymbolTable } from './IonLocalSymbolTable';
 export { LowLevelBinaryWriter } from './IonLowLevelBinaryWriter';
 export { NullNode } from './IonBinaryWriter';
 export { BinaryWriter } from "./IonBinaryWriter";
+export { StringSpan, BinarySpan } from "./IonSpan";

--- a/src/IonText.ts
+++ b/src/IonText.ts
@@ -49,6 +49,7 @@ const _is_letter: boolean[] = _make_bool_array("_$abcdefghijklmnopqrstuvwxyzABCD
 const _is_letter_or_digit = _make_bool_array("_$0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
 const _is_numeric_terminator: boolean[] = _make_bool_array("{}[](),\"\'\ \t\n\r\u000c");
 const _is_operator_char = _make_bool_array("!#%&*+-./;<=>?@^`|~");
+const _is_single_operator_char = _make_bool_array("()[],.;?^`~");
 const _is_whitespace = _make_bool_array(" \t\r\n\u000b\u000c");
 const isIdentifierArray: boolean[] = _make_bool_array("_$0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
 
@@ -62,7 +63,7 @@ export function asAscii(s: any) : string {
     s = "undefined::null";
   }
   else if (typeof s == 'number') {
-    s = ""+s;
+    s = String.fromCharCode(s);
   }
   else if (typeof s != 'string') {
     var esc = nextEscape(s, s.length);
@@ -142,7 +143,7 @@ export function toHex(c: number, len: number) : string {
   }
   if (s.length < len) {
     s = "000000000" + s; // TODO: 9 0's, 9 > max len expected (but what about bigger than that?)
-    s = s.substring(s.length - len, s.length); 
+    s = s.substring(s.length - len, s.length);
   }
   return s;
 }
@@ -162,6 +163,10 @@ export function is_letter_or_digit(ch: number) : boolean {
 
 export function is_operator_char(ch: number) : boolean {
   return _is_operator_char[ch];
+}
+
+export function is_single_operator_char(ch: number) : boolean {
+  return _is_single_operator_char[ch];
 }
 
 export function is_whitespace(ch: number) : boolean {

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -50,12 +50,12 @@ export class TextReader implements Reader {
   private _raw_type: number;
   private _raw: any;
 
-  constructor(source: Span, catalog: Catalog) {
+  constructor(source: Span, catalog: Catalog, raw_tokens: boolean) {
     if (!source) {
       throw new Error("a source Span is required to make a reader");
     }
 
-    this._parser   = new ParserTextRaw(source);
+    this._parser   = new ParserTextRaw(source, raw_tokens);
     this._depth    = 0;
     this._cat      = catalog;
     this._symtab   = defaultLocalSymbolTable();
@@ -73,7 +73,7 @@ export class TextReader implements Reader {
   }
 
   skip_past_container() {
-    var type, 
+    var type,
         d = 1,  // we want to have read the EOC tha matches the container we just saw
         p = this._parser;
     while (d > 0) {
@@ -121,7 +121,7 @@ export class TextReader implements Reader {
       }
     }
 
-    // for system value (IVM's and symbol table's) we continue 
+    // for system value (IVM's and symbol table's) we continue
     // around this
     this._type = get_ion_type(this._raw_type);
     return this._type;
@@ -178,7 +178,7 @@ export class TextReader implements Reader {
       }
     }
     else if (t._type.scalar) {
-      // BLOB is a scalar by you don't want to just use the string 
+      // BLOB is a scalar by you don't want to just use the string
       // value otherwise all other scalars are fine as is
       if (t._type !== IonTypes.BLOB) {
         s = t._raw;
@@ -226,5 +226,9 @@ export class TextReader implements Reader {
 
   ionValue() {
     throw new Error("E_NOT_IMPL: ionValue");
+  }
+
+  raw_parser() : ParserTextRaw {
+    return this._parser;
   }
 }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -21,7 +21,7 @@
 import { Catalog } from "./IonCatalog";
 import { Decimal } from "./IonDecimal";
 import { defaultLocalSymbolTable } from "./IonLocalSymbolTable";
-import { get_ion_type } from "./IonParserTextRaw";
+import { getIonType } from "./IonParserTextRaw";
 import { getSystemSymbolTable } from "./IonSystemSymbolTable";
 import { ion_symbol_table } from "./IonSymbols";
 import { IonType } from "./IonType";
@@ -31,7 +31,7 @@ import { LocalSymbolTable } from "./IonLocalSymbolTable";
 import { makeSymbolTable } from "./IonSymbols";
 import { ParserTextRaw } from "./IonParserTextRaw";
 import { Reader } from "./IonReader";
-import { Span } from "./IonSpan";
+import { StringSpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
@@ -50,7 +50,7 @@ export class TextReader implements Reader {
   private _raw_type: number;
   private _raw: any;
 
-  constructor(source: Span, catalog: Catalog, raw_tokens: boolean) {
+  constructor(source: StringSpan, catalog: Catalog, raw_tokens: boolean) {
     if (!source) {
       throw new Error("a source Span is required to make a reader");
     }
@@ -123,7 +123,7 @@ export class TextReader implements Reader {
 
     // for system value (IVM's and symbol table's) we continue
     // around this
-    this._type = get_ion_type(this._raw_type);
+    this._type = getIonType(this._raw_type);
     return this._type;
   }
 

--- a/src/IonValue.ts
+++ b/src/IonValue.ts
@@ -20,7 +20,7 @@
 import * as IonBinary from "./IonBinary";
 import { IonType } from "./IonType";
 import { IonTypes } from "./IonTypes";
-import { Span } from "./IonSpan";
+import { BinarySpan } from "./IonSpan";
 
 function error(msg: string) {
   throw {message: msg, where: "IonValue"};
@@ -138,7 +138,7 @@ abstract class IonValue {
     }
   }
 
-  typeAnnotationsAsString() : string { 
+  typeAnnotationsAsString() : string {
     if (this._annotations === undefined) return "";
     var s, ii, l = this._annotations.length;
     for (ii=0; ii<0; ii++) {
@@ -156,15 +156,15 @@ class IonNull extends IonValue {
   }
 
   toString() : string {
-    return super.toString() + IonTypes.NULL.name; 
+    return super.toString() + IonTypes.NULL.name;
   }
 
-  writeBinary(span: Span) : number {
+  writeBinary(span: BinarySpan) : number {
     span.write(this.binary_image);
     return 1;  // bytes written
   }
 
-  readBinary(span: Span, bid: number, len: number) : number {
+  readBinary(span: BinarySpan, bid: number, len: number) : number {
     if (len === 0 || len === IonBinary.LEN_NULL) {
       len = 0;
     }
@@ -176,11 +176,11 @@ class IonNull extends IonValue {
 }
 
 class IonBool extends IonValue {
-  getType() : IonType { 
+  getType() : IonType {
     return IonTypes.BOOL;
   }
 
-  toString() : string { 
+  toString() : string {
     var s;
     if (this.isNull()) {
       s = IonTypes.NULL.name + "." + this.getType().name;
@@ -191,19 +191,19 @@ class IonBool extends IonValue {
     return super.toString() + s;
   }
 
-  setValue(b: boolean) : void { 
+  setValue(b: boolean) : void {
     if (b !== undefined && (typeof b !== "boolean")) {
       error("IonBool values must be boolean (or undefined for null)");
     }
     this._datum = b;
   }
 
-  booleanValue() : boolean { 
+  booleanValue() : boolean {
     super.validateIsNotNull();
     return this._datum;
   }
 
-  writeBinary(span : Span) : number {
+  writeBinary(span : BinarySpan) : number {
     var binary_image = (IonTypes.BOOL.bid << IonBinary.TYPE_SHIFT)
     if (this.isNull()) {
       binary_image = binary_image | IonBinary.LEN_NULL;
@@ -218,7 +218,7 @@ class IonBool extends IonValue {
     return 1;  // bytes written
   }
 
-  readBinary(span: Span, bid: number, len: number) {
+  readBinary(span: BinarySpan, bid: number, len: number) {
     if (len == IonBinary.LEN_NULL) {
       this._datum = undefined;
     }
@@ -236,7 +236,7 @@ class IonInt extends IonNumber {
     return IonTypes.INT;
   }
 
-  toString() : string { 
+  toString() : string {
     var s;
     if (this.isNull()) {
       s = IonTypes.NULL.name + "." + this.getType().name;
@@ -247,7 +247,7 @@ class IonInt extends IonNumber {
     return  super.toString() + s;
   }
 
-  setValue(b: number) : void { 
+  setValue(b: number) : void {
     if (b === undefined) {
       this._datum = undefined;
     }
@@ -259,12 +259,12 @@ class IonInt extends IonNumber {
     }
   }
 
-  numberValue() : number { 
+  numberValue() : number {
     super.validateIsNotNull();
     return this._datum;
   }
 
-  writeBinary(span: Span) : number {
+  writeBinary(span: BinarySpan) : number {
     var binary_image = (IonTypes.INT.bid << IonBinary.TYPE_SHIFT),
         len = 1;
     if (this.isNull()) {
@@ -305,7 +305,7 @@ class IonInt extends IonNumber {
     return len;  // bytes written
   }
 
-  readBinary(span: Span, bid: number, len: number) : number {
+  readBinary(span: BinarySpan, bid: number, len: number) : number {
     if (len == IonBinary.LEN_NULL) {
       this._datum = undefined;
       len = 0;

--- a/tests/intern-debug.js
+++ b/tests/intern-debug.js
@@ -13,12 +13,13 @@
  */
 define({
   defaultTimeout: 2000, // ms
-  excludeInstrumentation: true, // disable codecoverate instrucmentation to allow debugging 
+  excludeInstrumentation: true, // disable code coverage for debugging
   filterErrorStack: true,
   suites: [
     'tests/unit/textNulls',
     'tests/unit/spans',
     'tests/unit/iontests',
+    'tests/unit/tokens',
     'tests/unit/IonCatalogTest',
     'tests/unit/IonImportTest',
     'tests/unit/IonLocalSymbolTableTest',
@@ -30,6 +31,6 @@ define({
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',
     'tests/unit/IonBinaryWriterTest',
-    'tests/unit/IonBinaryTimestampTest',
-  ],
+    'tests/unit/IonBinaryTimestampTest'
+  ]
 });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -15,7 +15,6 @@ define({
   defaultTimeout: 2000, // ms
   excludeInstrumentation: /^(?:tests|node_modules)\//,
   filterErrorStack: true,
-  xsuites: [ 'tests/unit/iontests' ],
   suites: [
     'tests/unit/textNulls',
     'tests/unit/spans',

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -15,10 +15,12 @@ define({
   defaultTimeout: 2000, // ms
   excludeInstrumentation: /^(?:tests|node_modules)\//,
   filterErrorStack: true,
+  xsuites: [ 'tests/unit/iontests' ],
   suites: [
     'tests/unit/textNulls',
     'tests/unit/spans',
     'tests/unit/iontests',
+    'tests/unit/tokens',
     'tests/unit/IonCatalogTest',
     'tests/unit/IonImportTest',
     'tests/unit/IonLocalSymbolTableTest',
@@ -33,3 +35,4 @@ define({
     'tests/unit/IonBinaryTimestampTest',
   ],
 });
+

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -38,7 +38,6 @@ define([
     var ionTestsPath = paths.join(cwd, 'ion-tests', 'iontestdata', 'good');
     var accumulator = [];
     findFiles(ionTestsPath, accumulator);
-    //console.log(accumulator.join('\n'));
 
     var skipList = [
       'good/decimalsWithUnderscores.ion',
@@ -51,13 +50,29 @@ define([
       'good/utf32.ion',
     ];
 
+    // For debugging, put single files in this list to have the test run only
+    // that file.   (But don't forget to clean this up on checkin!)
+    var debugList = [
+        //'good/sexps.ion'
+    ];
+
     var unskipped = [];
     for (var path of accumulator) {
+      var spath = path.replace(/\\/g, "/");
       var shouldSkip = false;
       for (var skip of skipList) {
-        if (path.endsWith(skip)) {
+        if (spath.endsWith(skip)) {
           shouldSkip = true;
           break;
+        }
+      }
+      if (debugList.length > 0) {
+        shouldSkip = true;
+        for (var debug of debugList) {
+          if (spath.endsWith(debug)) {
+            shouldSkip = false;
+            break;
+          }
         }
       }
       if (!shouldSkip) {
@@ -107,10 +122,9 @@ define([
                 chunks.push(chunk);
               }
               var buffer = Buffer.concat(chunks);
-              var reader = ion.makeReader(buffer);
+              var reader = ion.makeReader(path.endsWith(".10n") ?
+                                          buffer : buffer.toString("utf8"));
               console.log("Exhausting " + path);
-              if (path.endsWith('clobsWithWhitespace.ion')) {
-              }
               exhaust(reader);
               resolve();
             } catch (e) {

--- a/tests/unit/spans.js
+++ b/tests/unit/spans.js
@@ -15,16 +15,16 @@ define([
     'intern',
     'intern!object',
     'intern/chai!assert',
-    'dist/amd/es6/IonSpan',
+    'dist/amd/es6/IonTests'
   ],
-  function(intern, registerSuite, assert, ionSpan) {
+  function(intern, registerSuite, assert, ion) {
 
     var suite = {
       name: 'Spans'
     };
 
     suite['null valueAt'] = function() {
-      var span = ionSpan.makeSpan("null");
+      var span = new ion.StringSpan("null");
       assert.equal('n'.charCodeAt(0), span.valueAt(0));
       assert.equal('u'.charCodeAt(0), span.valueAt(1));
       assert.equal('l'.charCodeAt(0), span.valueAt(2));
@@ -33,7 +33,7 @@ define([
     };
 
     suite['null next'] = function() {
-      var span = ionSpan.makeSpan("null");
+      var span = new ion.StringSpan("null");
       assert.equal('n'.charCodeAt(0), span.next());
       assert.equal('u'.charCodeAt(0), span.next());
       assert.equal('l'.charCodeAt(0), span.next());
@@ -42,21 +42,8 @@ define([
     };
 
     suite['Buffer initial position'] = function() {
-      var buffer = Buffer.from("null");
-      var span = ionSpan.makeSpan(buffer);
+      var span = new ion.StringSpan('null');
       assert.equal(0, span.position());
-    };
-    
-    suite['makeSpan - Span input'] = function() {
-      let spanIn = ionSpan.makeSpan("{ hello: \"world\"}");
-      let actual = ionSpan.makeSpan(spanIn);
-      assert.strictEqual(actual, spanIn, 'a span input to makeSpan should return the input untouched')
-    };
-  
-    suite['makeSpan - Object input'] = function() {
-      let spanIn = ionSpan.makeSpan("{ hello: \"world\"}");
-      let actual = ionSpan.makeSpan(spanIn);
-      assert.strictEqual(actual, spanIn, 'a span input to makeSpan should return the input untouched')
     };
 
     registerSuite(suite);

--- a/tests/unit/tokens.js
+++ b/tests/unit/tokens.js
@@ -20,8 +20,7 @@ define(
     ],
     function(intern, registerSuite, assert, ion) {
         function make_parser(str) {
-            var reader = ion.makeReader(str, { raw_tokens: true });
-            var parser = reader.raw_parser();
+            var parser = ion.makeTextTokenizer(str);
             return parser;
         }
 
@@ -82,119 +81,124 @@ define(
         var suite = {
             name: 'Tokens'
         };
-        if (false) {  // for isolating failures within a single test
-            console.log("+++++++ DEBUGGING MODE, don't check this in!! ++++++");
-            suite['foo'] = function() {
-                test_int("0x10");
-            };
-        } else {
-            suite['null'] = function() {
-                test_null("null");
-                for (var t in ion.IonTypes) {
-                    var type = ion.IonTypes[t];
-                    if (type.bid >= 0 && type.bid < 16) {
-                        test_null("null." + type.name);
-                    }
+
+        suite['null'] = function() {
+            test_null("null");
+            for (var t in ion.IonTypes) {
+                var type = ion.IonTypes[t];
+                if (type.bid >= 0 && type.bid < 16) {
+                    test_null("null." + type.name);
                 }
-            };
+            }
+        };
 
-            suite['bool'] = function() {
-                test_bool("true");
-                test_bool("false");
-            };
+        suite['bool'] = function() {
+            test_bool("true");
+            test_bool("false");
+        };
 
-            suite['int'] = function() {
-                test_int("0");
-                test_int("-0");
-                test_int("88888888888888888888888888888888888888888888");
-                test_int("0x10");
-            };
+        suite['int'] = function() {
+            test_int("0");
+            test_int("-0");
+            test_int("88888888888888888888888888888888888888888888");
+            test_int("0x10");
+        };
 
-            suite['decimal'] = function() {
-                test_decimal("0.0");
-                test_decimal("-0.0");
-                test_decimal("0d0");
-                test_decimal("88888888888888888888888888888888888888888888.0");
-            };
+        suite['decimal'] = function() {
+            test_decimal("0.0");
+            test_decimal("-0.0");
+            test_decimal("0d0");
+            test_decimal("88888888888888888888888888888888888888888888.0");
+        };
 
-            suite['float'] = function() {
-                test_float("nan");
-                test_float("+inf");
-                test_float("-inf");
-                test_float("0.0e0");
-            };
+        suite['float'] = function() {
+            test_float("nan");
+            test_float("+inf");
+            test_float("-inf");
+            test_float("0.0e0");
+        };
 
-            suite['timestamp'] = function() {
-                test_timestamp("1999-12-25T00:00:00Z");
-            };
+        suite['timestamp'] = function() {
+            test_timestamp("1999-12-25T00:00:00Z");
+        };
 
-            suite['symbol'] = function() {
-                test_symbol("ab");
-                test_symbol("a");
-                test_symbol("$3");
-            };
+        suite['symbol'] = function() {
+            test_symbol("ab");
+            test_symbol("a");
+            test_symbol("$3");
+        };
 
-            suite['string'] = function() {
-                test_string("\"abc\"", "abc");
-                test_string("'''abc'''", "abc");
-                test_string('"ab\\"c"', 'ab"c');
-                test_string("'''abc''' // cmt\n'''def'''", "abcdef");
-                test_string("'''abc''' /* cmt */'''def'''", "abcdef");
-            };
+        suite['string'] = function() {
+            test_string("\"abc\"", "abc");
+            test_string("'''abc'''", "abc");
+            test_string('"ab\\"c"', 'ab"c');
+            test_string("'''abc''' // cmt\n'''def'''", "abcdef");
+            test_string("'''abc''' /* cmt */'''def'''", "abcdef");
+        };
 
-            suite['blob'] = function() {
-                test_blob("{{OiBTIKUgTyAASb8=}}");
-            };
+        suite['blob'] = function() {
+            test_blob("{{OiBTIKUgTyAASb8=}}");
+        };
 
 
-            suite['clob'] = function() {
-                test_clob('{{"a b c"}}', "a b c");
-                test_clob("{{ '''line 1'''\n    '''line 2'''\n}}", 'line 1line 2');
-                test_clob('{{ "line 3 \\" line 4" }}', 'line 3 " line 4');
-                test_clob('{{ "line 3 \\n line 4" }}', 'line 3 \n line 4');
-            };
+        suite['clob'] = function() {
+            test_clob('{{"a b c"}}', "a b c");
+            test_clob("{{ '''line 1'''\n    '''line 2'''\n}}", 'line 1line 2');
+            test_clob('{{ "line 3 \\" line 4" }}', 'line 3 " line 4');
+            test_clob('{{ "line 3 \\n line 4" }}', 'line 3 \n line 4');
+        };
 
-            suite['empty list'] = function() {
-                var parser = make_parser("[]");
-                next(parser, ion.IonTypes.SYMBOL, "[");
-                next(parser, ion.IonTypes.SYMBOL, "]");
-                assert.equal(parser.next(), -1);
-            };
+        suite['empty list'] = function() {
+            var parser = make_parser("[]");
+            next(parser, ion.IonTypes.SYMBOL, "[");
+            next(parser, ion.IonTypes.SYMBOL, "]");
+            assert.equal(parser.next(), -1);
+        };
 
-            suite['empty sexp'] = function() {
-                var parser = make_parser("()");
-                next(parser, ion.IonTypes.SYMBOL, "(");
-                next(parser, ion.IonTypes.SYMBOL, ")");
-                assert.equal(parser.next(), -1);
-            };
+        suite['empty sexp'] = function() {
+            var parser = make_parser("()");
+            next(parser, ion.IonTypes.SYMBOL, "(");
+            next(parser, ion.IonTypes.SYMBOL, ")");
+            assert.equal(parser.next(), -1);
+        };
 
-            suite['empty struct'] = function() {
-                var parser = make_parser("{}");
-                next(parser, ion.IonTypes.SYMBOL, "{");
-                next(parser, ion.IonTypes.SYMBOL, "}");
-                assert.equal(parser.next(), -1);
-            };
+        suite['empty struct'] = function() {
+            var parser = make_parser("{}");
+            next(parser, ion.IonTypes.SYMBOL, "{");
+            next(parser, ion.IonTypes.SYMBOL, "}");
+            assert.equal(parser.next(), -1);
+        };
 
-            suite['annotation'] = function() {
-                var parser = make_parser("abc::def");
-                next(parser, ion.IonTypes.SYMBOL, "abc");
-                next(parser, ion.IonTypes.SYMBOL, "::");
-                next(parser, ion.IonTypes.SYMBOL, "def");
-                assert.equal(parser.next(), -1);
-            };
+        suite['annotation'] = function() {
+            var parser = make_parser("abc::def");
+            next(parser, ion.IonTypes.SYMBOL, "abc");
+            next(parser, ion.IonTypes.SYMBOL, "::");
+            next(parser, ion.IonTypes.SYMBOL, "def");
+            assert.equal(parser.next(), -1);
+        };
 
-            suite['sexp'] = function() {
-                var parser = make_parser("(+ ++ abc::-1)");
-                next(parser, ion.IonTypes.SYMBOL, "(");
-                next(parser, ion.IonTypes.SYMBOL, "+");
-                next(parser, ion.IonTypes.SYMBOL, "++");
-                next(parser, ion.IonTypes.SYMBOL, "abc");
-                next(parser, ion.IonTypes.SYMBOL, "::");
-                next(parser, ion.IonTypes.INT, "-1");
-                next(parser, ion.IonTypes.SYMBOL, ")");
-                assert.equal(parser.next(), -1);
-            };
-        }
+        suite['sexp'] = function() {
+            var parser = make_parser("(+ ++ abc::-1)");
+            next(parser, ion.IonTypes.SYMBOL, "(");
+            next(parser, ion.IonTypes.SYMBOL, "+");
+            next(parser, ion.IonTypes.SYMBOL, "++");
+            next(parser, ion.IonTypes.SYMBOL, "abc");
+            next(parser, ion.IonTypes.SYMBOL, "::");
+            next(parser, ion.IonTypes.INT, "-1");
+            next(parser, ion.IonTypes.SYMBOL, ")");
+            assert.equal(parser.next(), -1);
+        };
+
+        suite['errors'] = function() {
+            var parser = make_parser("null.foo");
+            let error = false;
+            try {
+                next(parser, 0, "");
+            } catch (ex) {
+                error = true;
+            }
+            assert.equal(error, true);
+        };
         registerSuite(suite);
     }
 );

--- a/tests/unit/tokens.js
+++ b/tests/unit/tokens.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+define(
+    [
+        'intern',
+        'intern!object',
+        'intern/chai!assert',
+        'dist/amd/es6/IonTests',
+    ],
+    function(intern, registerSuite, assert, ion) {
+        function make_parser(str) {
+            var reader = ion.makeReader(str, { raw_tokens: true });
+            var parser = reader.raw_parser();
+            return parser;
+        }
+
+        function next(parser, expected_type, expected_value) {
+            var t = parser.next();
+            if (false) {
+                console.log("t = " + JSON.stringify(t));
+                console.log("start = " + parser.start());
+                console.log("end = " + parser.end());
+                console.log("s = " + parser.get_value_as_string(t));
+                console.log("raw = " + parser.get_raw_token());
+                console.log("type(t) = " + JSON.stringify(ion.get_ion_type(t)));
+                console.log("exp = " + JSON.stringify(expected_type));
+            }
+            assert.equal(ion.get_ion_type(t), expected_type);
+            assert.equal(parser.get_value_as_string(t), expected_value);
+        }
+
+        function test_token(type, str, exp) {
+            if (exp === undefined) exp = str;
+            var parser = make_parser(str);
+            next(parser, type, exp);
+            assert.equal(parser.get_raw_token(), str);
+            assert.equal(parser.next(), -1);
+        }
+
+        function test_null(s) {
+            test_token(ion.IonTypes.NULL, s);
+        }
+        function test_bool(s) {
+            test_token(ion.IonTypes.BOOL, s);
+        }
+        function test_int(s) {
+            test_token(ion.IonTypes.INT, s);
+        }
+        function test_decimal(s) {
+            test_token(ion.IonTypes.DECIMAL, s);
+        }
+        function test_float(s) {
+            test_token(ion.IonTypes.FLOAT, s);
+        }
+        function test_timestamp(s) {
+            test_token(ion.IonTypes.TIMESTAMP, s);
+        }
+        function test_symbol(s) {
+            test_token(ion.IonTypes.SYMBOL, s);
+        }
+        function test_string(s, ps) {
+            test_token(ion.IonTypes.STRING, s, ps);
+        }
+        function test_blob(s) {
+            test_token(ion.IonTypes.BLOB, s);
+        }
+        function test_clob(s, ps) {
+            test_token(ion.IonTypes.CLOB, s, ps);
+        }
+
+        var suite = {
+            name: 'Tokens'
+        };
+        if (false) {  // for isolating failures within a single test
+            console.log("+++++++ DEBUGGING MODE, don't check this in!! ++++++");
+            suite['foo'] = function() {
+                test_int("0x10");
+            };
+        } else {
+            suite['null'] = function() {
+                test_null("null");
+                for (var t in ion.IonTypes) {
+                    var type = ion.IonTypes[t];
+                    if (type.bid >= 0 && type.bid < 16) {
+                        test_null("null." + type.name);
+                    }
+                }
+            };
+
+            suite['bool'] = function() {
+                test_bool("true");
+                test_bool("false");
+            };
+
+            suite['int'] = function() {
+                test_int("0");
+                test_int("-0");
+                test_int("88888888888888888888888888888888888888888888");
+                test_int("0x10");
+            };
+
+            suite['decimal'] = function() {
+                test_decimal("0.0");
+                test_decimal("-0.0");
+                test_decimal("0d0");
+                test_decimal("88888888888888888888888888888888888888888888.0");
+            };
+
+            suite['float'] = function() {
+                test_float("nan");
+                test_float("+inf");
+                test_float("-inf");
+                test_float("0.0e0");
+            };
+
+            suite['timestamp'] = function() {
+                test_timestamp("1999-12-25T00:00:00Z");
+            };
+
+            suite['symbol'] = function() {
+                test_symbol("ab");
+                test_symbol("a");
+                test_symbol("$3");
+            };
+
+            suite['string'] = function() {
+                test_string("\"abc\"", "abc");
+                test_string("'''abc'''", "abc");
+                test_string('"ab\\"c"', 'ab"c');
+                test_string("'''abc''' // cmt\n'''def'''", "abcdef");
+                test_string("'''abc''' /* cmt */'''def'''", "abcdef");
+            };
+
+            suite['blob'] = function() {
+                test_blob("{{OiBTIKUgTyAASb8=}}");
+            };
+
+
+            suite['clob'] = function() {
+                test_clob('{{"a b c"}}', "a b c");
+                test_clob("{{ '''line 1'''\n    '''line 2'''\n}}", 'line 1line 2');
+                test_clob('{{ "line 3 \\" line 4" }}', 'line 3 " line 4');
+                test_clob('{{ "line 3 \\n line 4" }}', 'line 3 \n line 4');
+            };
+
+            suite['empty list'] = function() {
+                var parser = make_parser("[]");
+                next(parser, ion.IonTypes.SYMBOL, "[");
+                next(parser, ion.IonTypes.SYMBOL, "]");
+                assert.equal(parser.next(), -1);
+            };
+
+            suite['empty sexp'] = function() {
+                var parser = make_parser("()");
+                next(parser, ion.IonTypes.SYMBOL, "(");
+                next(parser, ion.IonTypes.SYMBOL, ")");
+                assert.equal(parser.next(), -1);
+            };
+
+            suite['empty struct'] = function() {
+                var parser = make_parser("{}");
+                next(parser, ion.IonTypes.SYMBOL, "{");
+                next(parser, ion.IonTypes.SYMBOL, "}");
+                assert.equal(parser.next(), -1);
+            };
+
+            suite['annotation'] = function() {
+                var parser = make_parser("abc::def");
+                next(parser, ion.IonTypes.SYMBOL, "abc");
+                next(parser, ion.IonTypes.SYMBOL, "::");
+                next(parser, ion.IonTypes.SYMBOL, "def");
+                assert.equal(parser.next(), -1);
+            };
+
+            suite['sexp'] = function() {
+                var parser = make_parser("(+ ++ abc::-1)");
+                next(parser, ion.IonTypes.SYMBOL, "(");
+                next(parser, ion.IonTypes.SYMBOL, "+");
+                next(parser, ion.IonTypes.SYMBOL, "++");
+                next(parser, ion.IonTypes.SYMBOL, "abc");
+                next(parser, ion.IonTypes.SYMBOL, "::");
+                next(parser, ion.IonTypes.INT, "-1");
+                next(parser, ion.IonTypes.SYMBOL, ")");
+                assert.equal(parser.next(), -1);
+            };
+        }
+        registerSuite(suite);
+    }
+);

--- a/tests/unit/tokens.js
+++ b/tests/unit/tokens.js
@@ -33,10 +33,10 @@ define(
                 console.log("end = " + parser.end());
                 console.log("s = " + parser.get_value_as_string(t));
                 console.log("raw = " + parser.get_raw_token());
-                console.log("type(t) = " + JSON.stringify(ion.get_ion_type(t)));
+                console.log("type(t) = " + JSON.stringify(ion.getIonType(t)));
                 console.log("exp = " + JSON.stringify(expected_type));
             }
-            assert.equal(ion.get_ion_type(t), expected_type);
+            assert.equal(ion.getIonType(t), expected_type);
             assert.equal(parser.get_value_as_string(t), expected_value);
         }
 


### PR DESCRIPTION
To give access to the low level token stream

Ion:
 - Add 'raw_tokens' option to makeTextReader(), allowing the raw text parser
   to be used as a lexer 
 - Export the raw parser's get_ion_type() function to map the raw token type
   to the corrent Ion type.
IonParserTextRaw:
 - Fix bug: get_ion_type incorrectly returned "STRING" for single quoted symbols
 - For raw mode, add "_read_token" as a variant of "_read_value" which returns
   individual tokens.
 - Add accessors for start/end.
 - Add locator() and error_line() functions which wraps the corresponding
   IonSpan implementations.  Leverage them in error reporting.
 - Rationalize start/end handling -- start always points to the first
   character of the raw token, end always points one character after the
   last character of the raw token.
IonSpan:
 - fix spelling of CARRIAGE_RETURN
 - add locator() function to map a position in the span to line/column information
 - add error_line() which returns the line containing a given token followed
   by a line which points to the token
IonText:
 - Add is_single_operator_char() function so that e.g., "a::-1" tokenizes
   as 'a', '::', '-1' instead of 'a', '::-', '1'
IonTextReader:
 - add raw_parser() accessor
tests/unit:
 - add tokenizer test
tests/unit/iontests:
 - Replace backslashes in paths with forward slashes so these tests work on Windows
 - Add a way to run only specific files for debugging
 - Since makeSpan creates a binary span if you give it a Buffer, convert text
   files to strings so makeSpan will create a text span.
tests/unit/tokens:
 - new unit test for raw mode token handling