### PR TITLE
Unit tests: reading binary UInt

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -230,14 +230,16 @@ export class ParserBinaryRaw {
         }
 
         // We overflowed
-        if (value < 0) {
+        if (numberOfBytes > 4 || value < 0) {
             throw new Error("Attempted to read an unsigned int that was larger than 31 bits."
                 + " Use readUnsignedLongIntFrom instead. UInt size: " + numberOfBytes + ", value: " + value
             );
         }
         // Fewer bytes than the required `numberOfBytes` were available in the input
-        if (byte === EOF)
-            return undefined;
+        if (byte === EOF) {
+            throw new Error("Ran out of data while reading a " + numberOfBytes + "-byte unsigned int.");
+        }
+
         return value;
     }
 

--- a/src/IonTests.ts
+++ b/src/IonTests.ts
@@ -21,3 +21,5 @@ export { LocalSymbolTable } from './IonLocalSymbolTable';
 export { LowLevelBinaryWriter } from './IonLowLevelBinaryWriter';
 export { NullNode } from './IonBinaryWriter';
 export { BinaryWriter } from "./IonBinaryWriter";
+export { ParserBinaryRaw } from "./IonParserBinaryRaw";
+export { BinarySpan } from "./IonSpan";

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -29,6 +29,7 @@ define({
     'tests/unit/IonTextWriterTest',
     'tests/unit/IonUnicodeTest',
     'tests/unit/IonLowLevelBinaryWriterTest',
+    'tests/unit/IonParserBinaryRawTest',
     'tests/unit/IonBinaryWriterTest',
     'tests/unit/IonBinaryTimestampTest',
     'tests/unit/IonTextReaderTest',

--- a/tests/unit/IonParserBinaryRawTest.js
+++ b/tests/unit/IonParserBinaryRawTest.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+define([
+    'intern',
+    'intern!object',
+    'intern/chai!assert',
+    'dist/amd/es6/IonTests',
+  ],
+  function(intern, registerSuite, assert, ion) {
+
+    let suite = {
+      name: 'Parser Binary Raw'
+    };
+
+    // Registers the provided test with the test suite.
+    let registerTest = function(testName, test, throwsException) {
+      suite[testName] = throwsException
+          ? function() { assert.throws(test, Error); }
+          : test;
+    }
+
+    let readUnsignedIntTest = function(bytes, expected, throwsException) {
+      let testName = throwsException
+          ? 'Throw an exception while reading unsigned int ' + expected + ' from bytes: ' + bytes
+          : 'Read unsigned int ' + expected + ' from bytes: ' + bytes;
+      let test = function() {
+        let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+        let actual = ion.ParserBinaryRaw.readUnsignedIntFrom(binarySpan, bytes.length);
+        assert.equal(actual, expected)
+      }
+      registerTest(testName, test, throwsException);
+    }
+
+    // Expected to pass
+    readUnsignedIntTest([0x00], 0);
+    readUnsignedIntTest([0x01], 1);
+    readUnsignedIntTest([0x0F], 15);
+    readUnsignedIntTest([0x00, 0x00], 0);
+    readUnsignedIntTest([0xFF,], Math.pow(2, 8) - 1);
+    readUnsignedIntTest([0xFF, 0xFF], Math.pow(2, 16) - 1);
+    readUnsignedIntTest([0xFF, 0xFF, 0xFF], Math.pow(2, 24) - 1);
+    readUnsignedIntTest([0x7F, 0xFF, 0xFF, 0xFF], Math.pow(2, 31) - 1);
+
+    // Expected to fail
+    readUnsignedIntTest([], 1, true); // No input data
+    readUnsignedIntTest([0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 32) - 1, true);
+    readUnsignedIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 40) - 1, true);
+
+    let readUnsignedLongIntTest = function(bytes, expected, throwsException) {
+      let testName = throwsException
+          ? 'Throw an exception while reading unsigned long int ' + expected + ' from bytes: ' + bytes
+          : 'Read unsigned long int ' + expected + ' from bytes: ' + bytes;
+      let test = function() {
+        let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+        let actual = ion.ParserBinaryRaw.readUnsignedLongIntFrom(binarySpan, bytes.length);
+        assert.equal(actual, expected)
+      }
+      registerTest(testName, test, throwsException);
+    }
+
+    readUnsignedLongIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 40) - 1);
+    readUnsignedLongIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 48) - 1);
+    readUnsignedLongIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 56) - 1);
+    readUnsignedLongIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 64) - 1);
+    readUnsignedLongIntTest([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF], Math.pow(2, 72) - 1);
+
+    registerSuite(suite);
+  }
+);


### PR DESCRIPTION
*Issue #, if available:* #209 

*Description of changes:*

Adds `tests/IonParserBinaryRawTest.js`, which contains unit tests for:
* `ParserBinaryRaw::readUnsignedInt`
* `ParserBinaryRaw::readUnsignedLongInt`

This testing surfaced issue #210. UInts which require exactly 32 bits to represent currently cause read failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
