### PR TITLE
fix(IonTextReader): Fix a bug which prevented skip_past_container() t…

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -73,16 +73,15 @@ export class TextReader implements Reader {
   }
 
   skip_past_container() {
-    var type, 
-        d = 1,  // we want to have read the EOC tha matches the container we just saw
-        p = this._parser;
-    while (d > 0) {
-      type = p.next();
+    let type;
+    let d = this.depth();  // we want to have read the EOC that matches the container we just saw
+    this.stepIn();
+    while (this.depth() > d) {
+      type = this.next();
       if (type === undefined) { // end of container
-        d--;
-      }
-      else if (type.container) {
-        d++;
+          this.stepOut();
+      } else if (type.container && !this.isNull()) {
+          this.stepIn();
       }
     }
   }

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -31,5 +31,6 @@ define({
     'tests/unit/IonLowLevelBinaryWriterTest',
     'tests/unit/IonBinaryWriterTest',
     'tests/unit/IonBinaryTimestampTest',
+    'tests/unit/IonTextReaderTest',
   ],
 });

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+ define(
+  function(require) {
+    const registerSuite = require('intern!object');
+    const assert = require('intern/chai!assert');
+    const ion = require('dist/amd/es6/Ion');
+
+    var suite = {
+      name: 'Text Reader'
+    };
+
+    suite['Read string value'] = function() {
+      var ionToRead = "\"string\"";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ionReader.value(), "string");
+    };
+
+    suite['Read boolean value'] = function() {
+      var ionToRead = "true";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ionReader.value(), true);
+    };
+
+    suite['Read boolean value in struct'] = function() {
+      var ionToRead = "{ a: false }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+      ionReader.stepIn();
+      ionReader.next();
+
+      assert.equal(ionReader.value(), false);
+    };
+
+    suite['Parse through struct'] = function() {
+      var ionToRead = "{ key : \"string\" }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+
+      ionReader.stepIn(); // Step into the base struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "key");
+      assert.equal(ionReader.value(), "string");
+    };
+
+    suite['Parse through struct can skip over container'] = function() {
+      var ionToRead = "{ a: { key1 : \"string1\" }, b: { key2 : \"string2\" } }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+
+      ionReader.stepIn(); // Step into the base struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "a");
+
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "b");
+
+      ionReader.stepIn(); // Step into the "b" struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "key2");
+      assert.equal(ionReader.value(), "string2");
+    };
+
+    suite['Parse through struct can skip over nested containers'] = function() {
+      var ionToRead = "{ outerkey1 : { innerkey1 : {a1: \"a1\", b1: \"b1\"} }, outerkey2 : { innerkey2 : {a2: \"a2\", b2: \"b2\"} } }";
+      var ionReader = ion.makeReader(ionToRead);
+      ionReader.next();
+
+      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+
+      ionReader.stepIn(); // Step into the base struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "outerkey1");
+
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "outerkey2");
+
+      ionReader.stepIn(); // Step into the "b" struct.
+      ionReader.next();
+
+      assert.equal(ionReader.fieldName(), "innerkey2");
+    };
+
+    registerSuite(suite);
+  }
+);


### PR DESCRIPTION
…o function correctly

The skip_past_container() method was previously looping until an
undefined value was found. This was
incorrectly causing the method to return undefined, which would break
the reader. When checking for
EOF, it can correctly identify the end of a container.

fix #140