### PR TITLE
Unit tests: VarUint and VarInt.

### DIFF
--- a/tests/unit/IonParserBinaryRawTest.js
+++ b/tests/unit/IonParserBinaryRawTest.js
@@ -277,7 +277,7 @@ define([
     }
 
     readVarSignedInt([0x80], 0);
-    readVarSignedInt([0xC0], -0); // Not forbidden by the spec
+    readVarSignedInt([0xC0], -0);
     readVarSignedInt([0x81], 1);
     readVarSignedInt([0xC1], -1);
     readVarSignedInt([0x00, 0x81], 1);


### PR DESCRIPTION
*Issue #, if available:* #205 and #231 

*Description of changes:*
Adds unit tests for reading [VarInt and VarUInt](http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
