### PR TITLE
Add millisecond precision for text Timestamps

### DIFF
--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -116,7 +116,7 @@ export class Decimal {
         }
         if(f) {
             let exponentShift = d ? (d.index - 1) - f.index : (str.length - 1) - f.index;
-            return new Decimal(new LongInt(str.substring(0, f.index - 1) +  str.substring(f.index + 1, exponentDelimiterIndex)), exponent - exponentShift);
+            return new Decimal(new LongInt(str.substring(0, f.index) +  str.substring(f.index + 1, exponentDelimiterIndex + 1)), exponent - exponentShift);
         } else {
             return new Decimal(new LongInt(str.substring(0,  exponentDelimiterIndex)), exponent);
         }

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -271,8 +271,10 @@ export class Timestamp {
         this.day = day;
         this.hour = hour;
         this.minute = minute;
+        let s = this.seconds !== undefined ? Math.trunc(this.seconds.numberValue()) : null;
+        let ms = this.seconds !== undefined ? Math.round(this.seconds.numberValue() % 1 * 1000) : null;
         this.checkValid();
-        this.date = new Date(Date.UTC(this.year, (this.precision === Precision.YEAR ? 0 : this.month - 1), this.day, this.hour, this.minute, null, null) - (this.offset * 60000));
+        this.date = new Date(Date.UTC(this.year, (this.precision === Precision.YEAR ? 0 : this.month - 1), this.day, this.hour, this.minute, s, ms) - (this.offset * 60000));
         /*
         let shiftHours = Math.floor(this.offset / 60);
         let shiftMinute = this.offset - (shiftHours * 60);


### PR DESCRIPTION
@wesboyt I need this change to parse UTC ISO-8601 Ion text timestamps with second and millisecond precision. I've tested it locally by parsing string input like "2019-05-31T00:04:19.305Z". 

This package still doesn't build due to other existing issues.
