### PR TITLE
isIVM fix for similar but non IVM symbols.

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -90,8 +90,10 @@ export class TextReader implements Reader {
 
     isIVM(input : string) : boolean {
         if (this.depth() > 0) return false;
-        if (input.length < 6 || this.annotations().length > 0) return false;
-        let prefix = "$ion_";
+        const ivm = "$ion_1_0";
+        const prefix = "$ion_";
+        if (input.length < ivm.length || this.annotations().length > 0) return false;
+
         let i = 0;
 
         while (i < prefix.length) {
@@ -111,7 +113,7 @@ export class TextReader implements Reader {
             if (ch < '0' || ch > '9') return false;
             i++;
         }
-        if (input !== "$ion_1_0") throw new Error("Only Ion version 1.0 is supported.");
+        if (input !== ivm) throw new Error("Only Ion version 1.0 is supported.");
         return true;
     }
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -100,14 +100,15 @@ export class TextReader implements Reader {
         }
 
         while (i < input.length && input.charAt(i) != '_') {
-            let tempChar = input.charAt(i);
-            if (tempChar < '0' || tempChar > '9') return false;
+            let ch = input.charAt(i);
+            if (ch < '0' || ch > '9') return false;
             i++;
         }
         i++;
+
         while (i < input.length) {
-            let tempChar = input.charAt(i);
-            if (tempChar < '0' || tempChar > '9') return false;
+            let ch = input.charAt(i);
+            if (ch < '0' || ch > '9') return false;
             i++;
         }
         if (input !== "$ion_1_0") throw new Error("Only Ion version 1.0 is supported.");

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -89,33 +89,33 @@ export class TextReader implements Reader {
   }
 
   isIVM(input : string, depth : number, annotations : string[]) : boolean {
-        if (depth > 0) return false;
-        const ivm = "$ion_1_0";
-        const prefix = "$ion_";
-        if (input.length < ivm.length || annotations.length > 0) return false;
+    if (depth > 0) return false;
+    const ivm = "$ion_1_0";
+    const prefix = "$ion_";
+    if (input.length < ivm.length || annotations.length > 0) return false;
 
-        let i = 0;
+    let i = 0;
 
-        while (i < prefix.length) {
-            if (prefix.charAt(i) !== input.charAt(i)) return false;
-            i++;
-        }
-
-        while (i < input.length && input.charAt(i) != '_') {
-            let ch = input.charAt(i);
-            if (ch < '0' || ch > '9') return false;
-            i++;
-        }
-        i++;
-
-        while (i < input.length) {
-            let ch = input.charAt(i);
-            if (ch < '0' || ch > '9') return false;
-            i++;
-        }
-        if (input !== ivm) throw new Error("Only Ion version 1.0 is supported.");
-        return true;
+    while (i < prefix.length) {
+      if (prefix.charAt(i) !== input.charAt(i)) return false;
+      i++;
     }
+
+    while (i < input.length && input.charAt(i) != '_') {
+      let ch = input.charAt(i);
+      if (ch < '0' || ch > '9') return false;
+      i++;
+    }
+    i++;
+
+    while (i < input.length) {
+      let ch = input.charAt(i);
+      if (ch < '0' || ch > '9') return false;
+      i++;
+    }
+    if (input !== ivm) throw new Error("Only Ion version 1.0 is supported.");
+    return true;
+  }
 
     isLikeIVM() : boolean {
       return false;

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -98,19 +98,19 @@ export class TextReader implements Reader {
             if (prefix.charAt(i) !== input.charAt(i)) return false;
             i++;
         }
-        let tempChar;
-        while (input.charAt(i) != '_') {
-            tempChar = input.charAt(i);
+
+        while (i < input.length && input.charAt(i) != '_') {
+            let tempChar = input.charAt(i);
             if (tempChar < '0' || tempChar > '9') return false;
             i++;
         }
         i++;
-        while (i < input.length) {
-            tempChar = input.charAt(i);
+        while (i < input.length && i < input.length) {
+            let tempChar = input.charAt(i);
             if (tempChar < '0' || tempChar > '9') return false;
             i++;
         }
-        if (input !== "$ion_1_0") throw new Error("Only ion version 1.0 is supported.");
+        if (input !== "$ion_1_0") throw new Error("Only Ion version 1.0 is supported.");
         return true;
     }
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -89,28 +89,28 @@ export class TextReader implements Reader {
   }
 
     isIVM(input : string) : boolean {
-        if(this.depth() > 0) return false;
-        if(input.length < 6 || this.annotations().length > 0) return false;
+        if (this.depth() > 0) return false;
+        if (input.length < 6 || this.annotations().length > 0) return false;
         let prefix = "$ion_";
         let i = 0;
 
-        while(i < prefix.length){
-            if(prefix.charAt(i) !== input.charAt(i)) return false;
+        while (i < prefix.length) {
+            if (prefix.charAt(i) !== input.charAt(i)) return false;
             i++;
         }
         let tempChar;
-        while(input.charAt(i) != '_'){
+        while (input.charAt(i) != '_') {
             tempChar = input.charAt(i);
-            if(tempChar < '0' || tempChar > '9') return false;
+            if (tempChar < '0' || tempChar > '9') return false;
             i++;
         }
         i++;
-        while(i < input.length){
+        while (i < input.length) {
             tempChar = input.charAt(i);
-            if(tempChar < '0' || tempChar > '9') return false;
+            if (tempChar < '0' || tempChar > '9') return false;
             i++;
         }
-        if(input !== "$ion_1_0") throw new Error("Only ion version 1.0 is supported.");
+        if (input !== "$ion_1_0") throw new Error("Only ion version 1.0 is supported.");
         return true;
     }
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -94,7 +94,7 @@ export class TextReader implements Reader {
         let prefix = "$ion_";
         let i = 0;
 
-        while (i < input.length && i < prefix.length) {
+        while (i < prefix.length) {
             if (prefix.charAt(i) !== input.charAt(i)) return false;
             i++;
         }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -88,11 +88,11 @@ export class TextReader implements Reader {
     }
   }
 
-    isIVM(input : string) : boolean {
-        if (this.depth() > 0) return false;
+  isIVM(input : string, depth : number, annotations : string[]) : boolean {
+        if (depth > 0) return false;
         const ivm = "$ion_1_0";
         const prefix = "$ion_";
-        if (input.length < ivm.length || this.annotations().length > 0) return false;
+        if (input.length < ivm.length || annotations.length > 0) return false;
 
         let i = 0;
 
@@ -138,7 +138,7 @@ next() {
         if (this._raw_type === T_IDENTIFIER) {
             if (this._depth > 0) break;
             this.load_raw();
-            if (!this.isIVM(this._raw)) break;
+            if (!this.isIVM(this._raw, this.depth(), this.annotations())) break;
             this._symtab = defaultLocalSymbolTable();
             this._raw = undefined;
             this._raw_type = undefined;

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -92,8 +92,23 @@ export class TextReader implements Reader {
         if(this.depth() > 0) return false;
         if(input.length < 6 || this.annotations().length > 0) return false;
         let prefix = "$ion_";
-        for(let i = 0; i < prefix.length; i++){
+        let i = 0;
+
+        while(i < prefix.length){
             if(prefix.charAt(i) !== input.charAt(i)) return false;
+            i++;
+        }
+        let tempChar;
+        while(input.charAt(i) != '_'){
+            tempChar = input.charAt(i);
+            if(tempChar < '0' || tempChar > '9') return false;
+            i++;
+        }
+        i++;
+        while(i < input.length){
+            tempChar = input.charAt(i);
+            if(tempChar < '0' || tempChar > '9') return false;
+            i++;
         }
         if(input !== "$ion_1_0") throw new Error("Only ion version 1.0 is supported.");
         return true;

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -94,7 +94,7 @@ export class TextReader implements Reader {
         let prefix = "$ion_";
         let i = 0;
 
-        while (i < prefix.length) {
+        while (i < input.length && i < prefix.length) {
             if (prefix.charAt(i) !== input.charAt(i)) return false;
             i++;
         }
@@ -105,7 +105,7 @@ export class TextReader implements Reader {
             i++;
         }
         i++;
-        while (i < input.length && i < input.length) {
+        while (i < input.length) {
             let tempChar = input.charAt(i);
             if (tempChar < '0' || tempChar > '9') return false;
             i++;

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -132,7 +132,7 @@
               ionReader.next();
               ionReader.next();
           } catch(error) {
-              throw new Error("Allowable IVM like symbol threw an error ");
+              throw new Error("Allowable IVM like symbol threw an error " + error);
           }
           ionToRead = "$ion_2_0";
           ionReader = ion.makeReader(ionToRead);
@@ -151,11 +151,11 @@
                   } catch(error) {
                       return true;
                   }
-                  throw new Error("Unsupported IVM symbol did not throw an error ");
+                  throw new Error("Unsupported IVM symbol did not throw an error.");
               }
-              throw new Error("Unsupported IVM symbol did not throw an error ");
+              throw new Error("Unsupported IVM symbol did not throw an error.");
           }
-          throw new Error("Unsupported IVM symbol did not throw an error ");
+          throw new Error("Unsupported IVM symbol did not throw an error.");
       };
 
     registerSuite(suite);

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -1,153 +1,157 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at:
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
- */
- define(
-  function(require) {
-    const registerSuite = require('intern!object');
-    const assert = require('intern/chai!assert');
-    const ion = require('dist/amd/es6/Ion');
+* Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at:
+*
+*     http://aws.amazon.com/apache2.0/
+*
+* or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+* language governing permissions and limitations under the License.
+*/
+define(
+    function(require) {
+        const registerSuite = require('intern!object');
+        const assert = require('intern/chai!assert');
+        const ion = require('dist/amd/es6/Ion');
 
-    var suite = {
-      name: 'Text Reader'
-    };
+        var suite = {
+            name: 'Text Reader'
+        };
 
-    suite['Read string value'] = function() {
-      var ionToRead = "\"string\"";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
+        suite['Read string value'] = function() {
+            var ionToRead = "\"string\"";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
 
-      assert.equal(ionReader.value(), "string");
-    };
+            assert.equal(ionReader.value(), "string");
+        };
 
-    suite['Read boolean value'] = function() {
-      var ionToRead = "true";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
+        suite['Read boolean value'] = function() {
+            var ionToRead = "true";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
 
-      assert.equal(ionReader.value(), true);
-    };
+            assert.equal(ionReader.value(), true);
+        };
 
-    suite['Read boolean value in struct'] = function() {
-      var ionToRead = "{ a: false }";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
-      ionReader.stepIn();
-      ionReader.next();
+        suite['Read boolean value in struct'] = function() {
+            var ionToRead = "{ a: false }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
+            ionReader.stepIn();
+            ionReader.next();
 
-      assert.equal(ionReader.value(), false);
-    };
+            assert.equal(ionReader.value(), false);
+        };
 
-      suite['resolves symbol IDs'] = function() {
-          let ionToRead = `$ion_symbol_table::{ symbols:[ "rock", "paper", "scissors" ]}{ $5: $6, $10: $11, $12: 'taco' }`;
-          let ionReader = ion.makeReader(ionToRead);
-          ionReader.next();
-          ionReader.stepIn();
-          ionReader.next();
-          assert.equal(ionReader.fieldName(), 'version');
-          assert.equal(ionReader.value(), 'imports');
-          ionReader.next();
-          assert.equal(ionReader.fieldName(), "rock");
-          assert.equal(ionReader.value(), "paper");
-          ionReader.next();
-          assert.equal(ionReader.fieldName(), "scissors");
-          assert.equal(ionReader.value(), 'taco');
-          ionReader.next();
-          ionReader.stepOut();
-          //assert.equal(ionReader.value(), false);
-      };
+        suite['resolves symbol IDs'] = function() {
+            let ionToRead = `$ion_symbol_table::{ symbols:[ "rock", "paper", "scissors" ]}{ $5: $6, $10: $11, $12: 'taco' }`;
+            let ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
+            ionReader.stepIn();
+            ionReader.next();
+            assert.equal(ionReader.fieldName(), 'version');
+            assert.equal(ionReader.value(), 'imports');
+            ionReader.next();
+            assert.equal(ionReader.fieldName(), "rock");
+            assert.equal(ionReader.value(), "paper");
+            ionReader.next();
+            assert.equal(ionReader.fieldName(), "scissors");
+            assert.equal(ionReader.value(), 'taco');
+            ionReader.next();
+            ionReader.stepOut();
+            //assert.equal(ionReader.value(), false);
+        };
 
-    suite['Parse through struct'] = function() {
-      var ionToRead = "{ key : \"string\" }";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
+        suite['Parse through struct'] = function() {
+            var ionToRead = "{ key : \"string\" }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
 
-      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+            assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
 
-      ionReader.stepIn(); // Step into the base struct.
-      ionReader.next();
+            ionReader.stepIn(); // Step into the base struct.
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "key");
-      assert.equal(ionReader.value(), "string");
-    };
+            assert.equal(ionReader.fieldName(), "key");
+            assert.equal(ionReader.value(), "string");
+        };
 
-    suite['Parse through struct can skip over container'] = function() {
-      var ionToRead = "{ a: { key1 : \"string1\" }, b: { key2 : \"string2\" } }";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
+        suite['Parse through struct can skip over container'] = function() {
+            var ionToRead = "{ a: { key1 : \"string1\" }, b: { key2 : \"string2\" } }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
 
-      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+            assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
 
-      ionReader.stepIn(); // Step into the base struct.
-      ionReader.next();
+            ionReader.stepIn(); // Step into the base struct.
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "a");
+            assert.equal(ionReader.fieldName(), "a");
 
-      ionReader.next();
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "b");
+            assert.equal(ionReader.fieldName(), "b");
 
-      ionReader.stepIn(); // Step into the "b" struct.
-      ionReader.next();
+            ionReader.stepIn(); // Step into the "b" struct.
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "key2");
-      assert.equal(ionReader.value(), "string2");
-    };
+            assert.equal(ionReader.fieldName(), "key2");
+            assert.equal(ionReader.value(), "string2");
+        };
 
-    suite['Parse through struct can skip over nested containers'] = function() {
-      var ionToRead = "{ outerkey1 : { innerkey1 : {a1: \"a1\", b1: \"b1\"} }, outerkey2 : { innerkey2 : {a2: \"a2\", b2: \"b2\"} } }";
-      var ionReader = ion.makeReader(ionToRead);
-      ionReader.next();
+        suite['Parse through struct can skip over nested containers'] = function() {
+            var ionToRead = "{ outerkey1 : { innerkey1 : {a1: \"a1\", b1: \"b1\"} }, outerkey2 : { innerkey2 : {a2: \"a2\", b2: \"b2\"} } }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
 
-      assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
+            assert.equal(ion.IonTypes.STRUCT, ionReader.valueType());
 
-      ionReader.stepIn(); // Step into the base struct.
-      ionReader.next();
+            ionReader.stepIn(); // Step into the base struct.
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "outerkey1");
+            assert.equal(ionReader.fieldName(), "outerkey1");
 
-      ionReader.next();
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "outerkey2");
+            assert.equal(ionReader.fieldName(), "outerkey2");
 
-      ionReader.stepIn(); // Step into the "b" struct.
-      ionReader.next();
+            ionReader.stepIn(); // Step into the "b" struct.
+            ionReader.next();
 
-      assert.equal(ionReader.fieldName(), "innerkey2");
-    };
+            assert.equal(ionReader.fieldName(), "innerkey2");
+        };
 
-      suite['Accept IVM like symbols and throw on IVMs except $ion_1_0'] = function() {
-          let shouldPass = ["$ion_1_0", "$ion_schema_1_0", "$ion_1", "$ion_1_a", "$ion_", "ion_1_"];
-          let shouldFail = ["$ion_2_0", "$ion_1_999", "$ion_999_0", "$ion_1_1", "$ion_1_00"];
-          for(let input in shouldPass) {
-              let ionReader = ion.makeReader(input);
-              try {
-                  while (ionReader.next() !== undefined) {}
-              } catch(error) {
-                  throw new Error("Allowable IVM like symbol threw an error " + error);
-              }
-          }
+        suite['Accept IVM-like symbols and throw on IVMs except $ion_1_0'] = function() {
+            let shouldPass = ["$ion_1_0", "$ion_schema_1_0", "$ion_1", "$ion_1_a", "$ion_", "ion_1_"];
+            let shouldThrow = ["$ion_2_0", "$ion_1_999", "$ion_999_0", "$ion_1_1", "$ion_1_00"];
 
-          for(let input in shouldFail) {
-              let ionReader = ion.makeReader(input);
-              let caughtError = false;
-              try {
-                  while (ionReader.next() !== undefined) {}
-              } catch(error) {
-                caughtError = true;
-              }
-              if(!caughtError) throw new Error("Unsupported IVM symbol did not throw an error.");
-          }
-      };
-    registerSuite(suite);
-  }
+            for (let i = 0; i < shouldPass.length; i++) {
+                let input = shouldPass[i];
+                let ionReader = ion.makeReader(input);
+                try {
+                    while (ionReader.next() !== undefined) {}
+                } catch(error) {
+                    throw new Error(`Allowable IVM like symbol ${input} threw an error g ` + error);
+                }
+            }
+
+            for (let i = 0; i < shouldThrow.length; i++) {
+                let input = shouldThrow[i];
+                let ionReader = ion.makeReader(input);
+                try {
+                    while (ionReader.next() !== undefined) {}
+                    throw new Error(`Unsupported IVM symbol ${input} did not throw an error.`);
+                } catch(error) {
+                     if (error.message !== "Only Ion version 1.0 is supported.") {
+                         throw new Error(`input: ${input} threw an unexpected error: ${error.message}`);
+                     }
+                }
+            }
+        };
+        registerSuite(suite);
+    }
 );

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -137,8 +137,8 @@
               }
           }
 
-          for(let i = 0; i < shouldFail.length; i++) {
-              let ionReader = ion.makeReader(shouldFail[i]);
+          for(let input in shouldFail) {
+              let ionReader = ion.makeReader(input);
               let caughtError = false;
               try {
                   while (ionReader.next() !== undefined) {}

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -135,7 +135,7 @@ define(
                 try {
                     while (ionReader.next() !== undefined) {}
                 } catch(error) {
-                    throw new Error(`Allowable IVM like symbol ${input} threw an error g ` + error);
+                    throw new Error(`Allowable IVM like symbol ${input} threw an error: ${error.message}.`);
                 }
             }
 
@@ -147,7 +147,7 @@ define(
                     throw new Error(`Unsupported IVM symbol ${input} did not throw an error.`);
                 } catch(error) {
                      if (error.message !== "Only Ion version 1.0 is supported.") {
-                         throw new Error(`input: ${input} threw an unexpected error: ${error.message}`);
+                         throw new Error(`input: ${input} threw an unexpected error: ${error.message}.`);
                      }
                 }
             }

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -126,38 +126,28 @@
     };
 
       suite['Accept IVM like symbols and throw on IVMs except $ion_1_0'] = function() {
-          let ionToRead = "$ion_1_0 $ion_schema_1_0";
-          let ionReader = ion.makeReader(ionToRead);
-          try {
-              ionReader.next();
-              ionReader.next();
-          } catch(error) {
-              throw new Error("Allowable IVM like symbol threw an error " + error);
-          }
-          ionToRead = "$ion_2_0";
-          ionReader = ion.makeReader(ionToRead);
-          try {
-              ionReader.next();
-          }catch(error) {
-              ionToRead = "$ion_1_999";
-              ionReader = ion.makeReader(ionToRead);
+          let shouldPass = ["$ion_1_0", "$ion_schema_1_0", "$ion_1", "$ion_1_a", "$ion_", "ion_1_"];
+          let shouldFail = ["$ion_2_0", "$ion_1_999", "$ion_999_0", "$ion_1_1", "$ion_1_00"];
+          for(let input in shouldPass) {
+              let ionReader = ion.makeReader(input);
               try {
-                  ionReader.next();
+                  while (ionReader.next() !== undefined) {}
               } catch(error) {
-                  ionToRead = "$ion_999_0";
-                  ionReader = ion.makeReader(ionToRead);
-                  try {
-                      ionReader.next();
-                  } catch(error) {
-                      return true;
-                  }
-                  throw new Error("Unsupported IVM symbol did not throw an error.");
+                  throw new Error("Allowable IVM like symbol threw an error " + error);
               }
-              throw new Error("Unsupported IVM symbol did not throw an error.");
           }
-          throw new Error("Unsupported IVM symbol did not throw an error.");
-      };
 
+          for(let i = 0; i < shouldFail.length; i++) {
+              let ionReader = ion.makeReader(shouldFail[i]);
+              let caughtError = false;
+              try {
+                  while (ionReader.next() !== undefined) {}
+              } catch(error) {
+                caughtError = true;
+              }
+              if(!caughtError) throw new Error("Unsupported IVM symbol did not throw an error.");
+          }
+      };
     registerSuite(suite);
   }
 );

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -125,6 +125,39 @@
       assert.equal(ionReader.fieldName(), "innerkey2");
     };
 
+      suite['Accept IVM like symbols and throw on IVMs except $ion_1_0'] = function() {
+          let ionToRead = "$ion_1_0 $ion_schema_1_0";
+          let ionReader = ion.makeReader(ionToRead);
+          try {
+              ionReader.next();
+              ionReader.next();
+          } catch(error) {
+              throw new Error("Allowable IVM like symbol threw an error ");
+          }
+          ionToRead = "$ion_2_0";
+          ionReader = ion.makeReader(ionToRead);
+          try {
+              ionReader.next();
+          }catch(error) {
+              ionToRead = "$ion_1_999";
+              ionReader = ion.makeReader(ionToRead);
+              try {
+                  ionReader.next();
+              } catch(error) {
+                  ionToRead = "$ion_999_0";
+                  ionReader = ion.makeReader(ionToRead);
+                  try {
+                      ionReader.next();
+                  } catch(error) {
+                      return true;
+                  }
+                  throw new Error("Unsupported IVM symbol did not throw an error ");
+              }
+              throw new Error("Unsupported IVM symbol did not throw an error ");
+          }
+          throw new Error("Unsupported IVM symbol did not throw an error ");
+      };
+
     registerSuite(suite);
   }
 );

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -150,7 +150,7 @@ define(
                 assert.throws(() => { reader.isIVM(value, depth, annotations)});
             } else {
                 let actual = reader.isIVM(value, depth, annotations);
-                assert.equal(expected, actual);
+                assert.equal(actual, expected);
             }
 
 

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -134,16 +134,16 @@ define(
             test_isIVM(textReader,"$ion_1_0", true, 0, []);
             test_isIVM(textReader,"$ion_1_0", false, 1, []);
             test_isIVM(textReader,"$ion_1_0", false, 0, ["taco"]);
-            for (let i = 0; i < isNotIVM; i++) {
+            for (let i = 0; i < isNotIVM.length; i++) {
                 test_isIVM(textReader, isNotIVM[i], false, 0, []);
             }
-            for (let i = 0; i < unsupportedIVM; i++) {
+            for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], "throw", 0, []);
             }
-            for (let i = 0; i < unsupportedIVM; i++) {
+            for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], false, 1, []);
             }
