### PR TITLE
Add output target for CommonJS/ES5 (better support for module loaders)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function(grunt) {
           sourceMap: true  // generate .map files for debugging
         }
       },
- 
+
       'amd-es6': {
         src: ['src/**/*.ts'],
         outDir: 'dist/amd/es6',
@@ -119,19 +119,19 @@ module.exports = function(grunt) {
         ]
       }
     },
-    babel: { 
-      options: { 
-        sourceMap: true, 
+    babel: {
+      options: {
+        sourceMap: true,
         presets: ['es2015']
       },
-      dist: { 
-        files: [{ 
-          'expand': true, 
+      dist: {
+        files: [{
+          'expand': true,
           cwd: 'dist/amd/es6',
-          'src': ['*.js'], 
-          'dest': 'dist/amd/es5/', 
+          'src': ['*.js'],
+          'dest': 'dist/amd/es5/',
           'ext': '.js',
-        }], 
+        }],
       },
     },
     /**
@@ -144,12 +144,12 @@ module.exports = function(grunt) {
         src: [ "./dist/commonjs/es6/Ion.js" ],
         dest: './dist/browser/js/ion-bundle.js',
         options: {
-         browserifyOptions: { 
+         browserifyOptions: {
            standalone: 'ion', // add `ion` to global JS variable `window` in browsers
            debug: true,
          },
-        transform: [["babelify", 
-                     { 
+        transform: [["babelify",
+                     {
                        "presets": ["es2015"],
                        "plugins" : [["transform-runtime", {"polyfill" : true}],
                                     ["transform-object-assign"]]
@@ -160,12 +160,12 @@ module.exports = function(grunt) {
         src: [ "./dist/commonjs/es6/Ion.js" ],
         dest: './dist/browser/js/ion-bundle.js',
         options: {
-         browserifyOptions: { 
+         browserifyOptions: {
            standalone: 'ion', // add `ion` to global JS variable `window` in browsers
            debug: false,
          },
-        transform: [["babelify", 
-                     { 
+        transform: [["babelify",
+                     {
                        "presets": ["es2015"],
                        "plugins" : [["transform-runtime", {"polyfill" : true}],
                                     ["transform-object-assign"]]
@@ -173,13 +173,13 @@ module.exports = function(grunt) {
         }
       }
     },
-      uglify: { 
-          options: { 
-              compress: true, 
-              mangle: true, 
+      uglify: {
+          options: {
+              compress: true,
+              mangle: true,
               sourceMap: false
-          }, 
-          target: { 
+          },
+          target: {
               src: './dist/browser/js/ion-bundle.js',
               dest: './dist/browser/js/ion-bundle.min.js',
           }
@@ -200,12 +200,12 @@ module.exports = function(grunt) {
   // Copy tasks
   grunt.registerTask('copy:all', ['copy:bundle', 'copy:tutorial']);
 
-  // Build and Translation tasks 
+  // Build and Translation tasks
   grunt.registerTask('build:browser', ['build', 'browserify:prod', 'uglify']); // standalone for browser
   grunt.registerTask('trans:browser', ['browserify:prod', 'uglify']); // browserify (assumes 'build' was run)
   grunt.registerTask('build:cjs', ['ts:commonjs-es6']);
   grunt.registerTask('build:amd', ['ts:amd-es6']);
-  grunt.registerTask('build:amd:debug', ['ts:amd-es6-debug']); 
+  grunt.registerTask('build:amd:debug', ['ts:amd-es6-debug']);
   grunt.registerTask('build', ['clean', 'build:amd', 'build:cjs','trans:browser', 'copy:all']);
 
 
@@ -216,14 +216,14 @@ module.exports = function(grunt) {
 
   // Documentation
   grunt.registerTask('nojekyll', 'Write an empty .nojekyll file to allow typedoc html output to be rendered',
-    function(){ 
+    function(){
       grunt.file.write('docs/.nojekyll', '');
     });
 
   grunt.registerTask('doc', ['typedoc']);
 
 
-  // release target used by Travis 
+  // release target used by Travis
   grunt.registerTask('release', ['build', 'test:run', 'test:coverage', 'typedoc', 'nojekyll']);
 
   // default for development

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,6 +93,17 @@ module.exports = function(grunt) {
           module: "commonjs",
           declaration: true
         }
+      },
+      'commonjs-es5': {
+        src: ['src/**/*.ts'],
+        outDir: 'dist/commonjs/es5',
+        options: {
+          target: "es5",
+          module: "commonjs",
+          downlevelIteration: true,
+          declaration: true,
+          lib: ['ESNext','DOM.Iterable', 'esnext.asynciterable']
+        }
       }
     },
       /**
@@ -203,11 +214,10 @@ module.exports = function(grunt) {
   // Build and Translation tasks
   grunt.registerTask('build:browser', ['build', 'browserify:prod', 'uglify']); // standalone for browser
   grunt.registerTask('trans:browser', ['browserify:prod', 'uglify']); // browserify (assumes 'build' was run)
-  grunt.registerTask('build:cjs', ['ts:commonjs-es6']);
+  grunt.registerTask('build:cjs', ['ts:commonjs-es6', 'ts:commonjs-es5']);
   grunt.registerTask('build:amd', ['ts:amd-es6']);
   grunt.registerTask('build:amd:debug', ['ts:amd-es6-debug']);
-  grunt.registerTask('build', ['clean', 'build:amd', 'build:cjs','trans:browser', 'copy:all']);
-
+  grunt.registerTask('build', ['clean', 'build:amd', 'build:cjs', 'trans:browser', 'copy:all']);
 
   // Tests
   grunt.registerTask('test', ['build', 'intern:es6']);     // build and test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",
+  "browser": "dist/commonjs/es5/Ion.js",
   "scripts": {
     "commit": "git-cz",
     "test": "grunt test",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^2.3.0",
-    "grunt-ts": "^6.0.0-beta.3",
+    "grunt-ts": "^6.0.0-beta.17",
     "grunt-typedoc": "^0.2.4",
     "intern": "^3.4.1",
     "remap-istanbul": "^0.9.1",


### PR DESCRIPTION
It is possible to make the TypeScript compiler to produce ES5 output, even while using generators and other experimental features. [TypeScript 2.3+](ts-release) added the `downlevelIteration` option:

> With --downlevelIteration, the compiler uses new type check and emit behavior that attempts to call a [Symbol.iterator]() method on the iterated object if it is found, and creates a synthetic array iterator over the object if it is not.

I've had to upgrade [`grunt-ts` to the latest version](https://github.com/TypeStrong/grunt-ts/blob/master/CHANGELOG.md#v600-beta17) in order to be able to pass these options to the compiler.

Finally, `package.json` can be updated with a [`browser` field][browser-spec] instructing bundlers like webpack and browserify to use the ES5 code generated by the tyepescript compiler instead of requiring babel and polyfills.

Combining these three features, I've changed the build of the `ion-js` package to produce an ES5 version of its CommonJS output which can be used without any extra configuration. The change should be transparent to all consumers that are not module loaders.

After building ion-js with the proposed changes and linking the package locally the webpack build succeeds:

```
➜  ion-js-webpack-demo git:(master) yarn build
yarn run v1.3.2
$ react-scripts build
Creating an optimized production build...
Compiled with warnings.

./src/index.js
  Line 1:  'makeReader' is defined but never used  no-unused-vars

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

File sizes after gzip:

  28.75 KB (-14.11 KB)  build/static/js/main.55cc3a08.js
  [...]
```
Fixes #116 

[ts-release]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html
[compiler-options]: https://www.typescriptlang.org/docs/handbook/compiler-options.html
[grunt-ts-changelog]: https://github.com/TypeStrong/grunt-ts/blob/master/CHANGELOG.md#v600-beta17
[browser-spec]: https://github.com/defunctzombie/package-browser-field-spec
[cra-guidance]: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify
