### PR TITLE
Symbol table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ is unsupported at this time.
 | bool      | yes      | no      |   none |
 | int | yes      | no      |    underscores, binaryints, bigints |
 | float | yes      | no      |    underscores |
-| decimal | yes      | no      |    none |
-| timestamp | yes      | no      |    offsets/max values non spec-compliant |
-| string | yes      | no      |    values outside of ucs2, whitespace escapes between triplequotes |
+| decimal | yes      | no      |    large fractions are slow roundtrip |
+| timestamp | yes      | no      |    fractional seconds are slow on large fractions |
+| string | yes      | no      |    none |
 | symbol | yes      | no      |    sid0, no symboltokens |
 | blob | no      | no      |    broken |
 | clob | yes      | no      |    backed by string |
@@ -53,8 +53,8 @@ is unsupported at this time.
 | list | yes      | no      |    none |
 | sexp | yes      | no      |    none |
 | annotations | yes      | no      |    none |
-| local symbol tables | no      | no      |    IVM corrupts the parser |
-| shared symbol tables | no      | no      |    not implemented |
+| local symbol tables | yes      | no      |    none |
+| shared symbol tables | yes      | no      |    none |
 
 | Github Issues |
 |:-------------|

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^2.3.0",
-    "grunt-ts": "^6.0.0-beta.3",
+    "grunt-ts": "^6.0.0-beta.19",
     "grunt-typedoc": "^0.2.4",
     "intern": "^3.4.1",
     "remap-istanbul": "^0.9.1",
     "semantic-release": "^6.3.6",
-    "typedoc": "^0.6.0",
-    "typescript": "^2.3.2"
+    "typedoc": "^0.11.1",
+    "typescript": "^2.9.2"
   }
 }

