### PR TITLE
fix(IonTextReader): Fix a bug which prevented skip_past_container() to function correctly

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -78,7 +78,7 @@ export class TextReader implements Reader {
         p = this._parser;
     while (d > 0) {
       type = p.next();
-      if (type === undefined) { // end of container
+      if (type === EOF) { // end of container
         d--;
       }
       else if (type.container) {

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -31,5 +31,6 @@ define({
     'tests/unit/IonLowLevelBinaryWriterTest',
     'tests/unit/IonBinaryWriterTest',
     'tests/unit/IonBinaryTimestampTest',
+    'tests/unit/IonTextReaderTest'
   ],
 });

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+ define(
+  function(require) {
+    const registerSuite = require('intern!object');
+    const assert = require('intern/chai!assert');
+    const ion = require('dist/amd/es6/Ion');
+
+    var suite = {
+      name: 'Text Reader'
+    };
+
+    suite['Read string value'] = function() {
+      var ionToRead = "\"string\"";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next()
+
+      assert.equal(ionReader.value(), "string");
+    };
+
+    suite['Parse through struct'] = function() {
+      var ionToRead = "{ key : \"string\" }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next()
+
+      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+
+      ionReader.stepIn(); // Step into the base struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "key");
+      assert.equal(ionReader.value(), "string");
+    };
+
+    suite['Parse through struct can skip over container'] = function() {
+      var ionToRead = "{ a: { key1 : \"string1\" }, b: { key2 : \"string2\" } }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+
+      ionReader.stepIn(); // Step into the base struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "a");
+
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "b");
+
+      ionReader.stepIn(); // Step into the "b" struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "key2");
+      assert.equal(ionReader.value(), "string2");
+    };
+
+    registerSuite(suite);
+  }
+);


### PR DESCRIPTION
The skip_past_container() method was previously looping until an undefined value was found. This was
incorrectly causing the method to return undefined, which would break the reader. When checking for
EOF, it can correctly identify the end of a container.