### PR TITLE
fix(source): Fix skipping past containers in IonTextReader

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -78,7 +78,7 @@ export class TextReader implements Reader {
         p = this._parser;
     while (d > 0) {
       type = p.next();
-      if (type === undefined) { // end of container
+      if (type === EOF) { // end of container
         d--;
       }
       else if (type.container) {

--- a/tests/intern-debug.js
+++ b/tests/intern-debug.js
@@ -27,6 +27,7 @@ define({
     'tests/unit/IonWriteableTest',
     'tests/unit/IonTimestampTest',
     'tests/unit/IonTextTest',
+    'tests/unit/IonTextReaderTest',
     'tests/unit/IonTextWriterTest',
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -27,6 +27,7 @@ define({
     'tests/unit/IonWriteableTest',
     'tests/unit/IonTimestampTest',
     'tests/unit/IonTextTest',
+    'tests/unit/IonTextReaderTest',
     'tests/unit/IonTextWriterTest',
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+define([
+    'intern',
+    'intern!object',
+    'intern/chai!assert',
+    'dist/amd/es6/IonTests',
+  ],
+  function(intern, registerSuite, assert, ion) {
+
+    var suite = {
+      name: 'Text reader'
+    };
+
+    suite['skipOverStruct'] = function() {
+      var reader = ion.makeReader("{key1:value1} {key2:value2} 123");
+      assert.equal(reader.next(), ion.IonTypes.STRUCT);
+      assert.equal(reader.next(), ion.IonTypes.STRUCT);
+      assert.equal(reader.next(), ion.IonTypes.INT);
+    };
+
+    suite['skipOverNestedStruct'] = function() {
+      var reader = ion.makeReader("{nested:{foo:bar}, number:123}");
+      reader.next();
+      reader.stepIn();
+      assert.equal(reader.next(), ion.IonTypes.STRUCT);
+      assert.equal(reader.next(), ion.IonTypes.INT);
+      reader.stepOut();
+    };
+
+    suite['skipOverListAndSexp'] = function() {
+      var reader = ion.makeReader("[a, b, c] (d e f) 123");
+      assert.equal(reader.next(), ion.IonTypes.LIST);
+      assert.equal(reader.next(), ion.IonTypes.SEXP);
+      assert.equal(reader.next(), ion.IonTypes.INT);
+    };
+
+    registerSuite(suite);
+  }
+);


### PR DESCRIPTION
Fix an incorrect check for `undefined` rather than `EOF` to denote the end of a container when
skipping over containers via skip_past_container() (from next()).