-            for (let i = 0; i < unsupportedIVM; i++) {
+            for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], false, 0, ["taco"]);
             }
         };
@@ -156,6 +156,7 @@ define(
                     if (error.message !== "Only Ion version 1.0 is supported.") {
                         throw new Error(`input: ${value} threw an unexpected error: ${error.message}.`);
                     }
+                    return;
                 }
                 throw new Error("Expected " + value + " to throw an error.");
             } else {

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -1,16 +1,17 @@
 /*
-* Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at:
-*
-*     http://aws.amazon.com/apache2.0/
-*
-* or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
-* language governing permissions and limitations under the License.
-*/
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 define(
     function(require) {
         const registerSuite = require('intern!object');
@@ -139,26 +140,14 @@ define(
             }
             for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], "throw", 0, []);
-            }
-            for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], false, 1, []);
-            }
-            for (let i = 0; i < unsupportedIVM.length; i++) {
                 test_isIVM(textReader, unsupportedIVM[i], false, 0, ["taco"]);
             }
         };
 
         function test_isIVM(reader, value, expected, depth, annotations) {
             if (expected === "throw") {
-                try {
-                    reader.isIVM(value, depth, annotations);
-                } catch(error) {
-                    if (error.message !== "Only Ion version 1.0 is supported.") {
-                        throw new Error(`input: ${value} threw an unexpected error: ${error.message}.`);
-                    }
-                    return;
-                }
-                throw new Error("Expected " + value + " to throw an error.");
+                assert.throws(() => { reader.isIVM(value, depth, annotations)});
             } else {
                 let actual = reader.isIVM(value, depth, annotations);
                 assert.equal(expected, actual);


### PR DESCRIPTION
#202 

Instead of throwing on all symbols with $ion_ we now throw on $ion_(0-9xxx...)_(0-9xxx...) when not exactly $ion_1_0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