--- a/src/IonImport.ts
+++ b/src/IonImport.ts
@@ -28,58 +28,57 @@ import { SymbolIndex } from "./IonSymbolIndex";
  * @see http://amzn.github.io/ion-docs/symbols.html#imports
  */
 export class Import {
-  private readonly _offset: number;
-  private readonly _length: number;
-  private readonly index: SymbolIndex = {};
+    private readonly _offset: number;
+    private readonly _length: number;
+    private readonly index: SymbolIndex = {};
+    private readonly _parent : Import;
+    private readonly _symbolTable : SharedSymbolTable;
 
-  constructor(
-    private readonly _parent: Import,
-    private readonly _symbolTable: SharedSymbolTable,
-    length?: number
-  ) {
-    this._offset = (_parent && (_parent.offset + _parent.length)) || 1;
-    this._length = length || _symbolTable.symbols.length;
+    constructor(parent : Import, symbolTable : SharedSymbolTable, length?: number) {
+        this._parent = parent;
+        this._symbolTable = symbolTable;
+        this._offset = this.parent ? this.parent.offset + this.parent.length : 1;//this is wrong.
+        this._length = length || this.symbolTable.symbols.length;
 
-    let symbols: string[] = _symbolTable.symbols;
-    for (let i: number = 0; i < this._length; i++) {
-      this.index[symbols[i]] = this._offset + i;
-    }
-  }
-
-  getSymbol(symbolId: number) : string {
-    if (!isNullOrUndefined(this.parent)) {
-      let parentSymbol = this.parent.getSymbol(symbolId);
-      if (!isUndefined(parentSymbol)) {
-        return parentSymbol;
-      }
+        let symbols: string[] = this.symbolTable.symbols;
+        for (let i: number = 0; i < this.length; i++) {
+            this.index[symbols[i]] = this.offset + i;
+        }
     }
 
-    let index: number = symbolId - this.offset;
-    if (index < this.length) {
-      return this.symbolTable.symbols[index];
+    getSymbol(symbolId: number) : string {
+        if (!isNullOrUndefined(this.parent)) {
+            let parentSymbol = this.parent.getSymbol(symbolId);
+            if (!isUndefined(parentSymbol)) {
+                return parentSymbol;
+            }
+        }
+
+        let index: number = symbolId - this.offset;
+        if (index < this.length) {
+            return this.symbolTable.symbols[index];
+        }
+
+        return undefined;
     }
 
-    return undefined;
-  }
+    getSymbolId(symbol_: string) : number {
+        return (this.parent && this._parent.getSymbolId(symbol_)) || this.index[symbol_];
+    }
 
-  getSymbolId(symbol_: string) : number {
-    return (this.parent && this.parent.getSymbolId(symbol_))
-      || this.index[symbol_];
-  }
+    get parent() : Import {
+        return this._parent;
+    }
 
-  get parent() : Import {
-    return this._parent;
-  }
+    get offset() : number {
+        return this._offset;
+    }
 
-  get offset() : number {
-    return this._offset;
-  }
+    get length() : number {
+        return this._length;
+    }
 
-  get length() : number {
-    return this._length;
-  }
-
-  get symbolTable() : SharedSymbolTable {
-    return this._symbolTable;
-  }
+    get symbolTable() : SharedSymbolTable {
+        return this._symbolTable;
+    }
 }

--- a/src/IonImport.ts
+++ b/src/IonImport.ts
@@ -37,7 +37,7 @@ export class Import {
     constructor(parent : Import, symbolTable : SharedSymbolTable, length?: number) {
         this._parent = parent;
         this._symbolTable = symbolTable;
-        this._offset = this.parent ? this.parent.offset + this.parent.length : 1;//this is wrong.
+        this._offset = this.parent ? this.parent.offset + this.parent.length : 1;
         this._length = length || this.symbolTable.symbols.length;
 
         let symbols: string[] = this.symbolTable.symbols;

--- a/src/IonLocalSymbolTable.ts
+++ b/src/IonLocalSymbolTable.ts
@@ -37,8 +37,7 @@ export class LocalSymbolTable  {
   }
 
   getSymbolId(symbol_: string) : number {
-    return this._import.getSymbolId(symbol_)
-      || this.index[symbol_];
+    return this._import.getSymbolId(symbol_) || this.index[symbol_];
   }
 
   addSymbol(symbol_: string) : number {
@@ -53,22 +52,27 @@ export class LocalSymbolTable  {
     return symbolId;
   }
 
-  getSymbol(symbolId: number): string {
-    let importedSymbol: string = this._import.getSymbol(symbolId);
-    if (!isUndefined(importedSymbol)) {
-      return importedSymbol;
-    }
+    getSymbol(symbolId: number): string {
+        if(symbolId > this.maxId) throw new Error("SymbolID greater than maxID.");
+        let importedSymbol: string = this.import.getSymbol(symbolId);
+        if (!isUndefined(importedSymbol)) {
+            return importedSymbol;
+        }
 
-    let index = symbolId - this.offset;
-    if (index < this.symbols.length) {
-      return this.symbols[index];
-    }
+        let index = symbolId - this.offset;
+        if (index < this.symbols.length) {
+            return this.symbols[index];
+        }
 
-    return undefined;
-  }
+        return undefined;
+    }
 
   get symbols() : string[] {
     return this._symbols;
+  }
+
+  get maxId() : number {
+      return this.offset + this._symbols.length - 1;
   }
 
   get import() : Import {

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -539,7 +539,7 @@ const MAX_BYTES_FOR_INT_IN_NUMBER = 6; // = floor(52 /* sig fig bits in number *
 const ZERO_POINT_ZERO = new Float64Array([0.0]);
 
 export class ParserBinaryRaw {
-  private buf = new ArrayBuffer(8);                   // TODO - what about threading? no.
+  private buf = new ArrayBuffer(8);
   private buf_as_bytes = new Uint8Array(this.buf);    //        we could new them locally in normal_float_to_bytes
   private buf_as_double = new Float64Array(this.buf); //        but that seems wasteful. ... hmmm
 

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -539,7 +539,7 @@ const MAX_BYTES_FOR_INT_IN_NUMBER = 6; // = floor(52 /* sig fig bits in number *
 const ZERO_POINT_ZERO = new Float64Array([0.0]);
 
 export class ParserBinaryRaw {
-  private buf = new ArrayBuffer(8);                   // TODO - what about threading?
+  private buf = new ArrayBuffer(8);                   // TODO - what about threading? no.
   private buf_as_bytes = new Uint8Array(this.buf);    //        we could new them locally in normal_float_to_bytes
   private buf_as_double = new Float64Array(this.buf); //        but that seems wasteful. ... hmmm
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -192,31 +192,29 @@ next() {
     return this._parser.isNull();
   }
 
-  stringValue() : string {
-    var i, s, t = this;
-    this.load_raw();
-    if (t.isNull()) {
-      s = "null";
-      if (t._type != IonTypes.NULL) {
-        s += "." + t._type.name;
-      }
+    stringValue() : string {
+        this.load_raw();
+        if (this.isNull()) return (this._type === IonTypes.NULL) ? "null" : "null." + this._type.name;
+        if (this._type.scalar) {
+            // BLOB is a scalar by you don't want to just use the string
+            // value otherwise all other scalars are fine as is
+            switch(this._type) {
+                case IonTypes.BLOB:
+                    throw new Error("Blobs currently unsupported.");
+                case IonTypes.SYMBOL:
+                    if(this._raw_type === T_IDENTIFIER && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))){
+                        let tempStr = this._raw.substr(1, this._raw.length);
+                        if (+tempStr === +tempStr) return this._symtab.getSymbol(Number(tempStr));//look up sid, +str === +str is a one line is integer hack
+                    } else if (this._raw_type === T_STRING1 && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))) {
+                        let tempStr = this._raw.substr(1, this._raw.length);
+                        if (+tempStr === +tempStr) return "'" + this._raw + "'";
+                    }
+                    return this._raw;
+                default:
+                    return this._raw;
+            }
+        }
     }
-    else if (t._type.scalar) {
-      // BLOB is a scalar by you don't want to just use the string 
-      // value otherwise all other scalars are fine as is
-      if (t._type !== IonTypes.BLOB) {
-        s = t._raw;
-      }
-      else {
-        s = t._raw;   // TODO - this is a temp fix !!
-      }
-    }
-    else {
-      i = t.ionValue();
-      s = i.stringValue();
-    }
-    return s;
-  }
 
   numberValue() {
     if (!this._type.num) {

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -204,15 +204,17 @@ next() {
                 case IonTypes.SYMBOL:
                     if(this._raw_type === T_IDENTIFIER && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))){
                         let tempStr = this._raw.substr(1, this._raw.length);
-                        if (+tempStr === +tempStr) return this._symtab.getSymbol(Number(tempStr));//look up sid, +str === +str is a one line is integer hack
-                    } else if (this._raw_type === T_STRING1 && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))) {
-                        let tempStr = this._raw.substr(1, this._raw.length);
-                        if (+tempStr === +tempStr) return "'" + this._raw + "'";
+                        if (+tempStr === +tempStr) {//look up sid, +str === +str is a one line is integer hack
+                            let symbol = this._symtab.getSymbol(Number(tempStr));
+                            if(symbol === undefined) throw new Error("Unresolveable symbol ID, symboltokens unsupported.");
+                        }
                     }
                     return this._raw;
                 default:
                     return this._raw;
             }
+        } else {
+            throw new Error("Cannot create string representation of non-scalar values.");
         }
     }
 

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -381,7 +381,18 @@ export class TextWriter implements Writer {
 
     private writeSymbolToken(s: string) : void {
         if (isIdentifier(s)) {
-            this.writeUtf8(s);
+            if(s.length > 1 && s.charAt(0) === '$'.charAt(0)){
+                let tempStr = s.substr(1, s.length);
+                if (+tempStr === +tempStr) {//+str === +str is a one line is integer hack
+                    this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
+                    this.writeable.writeStream(escape(s, SymbolEscapes));
+                    this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
+                } else {
+                    this.writeUtf8(s);
+                }
+            } else {
+                this.writeUtf8(s);
+            }
         } else if ((!this.isTopLevel) && (this.currentContainer.containerType === TypeCodes.SEXP) && isOperator(s)) {
             this.writeUtf8(s);
         } else {

--- a/tests/unit/IonLocalSymbolTableTest.js
+++ b/tests/unit/IonLocalSymbolTableTest.js
@@ -47,6 +47,7 @@ define([
       assertSystemSymbols(symbolTable);
       try {
         symbolTable.getSymbol(10);
+        throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
       }

--- a/tests/unit/IonLocalSymbolTableTest.js
+++ b/tests/unit/IonLocalSymbolTableTest.js
@@ -45,7 +45,11 @@ define([
     suite['Imports system symbol table by default'] = function() {
       var symbolTable = ion.defaultLocalSymbolTable();
       assertSystemSymbols(symbolTable);
-      assert.isUndefined(symbolTable.getSymbol(10));
+      try {
+        symbolTable.getSymbol(10);
+      } catch(e) {
+          if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
+      }
     }
 
     suite['Imports are added in order'] = function() {
@@ -57,7 +61,13 @@ define([
       var symbolTable = new ion.LocalSymbolTable(import2);
 
       assert.isDefined(symbolTable.getSymbol(13));
-      assert.isUndefined(symbolTable.getSymbol(14));
+      try{
+          symbolTable.getSymbol(14);
+          throw new Error("Expected Error.")
+      } catch(e) {
+          if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
+      }
+
 
       assertSystemSymbols(symbolTable);
       assert.equal(symbolTable.getSymbolId('a'), 10);
@@ -81,7 +91,12 @@ define([
       assert.equal(symbolTable.getSymbolId('d'), 13);
       assert.equal(symbolTable.getSymbolId('e'), 14);
       assert.equal(symbolTable.getSymbolId('f'), 15);
-      assert.isUndefined(symbolTable.getSymbol(16));
+      try{
+          symbolTable.getSymbol(16);
+          throw new Error("Expected Error.")
+      } catch(e) {
+          if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
+      }
     }
 
     suite['Maxid less than symbol table length restricts imports'] = function() {
@@ -93,7 +108,12 @@ define([
       var symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
       assert.isDefined(symbolTable.getSymbol(13));
-      assert.isUndefined(symbolTable.getSymbol(14));
+      try{
+          symbolTable.getSymbol(14);
+          throw new Error("Expected Error.")
+      } catch(e) {
+          if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
+      }
 
       assertSystemSymbols(symbolTable);
       assert.equal(symbolTable.getSymbolId('a'), 10);
@@ -113,7 +133,13 @@ define([
       var symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
       assert.isDefined(symbolTable.getSymbol(17));
-      assert.isUndefined(symbolTable.getSymbol(18));
+      try {
+          symbolTable.getSymbol(18);
+          throw new Error("Expected Error.")
+      } catch(e) {
+          if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
+      }
+
 
       assertSystemSymbols(symbolTable);
       assert.equal(symbolTable.getSymbolId('a'), 10);

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -57,14 +57,13 @@ define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path
             'good/blobs.ion', //blobs unsupported.
             'good/testfile29.ion', //blobs unsupported.
             'good/testfile26.ion', //blobs unsupported.
-            'good/subfieldVarUInt32bit.ion', //passes, but takes too long to run every build due to longint rounding.
-            'good/subfieldVarUInt.ion', //passes, but takes too long to run every build due to longint rounding.
+            'good/subfieldVarUInt32bit.ion', //passes, but takes too long to run every build.
+            'good/subfieldVarUInt.ion', //passes, but takes too long to run every build.
             'good/floatsWithUnderscores.ion', //numbers with underscores unsupported.
             'good/equivs/floatsWithUnderscores.ion', //numbers with underscores unsupported.
             'good/equivs/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
             'good/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
             'good/equivs/bigInts.ion', //numbers unsupported by js's int or float are unsupported.
-            //'good/equivs/strings.ion', //triplequote interaction with span and whitespace corrupts the state of the parser.
             'good/intBigSize512.ion', //int maxsize limitation.
             'good/symbolZero.ion', //no symboltoken support as of yet.
         ];

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -42,30 +42,31 @@ define(['intern', 'intern!object', 'intern/dojo/node!fs', 'intern/dojo/node!path
 
         let skipList = [
             'good/non-equivs/blobs.ion',
-            'good/utf32.ion', //testing not configured to decode raw utf32
-            'good/utf16.ion', //testing not configured to decode raw utf16
+            'good/utf32.ion', //testing not configured to decode raw utf32.
+            'good/utf16.ion', //testing not configured to decode raw utf16.
             'good/subfieldVarInt.ion', //passes, but takes too long to run every build due to longint rounding.
-            'good/nonNulls.ion', //blobs bug
-            'good/non-equivs/nonNulls.ion', //blobs bug
-            'good/lists.ion', //blobs bug
-            'good/intBinary.ion', //binaryInts unsupported
-            'good/intsWithUnderscores.ion', //binary ints unsupported
-            'good/intBigSize256.ion', //int maxsize limitation
-            'good/equivs/intsWithUnderscores.ion', //binary ints unsupported
-            'good/equivs/blobs.ion', //blobs unsupported
-            'good/equivs/binaryInts.ion', //binary ints unsupported
-            'good/blobs.ion', //blobs unsupported
-            'good/testfile29.ion', //blobs unsupported
-            'good/testfile26.ion', //blobs unsupported
+            'good/nonNulls.ion', //blobs bug.
+            'good/non-equivs/nonNulls.ion', //blobs bug.
+            'good/lists.ion', //blobs bug.
+            'good/intBinary.ion', //binaryInts unsupported.
+            'good/intsWithUnderscores.ion', //binary ints unsupported.
+            'good/intBigSize256.ion', //int maxsize limitation.
+            'good/equivs/intsWithUnderscores.ion', //binary ints unsupported.
+            'good/equivs/blobs.ion', //blobs unsupported.
+            'good/equivs/binaryInts.ion', //binary ints unsupported.
+            'good/blobs.ion', //blobs unsupported.
+            'good/testfile29.ion', //blobs unsupported.
+            'good/testfile26.ion', //blobs unsupported.
             'good/subfieldVarUInt32bit.ion', //passes, but takes too long to run every build due to longint rounding.
             'good/subfieldVarUInt.ion', //passes, but takes too long to run every build due to longint rounding.
-            'good/floatsWithUnderscores.ion', //numbers with underscores unsupported
-            'good/equivs/floatsWithUnderscores.ion', //numbers with underscores unsupported
-            'good/equivs/decimalsWithUnderscores.ion', //numbers with underscores unsupported
-            'good/decimalsWithUnderscores.ion', //numbers with underscores unsupported
-            'good/equivs/bigInts.ion', //numbers unsupported by js's int or float are unsupported
-            'good/equivs/strings.ion', //triplequote interaction with span and whitespace corrupts the state of the parser.
-            'good/intBigSize512.ion', //int maxsize limitation
+            'good/floatsWithUnderscores.ion', //numbers with underscores unsupported.
+            'good/equivs/floatsWithUnderscores.ion', //numbers with underscores unsupported.
+            'good/equivs/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
+            'good/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
+            'good/equivs/bigInts.ion', //numbers unsupported by js's int or float are unsupported.
+            //'good/equivs/strings.ion', //triplequote interaction with span and whitespace corrupts the state of the parser.
+            'good/intBigSize512.ion', //int maxsize limitation.
+            'good/symbolZero.ion', //no symboltoken support as of yet.
         ];
 
         // For debugging, put single files in this list to have the test run only


### PR DESCRIPTION
After fixing IVM issues these commits handle some basic bugs around symbolID lookups and triple quote character escape sequences / illegal control characters. Also updated the readme to reflect the new levels of support.
Probably could be split into two PRs I can force push the head back 2 commits if you deem it necessary.