### PR TITLE
Blob support, utf8 support, amortized write cost support, binary writ…

### DIFF
--- a/src/IonLowLevelBinaryWriter.ts
+++ b/src/IonLowLevelBinaryWriter.ts
@@ -11,8 +11,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { isNumber } from "./IonUtilities";
-import { isUndefined } from "./IonUtilities";
 import { Writeable } from "./IonWriteable";
 
 /**
@@ -22,131 +20,106 @@ import { Writeable } from "./IonWriteable";
  */
 export class LowLevelBinaryWriter {
   private readonly writeable: Writeable;
-  private numberBuffer: number[] = new Array(10);
 
-  constructor(writeableOrLength: Writeable | number) {
-    if (isNumber(writeableOrLength)) {
-      this.writeable = new Writeable();
-    } else {
-      this.writeable = <Writeable>writeableOrLength;
-    }
-  }
-
-  writeSignedInt(originalValue: number, length: number) : void {
-    if (length > this.numberBuffer.length) {
-      this.numberBuffer = new Array(length);
+  constructor(writeable : Writeable) {
+        this.writeable = writeable;
     }
 
+
+  writeSignedInt(originalValue: number) : void {//TODO this should flip to different modes based on the length calculation because bit shifting will drop to 32 bits.
+    let length = LowLevelBinaryWriter.getSignedIntSize(originalValue);
     let value: number = Math.abs(originalValue);
-
+    let tempBuf = new Uint8Array(length);
     // Trailing bytes
-    let i: number = this.numberBuffer.length;
+    let i: number = tempBuf.length;
     while (value >= 128) {
-      this.numberBuffer[--i] = value & 0xFF;
+      tempBuf[--i] = value & 0xFF;
       value >>>= 8;
     }
 
-    this.numberBuffer[--i] = value;
-
-    // Padding
-    let bytesWritten: number = this.numberBuffer.length - i;
-    for (let j: number = 0; j < length - bytesWritten; j++) {
-      this.numberBuffer[--i] = 0;
-    }
-
-    if (bytesWritten > length) {
-      throw new Error(`Value ${value} cannot fit into ${length} bytes`);
-    }
+    tempBuf[--i] = value & 0xFF;
 
     // Sign bit
-    if (originalValue < 0) {
-      this.numberBuffer[i] |= 0x80;
-    }
+    if (1/originalValue < 0) tempBuf[0] |= 0x80;
 
-    this.writeable.writeBytes(this.numberBuffer, i);
+    this.writeable.writeBytes(tempBuf);
   }
 
-  writeUnsignedInt(originalValue: number, length?: number) : void {
-    if (isUndefined(length)) {
-      length = LowLevelBinaryWriter.getUnsignedIntSize(originalValue)
-    }
-    if (length > this.numberBuffer.length) {
-      this.numberBuffer = new Array(length);
-    }
+  writeUnsignedInt(originalValue: number) : void {
+    let length = LowLevelBinaryWriter.getUnsignedIntSize(originalValue);
+    let tempBuf = new Uint8Array(length);
+
 
     let value: number = originalValue;
-    let i: number = this.numberBuffer.length;
+    let i: number = tempBuf.length;
 
     while (value > 0) {
-      this.numberBuffer[--i] = value & 0xFF;
+      tempBuf[--i] = value;
       value >>>= 8;
     }
 
-    // Padding
-    let bytesWritten: number = this.numberBuffer.length - i;
-    for (let j: number = 0; j < length - bytesWritten; j++) {
-      this.numberBuffer[--i] = 0;
-    }
-
-    if (bytesWritten > length) {
-      throw new Error(`Value ${value} cannot fit into ${length} bytes`);
-    }
-
-    this.writeable.writeBytes(this.numberBuffer, i);
+    this.writeable.writeBytes(tempBuf);
   }
 
   writeVariableLengthSignedInt(originalValue: number) : void {
-    if (!Number['isInteger'](originalValue)) {
-      throw new Error(`Cannot call writeVariableLengthSignedInt with non-integer value ${originalValue}`);
-    }
-
+    let tempBuf = new Uint8Array(LowLevelBinaryWriter.getVariableLengthSignedIntSize(originalValue));
     let value: number = Math.abs(originalValue);
-    let i: number = this.numberBuffer.length - 1;
+    let i = tempBuf.length - 1;
 
     while (value >= 64) {
-      this.numberBuffer[i--] = value & 0x7F;
+      tempBuf[i--] = value & 0x7F;
       value >>>= 7;
     }
 
     // Leading byte
-    this.numberBuffer[i] = value;
+    tempBuf[i] = value;
 
     // Sign bit
-    if (originalValue < 0) {
-      this.numberBuffer[i] |= 0x40;
+    if (1/originalValue < 0) {
+      tempBuf[i] |= 0x40;
     }
 
     // Stop bit
-    this.numberBuffer[this.numberBuffer.length - 1] |= 0x80;
+    tempBuf[tempBuf.length - 1] |= 0x80;
 
-    this.writeable.writeBytes(this.numberBuffer, i, this.numberBuffer.length - i);
+    this.writeable.writeBytes(tempBuf);
   }
 
   writeVariableLengthUnsignedInt(originalValue: number) : void {
+    let tempBuf = new Uint8Array(LowLevelBinaryWriter.getVariableLengthUnsignedIntSize(originalValue));
     let value: number = originalValue;
-    let i: number = this.numberBuffer.length;
+    let i = tempBuf.length;
 
-    this.numberBuffer[--i] = (value & 0x7F) | 0x80;
+    tempBuf[--i] = (value & 0x7F) | 0x80;
     value >>>= 7;
 
     while (value > 0) {
-      this.numberBuffer[--i] = value & 0x7F
+     tempBuf[--i] = value & 0x7F
       value >>>= 7;
     }
 
-    this.writeable.writeBytes(this.numberBuffer, i);
+    this.writeable.writeBytes(tempBuf);
   }
 
   writeByte(byte: number) : void {
     this.writeable.writeByte(byte);
   }
 
-  writeBytes(bytes: number[]) : void {
+  writeBytes(bytes: Uint8Array) : void {
     this.writeable.writeBytes(bytes);
   }
 
-  getBytes(): number[] {
+  getBytes(): Uint8Array {
     return this.writeable.getBytes();
+  }
+
+  static getSignedIntSize(value : number) : number {
+      if (value === 0) return 1;
+      let absValue = Math.abs(value);
+      let numberOfBits = Math.floor(Math['log2'](absValue));
+      let numberOfBytes = Math.ceil(numberOfBits / 8);
+      if(numberOfBits % 8 === 0) numberOfBytes++;
+      return numberOfBytes;
   }
 
   static getUnsignedIntSize(value: number) : number {

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -33,7 +33,8 @@ import { ParserTextRaw } from "./IonParserTextRaw";
 import { Reader } from "./IonReader";
 import { StringSpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
-import {is_digit} from "./IonText";
+import { fromBase64 } from "./IonText";
+import { is_digit } from "./IonText";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
 
@@ -52,7 +53,7 @@ export class TextReader implements Reader {
   private _raw_type: number;
   private _raw: any;
 
-  constructor(source: StringSpan, catalog: Catalog) {
+  constructor(source: StringSpan, catalog?: Catalog) {
     if (!source) {
       throw new Error("a source Span is required to make a reader");
     }
@@ -197,7 +198,7 @@ next() {
             // value otherwise all other scalars are fine as is
             switch(this._type) {
                 case IonTypes.BLOB:
-                    throw new Error("Blobs currently unsupported.");
+                    return this._raw;
                 case IonTypes.SYMBOL:
                     if(this._raw_type === T_IDENTIFIER && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))){
                         let tempStr = this._raw.substr(1, this._raw.length);
@@ -222,8 +223,24 @@ next() {
     return this._parser.numberValue();
   }
 
-  byteValue() : number[] {
-    throw new Error("E_NOT_IMPL: byteValue");
+  byteValue() : Uint8Array {
+    this.load_raw();
+    if(this.isNull()) return null;
+    switch(this._type){
+        case IonTypes.CLOB : {
+            let length = this._raw.length;
+            let data = new Uint8Array(length);
+            for(let i = 0; i < this._raw.length; i++){
+                data[i] = this._raw.charCodeAt(i);
+            }
+            return data;
+        }
+        case IonTypes.BLOB : {
+            return fromBase64(this._raw);
+        }
+        default:
+            throw new Error(this._type.name + ".byteValue() is not supported.");
+    }
   }
 
   booleanValue() {
@@ -234,15 +251,19 @@ next() {
   }
 
     decimalValue() : Decimal {
+        if(this.isNull()) return null;
         return Decimal.parse(this.stringValue());
     }
 
     timestampValue() : Timestamp {
+        if(this.isNull()) return null;
         return Timestamp.parse(this.stringValue());
     }
 
     value() {
         switch(this._type) {
+            case IonTypes.NULL :
+                return null;
             case IonTypes.BOOL : {
                 return this.booleanValue();
             }
@@ -265,10 +286,10 @@ next() {
                 return this.timestampValue();
             }
             case IonTypes.CLOB : {
-                return this.stringValue();
+                return this.byteValue();
             }
             case IonTypes.BLOB : {
-                return this.stringValue();
+                return this.byteValue();
             }
             default : {
                 return undefined;

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -11,21 +11,10 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 * language governing permissions and limitations under the License.
 */
-import { CharCodes } from "./IonText";
-import { ClobEscapes } from "./IonText";
 import { Decimal } from "./IonDecimal";
 import { encodeUtf8 } from "./IonUnicode";
-import { encodeUtf8Stream } from "./IonUnicode";
-import { escape } from "./IonText";
-import { isIdentifier } from "./IonText";
-import { isNullOrUndefined } from "./IonUtilities";
-import { isOperator } from "./IonText";
-import { isUndefined } from "./IonUtilities";
-import { last } from "./IonUtilities";
-import { StringEscapes } from "./IonText";
-import { SymbolEscapes } from "./IonText";
+import { escape, toBase64, StringEscapes, SymbolEscapes, isIdentifier, isOperator, CharCodes, ClobEscapes } from "./IonText";
 import { Timestamp } from "./IonTimestamp";
-import { toBase64 } from "./IonText";
 import { TypeCodes } from "./IonBinary";
 import { Writeable } from "./IonWriteable";
 import { Writer } from "./IonWriter";
@@ -51,7 +40,7 @@ export class Context {
 
 export class TextWriter implements Writer {
     private containerContext : Context[] = [];
-    getBytes(): number[] {
+    getBytes(): Uint8Array {
         return this.writeable.getBytes();
     }
 
@@ -59,11 +48,9 @@ export class TextWriter implements Writer {
         this.containerContext.push(new Context(undefined));
     }
 
-    writeBlob(value: number[], annotations?: string[]) : void {
-        this.writeValue(TypeCodes.BLOB, value, annotations, (value: number[]) => {
-            this.writeUtf8('{{');
-            this.writeable.writeBytes(encodeUtf8(toBase64(value)));
-            this.writeUtf8('}}');
+    writeBlob(value: Uint8Array, annotations?: string[]) : void {
+        this.writeValue(TypeCodes.BLOB, value, annotations, (value: Uint8Array) => {
+            this.writeable.writeBytes(encodeUtf8('{{' + toBase64(value) + '}}'));
         });
     }
 
@@ -73,11 +60,10 @@ export class TextWriter implements Writer {
         });
     }
 
-    writeClob(value: number[], annotations?: string[]) : void {
-        this.writeValue(TypeCodes.CLOB, value, annotations, (value: number[]) => {
+    writeClob(value: Uint8Array, annotations?: string[]) : void {
+        this.writeValue(TypeCodes.CLOB, value, annotations, (value: Uint8Array) => {
             let hexStr : string;
-            this.writeUtf8('{{');
-            this.writeUtf8('"');
+            this.writeUtf8('{{"');
             for (let i : number = 0; i < value.length; i++) {
                 let c : number = value[i];
                 if (c > 127 && c < 256) {
@@ -87,7 +73,7 @@ export class TextWriter implements Writer {
                     }
                 } else {
                     let escape: number[] = ClobEscapes[c];
-                    if (isUndefined(escape)) {
+                    if (escape === undefined) {
                         if(c < 32){
                             hexStr = "\\x" + c.toString(16);
                             for(let j = 0; j < hexStr.length; j++){
@@ -97,12 +83,11 @@ export class TextWriter implements Writer {
                             this.writeable.writeByte(c);
                         }
                     } else {
-                        this.writeable.writeBytes(escape);
+                        this.writeable.writeBytes(new Uint8Array(escape));
                     }
                 }
             }
-            this.writeUtf8('"');
-            this.writeUtf8('}}');
+            this.writeUtf8('"}}');
         });
     }
 
@@ -244,9 +229,7 @@ export class TextWriter implements Writer {
 
     writeString(value: string, annotations?: string[]) : void {
         this.writeValue(TypeCodes.STRING, value, annotations, (value: string) => {
-            this.writeable.writeByte(CharCodes.DOUBLE_QUOTE);
-            this.writeable.writeStream(escape(value, StringEscapes));
-            this.writeable.writeByte(CharCodes.DOUBLE_QUOTE);
+            this.writeable.writeBytes(encodeUtf8('"' + escape(value, StringEscapes) + '"'));
         });
     }
 
@@ -298,7 +281,7 @@ export class TextWriter implements Writer {
 
     private writeValue<T>(typeCode: TypeCodes, value: T, annotations: string[], serialize: Serializer<T>) {
         if (this.currentContainer.state === State.STRUCT_FIELD) throw new Error("Expecting a struct field");
-        if (isNullOrUndefined(value)) {
+        if (value === null || value === undefined) {
             this.writeNull(typeCode, annotations);
             return;
         }
@@ -350,14 +333,11 @@ export class TextWriter implements Writer {
     }
 
     private writeUtf8(s: string) : void {
-        this.writeable.writeBytes(encodeUtf8(s));
+            this.writeable.writeBytes(encodeUtf8(s));
     }
 
     private writeAnnotations(annotations: string[]) : void {
-        if (isNullOrUndefined(annotations)) {
-            return;
-        }
-
+        if (annotations === null || annotations === undefined) return;
         for (let annotation of annotations) {
             this.writeSymbolToken(annotation);
             this.writeUtf8('::');
@@ -385,9 +365,7 @@ export class TextWriter implements Writer {
             if(s.length > 1 && s.charAt(0) === '$'.charAt(0)){
                 let tempStr = s.substr(1, s.length);
                 if (+tempStr === +tempStr) {//+str === +str is a one line is integer hack
-                    this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
-                    this.writeable.writeStream(escape(s, SymbolEscapes));
-                    this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
+                    this.writeable.writeBytes(encodeUtf8("'" + escape(s, SymbolEscapes) + "'"));
                 } else {
                     this.writeUtf8(s);
                 }
@@ -397,9 +375,7 @@ export class TextWriter implements Writer {
         } else if ((!this.isTopLevel) && (this.currentContainer.containerType === TypeCodes.SEXP) && isOperator(s)) {
             this.writeUtf8(s);
         } else {
-            this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
-            this.writeable.writeStream(escape(s, SymbolEscapes));
-            this.writeable.writeByte(CharCodes.SINGLE_QUOTE);
+            this.writeable.writeBytes(encodeUtf8("'" + escape(s, SymbolEscapes) + "'"));
         }
     }
 }

--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -16,93 +16,59 @@
 * @see https://amzn.github.io/ion-docs/stringclob.html
 * @see http://www.unicode.org/versions/Unicode5.0.0/
 */
-import { Writeable } from "./IonWriteable";
-
-const SIX_BIT_MASK: number = 0x3F;
-const TEN_BIT_MASK: number = 0x3FF;
-
-const HIGH_SURROGATE_OFFSET = 0xD800;
-const LOW_SURROGATE_MASK = 0xFC00;
-const LOW_SURROGATE_OFFSET = 0xDC00;
-const LOW_SURROGATE_END = 0xE000;
-
-function isHighSurrogate(charCode: number) : boolean {
-    return charCode >= HIGH_SURROGATE_OFFSET && charCode < LOW_SURROGATE_OFFSET;
-}
-
-export function encodeUtf8(s: string) : number[] {
-    let writeable: Writeable = new Writeable();
-    for (let b of encodeUtf8Stream(charCodes(s))) {
-        writeable.writeByte(b);
-    }
-    return writeable.getBytes();
-}
-
-export function *encodeUtf8Stream(it: IterableIterator<number>)  : IterableIterator<number> {
-    let pushback: number = -1;
-    for(;;) {
-        let codePoint: number;
-        if (pushback !== -1) {
-            codePoint = pushback;
-            pushback = -1;
+export function encodeUtf8(s: string) : Uint8Array {
+    let i = 0, bytes = new Uint8Array(s.length * 4), c;
+    for (let ci = 0; ci < s.length; ci++) {
+        c = s.charCodeAt(ci);
+        if (c < 128) {
+            bytes[i++] = c;
+            continue;
+        }
+        if (c < 2048) {
+            bytes[i++] = c >> 6 | 192;
         } else {
-            let r: IteratorResult<number> = it.next();
-            if (r.done) {
-                return;
-            } else {
-                codePoint = r.value;
-            }
+            if (c > 0xd7ff && c < 0xdc00) {
+                if (++ci >= s.length)
+                    throw new Error('UTF-8 encode: incomplete surrogate pair');
+                let c2 = s.charCodeAt(ci);
+                if (c2 < 0xdc00 || c2 > 0xdfff)
+                    throw new Error('UTF-8 encode: second surrogate character 0x' + c2.toString(16) + ' at index ' + ci + ' out of range');
+                c = 0x10000 + ((c & 0x03ff) << 10) + (c2 & 0x03ff);
+                bytes[i++] = c >> 18 | 240;
+                bytes[i++] = c >> 12 & 63 | 128;
+            } else bytes[i++] = c >> 12 | 224;
+            bytes[i++] = c >> 6 & 63 | 128;
         }
-
-        if (codePoint < 128) { // 7 bits
-            yield codePoint;
-        } else if (codePoint < 2048) { // 11 bits
-            yield 0xC0 | (codePoint >>> 6);
-            yield 0x80 | (codePoint & SIX_BIT_MASK);
-        } else if (codePoint < HIGH_SURROGATE_OFFSET) { // 16 bits, non-surrogate
-            yield 0xE0 | (codePoint >>> 12);
-            yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-            yield 0x80 | (codePoint & SIX_BIT_MASK);
-        } else if (codePoint < LOW_SURROGATE_OFFSET) { // 16 bits, high surrogate
-            let r2: IteratorResult<number> = it.next();
-            if (r2.done) {
-                yield 0xE0 | (codePoint >>> 12);
-                yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-                yield 0x80 | (codePoint & SIX_BIT_MASK);
-                return;
-            }
-
-            let codePoint2: number = r2.value;
-            let hasLowSurrogate: boolean = (codePoint2 & LOW_SURROGATE_MASK) === LOW_SURROGATE_OFFSET;
-            if (hasLowSurrogate) {
-                let highSurrogate: number = codePoint - HIGH_SURROGATE_OFFSET;
-                let lowSurrogate: number = codePoint2 - LOW_SURROGATE_OFFSET;
-                codePoint = 0x10000 + (highSurrogate << 10) | lowSurrogate;
-                yield 0xF0 | (codePoint >>> 18);
-                yield 0x80 | ((codePoint >>> 12) & SIX_BIT_MASK);
-                yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-                yield 0x80 | (codePoint & SIX_BIT_MASK);
-            } else { // Unpaired high surrogate (UCS-2)
-                yield 0xE0 | (codePoint >>> 12);
-                yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-                yield 0x80 | (codePoint & SIX_BIT_MASK);
-                pushback = codePoint2;
-            }
-        } else if (codePoint < 65536) { // 16 bits, non-surrogate
-            yield 0xE0 | (codePoint >>> 12);
-            yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-            yield 0x80 | (codePoint & SIX_BIT_MASK);
-        } else if (codePoint < 2097152) { // 21 bits
-            yield 0xF0 | (codePoint >>> 18);
-            yield 0x80 | ((codePoint >>> 12) & SIX_BIT_MASK);
-            yield 0x80 | ((codePoint >>> 6) & SIX_BIT_MASK);
-            yield 0x80 | (codePoint & SIX_BIT_MASK);
-        }
+        bytes[i++] = c & 63 | 128;
     }
+    return bytes.subarray(0, i);
 }
 
-function *charCodes(s: string) : IterableIterator<number> {
-    for (let i: number = 0; i < s.length; i++) {
-        yield s.charCodeAt(i);
+export function decodeUtf8(bytes: Uint8Array) : string {
+    let i = 0, s = '', c;
+    while (i < bytes.length) {
+        c = bytes[i++];
+        if (c > 127) {
+            if (c > 191 && c < 224) {
+                if (i >= bytes.length)
+                    throw new Error('UTF-8 decode: incomplete 2-byte sequence');
+                c = (c & 31) << 6 | bytes[i++] & 63;
+            } else if (c > 223 && c < 240) {
+                if (i + 1 >= bytes.length)
+                    throw new Error('UTF-8 decode: incomplete 3-byte sequence');
+                c = (c & 15) << 12 | (bytes[i++] & 63) << 6 | bytes[i++] & 63;
+            } else if (c > 239 && c < 248) {
+                if (i + 2 >= bytes.length)
+                    throw new Error('UTF-8 decode: incomplete 4-byte sequence');
+                c = (c & 7) << 18 | (bytes[i++] & 63) << 12 | (bytes[i++] & 63) << 6 | bytes[i++] & 63;
+            } else throw new Error('UTF-8 decode: unknown multibyte start 0x' + c.toString(16) + ' at index ' + (i - 1));
+        }
+        if (c <= 0xffff) s += String.fromCharCode(c);
+        else if (c <= 0x10ffff) {
+            c -= 0x10000;
+            s += String.fromCharCode(c >> 10 | 0xd800)
+            s += String.fromCharCode(c & 0x3FF | 0xdc00)
+        } else throw new Error('UTF-8 decode: code point 0x' + c.toString(16) + ' exceeds UTF-16 reach');
     }
+    return s;
 }

--- a/src/IonWriteable.ts
+++ b/src/IonWriteable.ts
@@ -1,54 +1,85 @@
-/*
- * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at:
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
- */
-import { isUndefined } from "./IonUtilities";
-import { last } from "./IonUtilities";
+    /*
+    * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    *
+    * Licensed under the Apache License, Version 2.0 (the "License").
+    * You may not use this file except in compliance with the License.
+    * A copy of the License is located at:
+    *
+    *     http://aws.amazon.com/apache2.0/
+    *
+    * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+    * language governing permissions and limitations under the License.
+    */
+    /**
+    * A byte array builder.
+    *
+    * This implementation attempts to minimize append and allocate operations by writing into
+    * a pre-allocated array, although additional arrays are allocated as necessary.
+    */
+    export class Writeable {
+        private bufferSize: number;
+        private buffers: Uint8Array[];
+        private index : number;
+        private clean : boolean;
 
-const DEFAULT_BUFFER_SIZE: number = 4096;
-
-/**
- * A byte array builder.
- *
- * This implementation attempts to minimize append and allocate operations by writing into
- * a pre-allocated array, although additional arrays are allocated as necessary.
- */
-export class Writeable {
-    private buffer: number[];
-
-    constructor() {
-        this.buffer = [];
-    }
-
-    writeByte(b: number) {
-        this.buffer.push(b);
-    }
-
-    writeBytes(b: number[] | Uint8Array, offset: number = 0, length?: number): void {
-        if (isUndefined(length)) {
-            length = b.length - offset;
+        constructor(bufferSize? : number) {
+            this.bufferSize = bufferSize ? bufferSize : 4096;
+            this.buffers = [new Uint8Array(this.bufferSize)];
+            this.index = 0;
+            this.clean = false;
         }
-        for (let i: number = offset; i < b.length; i++) {
-            this.buffer.push(b[i]);
+
+        writeByte(byte : number) {
+            this.clean = false;
+            this.currentBuffer[this.index] = byte;
+            this.index++;
+            if(this.index === this.bufferSize) {
+                this.buffers.push(new Uint8Array(this.bufferSize));
+                this.index = 0;
+            }
+        }
+
+        writeBytes(buf : Uint8Array, offset?: number, length? : number): void {
+            if(offset === undefined) offset = 0;
+
+            let writeLength = length !== undefined ? (Math.min(buf.length - offset, length)): buf.length - offset;
+            if (writeLength < (this.currentBuffer.length - this.index) - 1) {
+                this.currentBuffer.set(buf.subarray(offset, offset + writeLength), this.index);
+                this.index += writeLength;
+            } else {
+                this.buffers[this.buffers.length - 1] = this.currentBuffer.slice(0,this.index);
+                this.buffers.push(buf.subarray(offset,length));
+                this.buffers.push(new Uint8Array(this.bufferSize));
+                this.clean = false;
+                this.index = 0;
+            }
+        }
+
+        getBytes() : Uint8Array {
+            if(this.clean) return this.buffers[0];
+            let buffer = new Uint8Array(this.totalSize);
+            let tempLength = 0;
+            for(let i = 0; i < this.buffers.length - 1; i++){
+                buffer.set(this.buffers[i], tempLength);
+                tempLength += this.buffers[i].length;
+            }
+            buffer.set(this.currentBuffer.subarray(0, this.index), tempLength);
+            this.buffers = [buffer, new Uint8Array(this.bufferSize)];
+            this.index = 0;
+            this.clean = true;
+            return buffer;
+        }
+
+        get currentBuffer() {
+            return this.buffers[this.buffers.length - 1];
+        }
+
+        get totalSize() {
+            let size = 0;
+            for(let i = 0; i < this.buffers.length - 1; i++){
+                size += this.buffers[i].length;
+            }
+            return size + this.index;
         }
     }
-
-    writeStream(it: IterableIterator<number>) {
-        for (let b of it) {
-            this.writeByte(b);
-        }
-    }
-
-    getBytes(): number[] {
-        return this.buffer;
-    }
-}


### PR DESCRIPTION
utf-8 support:
This change was first built to allow full integration testing, prior it was literally impossible to roundtrip between the text and binary since text could only read strings and binary could only write number[].
This required rewriting the entire library to support uint8array as its backing value, rewriting the utf8 encode/decode logic to use uint8array, and rebuilding the apis around getbytes/writeables.
These changes are visible in:
-src/IonLowLevelBinaryWriter.ts
-src/IonTextReader.ts
-src/IonTextWriter.ts
-src/IonUnicode.ts
-src/IonWriteable.ts

Blob support:
This change was built to allow blobs which previously had no api's/was backed by a string which made little sense. 
It is visible in:
-src/IonTextReader.ts
-src/IonText.ts
-src/IonTextWriter.ts

Amortized write costs:
This change was prompted by changing the backing buffer from number[] (really an object with number fields) to uint8array which is 10-12x faster and 20x faster with amortized costs. (also 4x smaller 8 bits vs 32)
It is visible in:
-src/IonWriteable.ts

Low level binary writer precalc lengths:
This change was due to bugs in the binary writer once integration testing was working. The binary writer would churn out garbage and randomly padded values based on a shoddy low level number writer implementation.
It is visible in:
-src/IonLowLevelBinaryWriter.ts