### PR TITLE
Utf16 surrogate pairs

### DIFF
--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -15,7 +15,7 @@ import { BinaryReader } from "./IonBinaryReader";
 import { Catalog } from "./IonCatalog";
 import { IVM } from "./IonConstants";
 import { Reader } from "./IonReader";
-import { Span, makeSpan } from "./IonSpan";
+import { Span, makeSpan, StringSpan } from "./IonSpan";
 import { TextReader } from "./IonTextReader";
 import { InvalidArgumentError } from "./IonErrors";
 import { Writer } from "./IonWriter";
@@ -57,7 +57,7 @@ function makeBinaryReader(span: Span, options: Options) : BinaryReader {
   return new BinaryReader(span, options && options.catalog);
 }
 
-function makeTextReader(span: Span, options: Options) : TextReader {
+function makeTextReader(span: StringSpan, options: Options) : TextReader {
   return new TextReader(span, options && options.catalog);
 }
 
@@ -94,7 +94,7 @@ export function makeReader(buf: any, options: Options) : Reader {
                 : get_buf_type(inSpan);
   let reader: Reader = (stype === 'binary')
              ? makeBinaryReader(inSpan, options)
-             : makeTextReader(inSpan, options);
+             : makeTextReader(<StringSpan>inSpan, options);
   return reader;
 }
 

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -1056,12 +1056,12 @@ private _test_symbol_as_annotation() : boolean {
                         if(this.isLowSurrogate(tempChar)){
                             s += ch + tempChar;
                             index++;
-                        }else{
+                        } else{
                             throw new Error("illegal high surrogate" + ch);
                         }
-                    }else if(this.isLowSurrogate(ch)){
+                    } else if(this.isLowSurrogate(ch)){
                         throw new Error("illegal low surrogate: " + ch);
-                    }else{
+                    } else{
                         s += String.fromCharCode(ch);
                     }
                 }
@@ -1085,10 +1085,10 @@ private _test_symbol_as_annotation() : boolean {
                         if(this.isLowSurrogate(tempChar)){
                             s += ch + tempChar;
                             index++;
-                        }else{
+                        } else{
                             throw new Error("illegal high surrogate" + ch);
                         }
-                    }else if(this.isLowSurrogate(ch)){
+                    } else if(this.isLowSurrogate(ch)){
                         throw new Error("illegal low surrogate: " + ch);
                     } else if(ch === CH_SQ) {
                         if (this.verifyTriple(index)) {
@@ -1124,14 +1124,14 @@ private _test_symbol_as_annotation() : boolean {
                         }
                         index += this._esc_len;
                         break;
-                    }else if ( ch ===CH_SQ) {
+                    } else if ( ch ===CH_SQ) {
                         if (this.verifyTriple(index)) {
                             index = this._skip_triple_quote_gap(index, this._end, acceptComments);
                         } else {
                             s += String.fromCharCode(ch);
                         }
                         break;
-                    }else{
+                    } else{
                         s += String.fromCharCode(ch);
                         break;
                     }

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -1009,11 +1009,11 @@ private _test_symbol_as_annotation() : boolean {
   }
 
     private isHighSurrogate(ch : number) : boolean{
-        return ch > 0xD800 && ch < 0xDBFF;
+        return ch >= 0xD800 && ch <= 0xDBFF;
     }
 
     private isLowSurrogate(ch : number) : boolean{
-        return ch > 0xDC00 && ch < 0xDFFF;
+        return ch >= 0xDC00 && ch <= 0xDFFF;
     }
 
     get_value_as_string(t: number) : string {

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -63,7 +63,7 @@ export abstract class Span {
 }
 
 export class StringSpan extends Span {
-  _src : string;
+  private _src : string;
   private _pos : number;
   private _start : number;
   private _limit : number;
@@ -85,6 +85,10 @@ export class StringSpan extends Span {
     this._start = this._pos;
     this._line_start = this._pos;
     this._old_line_start = 0;
+  }
+
+  viewSource() : string {
+      return this._src;
   }
 
   position() : number {

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -63,7 +63,7 @@ export abstract class Span {
 }
 
 export class StringSpan extends Span {
-  private _src : string;
+  _src : string;
   private _pos : number;
   private _start : number;
   private _limit : number;

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -164,6 +164,10 @@ export class StringSpan extends Span {
     return this._src.charCodeAt(ii);
   }
 
+  getCodePoint(index : number) : number {
+      return this._src.codePointAt(index);
+  }
+
   line_number() : number {
     return this._line;
   }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -31,7 +31,7 @@ import { LocalSymbolTable } from "./IonLocalSymbolTable";
 import { makeSymbolTable } from "./IonSymbols";
 import { ParserTextRaw } from "./IonParserTextRaw";
 import { Reader } from "./IonReader";
-import { Span } from "./IonSpan";
+import { StringSpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
@@ -50,7 +50,7 @@ export class TextReader implements Reader {
   private _raw_type: number;
   private _raw: any;
 
-  constructor(source: Span, catalog: Catalog) {
+  constructor(source: StringSpan, catalog: Catalog) {
     if (!source) {
       throw new Error("a source Span is required to make a reader");
     }

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -14,10 +14,6 @@
 define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path', 'dist/amd/es6/IonTests'],
     function(intern, registerSuite, fs, paths, ion) {
 
-        async function readFiles(accumulator){
-
-        }
-
         function findFiles(folder, accumulator) {
             let files = fs.readdirSync(folder);
             while (files.length > 0) {
@@ -33,7 +29,6 @@ define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path
             for(let i = 0; i < accumulator.length; i++){
                 tempstr = fs.readFileSync(accumulator[i]);
             }
-            readFiles(accumulator);
         }
 
         let cwd = process.cwd();

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -65,8 +65,6 @@ define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path
             'good/symbolExplicitZero.10n',
             'good/symbolImplicitZero.10n',
             'good/testfile28.10n',
-            'good/equivs/utf8/stringU0001D11E.ion', //outside of javascripts supported range 0xffff
-            'good/equivs/utf8/stringUtf8.ion', //outside of javascripts supported range 0xffff
             'good/utf32.ion', //js is unable to handle values outside of usc2
             'good/utf16.ion', //js is unable to handle values outside of usc2
             'good/subfieldVarInt.ion', //IVM bug

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -14,6 +14,10 @@
 define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path', 'dist/amd/es6/IonTests'],
     function(intern, registerSuite, fs, paths, ion) {
 
+        async function readFiles(accumulator){
+
+        }
+
         function findFiles(folder, accumulator) {
             let files = fs.readdirSync(folder);
             while (files.length > 0) {
@@ -26,6 +30,10 @@ define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path
                     accumulator.push(path);
                 }
             }
+            for(let i = 0; i < accumulator.length; i++){
+                tempstr = fs.readFileSync(accumulator[i]);
+            }
+            readFiles(accumulator);
         }
 
         let cwd = process.cwd();


### PR DESCRIPTION
I added utf16 codepoint conversion logic when calling get_value_as_string() thanks to Allman's input.
Tried to refactor the logic but ended up leaving it kinda ugly for now until i do a larger refactor on lexing/parsing as the changes were getting widespread (fixing hex/underscore ints, changing the way the lexer/parser maintains state, splitting them apart).