### PR TITLE
fix(source): Fix numberValue and booleanValue for TextReader

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -1093,8 +1093,8 @@ export class ParserTextRaw {
   }
 
   numberValue() : number {
-    var n, s = this.get_value_as_string(this._value_type);
-    switch (this._value_type) {
+    var n, s = this.get_value_as_string(this._curr);
+    switch (this._curr) {
       case T_INT:
       case T_HEXINT:
       case T_FLOAT:
@@ -1113,7 +1113,7 @@ export class ParserTextRaw {
   }
 
   booleanValue() : boolean {
-    if (this._value_type !== T_BOOL) {
+    if (this._curr !== T_BOOL) {
       return undefined;
     }
     let s: string = this.get_value_as_string(T_BOOL);

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -46,6 +46,45 @@ define([
       assert.equal(reader.next(), ion.IonTypes.INT);
     };
 
+    suite['numberValueForInt'] = function() {
+        var reader = ion.makeReader("1");
+        assert.equal(reader.next(), ion.IonTypes.INT);
+        assert.equal(reader.numberValue(), 1);
+    };
+
+    suite['numberValueForFloat'] = function() {
+        var reader = ion.makeReader("15e-1");
+        assert.equal(reader.next(), ion.IonTypes.FLOAT);
+        assert.equal(reader.numberValue(), 1.5);
+    };
+
+    suite['numberValueForHexInt'] = function() {
+        var reader = ion.makeReader("0x1234");
+        assert.equal(reader.next(), ion.IonTypes.INT);
+        assert.equal(reader.numberValue(), 0x1234);
+    };
+
+    suite['numberValueForInf'] = function() {
+        var reader = ion.makeReader("+inf");
+        assert.equal(reader.next(), ion.IonTypes.FLOAT);
+        assert(!isFinite(reader.numberValue()));
+    };
+
+    suite['numberValueInStruct'] = function() {
+        var reader = ion.makeReader("{num:1}");
+        reader.next();
+        reader.stepIn();
+        assert.equal(reader.next(), ion.IonTypes.INT);
+        assert.equal(reader.numberValue(), 1);
+        reader.stepOut();
+    };
+
+    suite['booleanValue'] = function() {
+        var reader = ion.makeReader("true");
+        assert.equal(reader.next(), ion.IonTypes.BOOL);
+        assert.equal(reader.booleanValue(), true);
+    };
+
     registerSuite(suite);
   }
 );


### PR DESCRIPTION
Calling `next()` on a text reader consumes `_value_type` into `_curr` and resets `_value_type` to
`ERROR`.  Changed `numberValue()` and `booleanValue()` to check `this._curr` instead.
