### PR TITLE
allows binary reader to resolve symbols, and allows *value() methods to return the current value more than once

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -168,7 +168,7 @@ export class BinaryReader implements Reader {
 
   stringValue() : string {
     let t: BinaryReader = this;
-    var n, s, p = t._parser;
+    let s, p = t._parser;
     if (t.isNull()) {
       s = "null";
       if (t._raw_type != TB_NULL) {
@@ -179,8 +179,7 @@ export class BinaryReader implements Reader {
       // BLOB is a scalar by you don't want to just use the string 
       // value otherwise all other scalars are fine as is
       if (t._raw_type === TB_SYMBOL) {
-        n = p.numberValue();//this is returning null.
-        s = this.getSymbolString(n);
+        s = this.getSymbolString(p.numberValue());
       }
       else {
         s = p.stringValue();

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -453,6 +453,7 @@ export class ParserBinaryRaw {
     }
 
     private load_value() : void {
+        if (this._curr != undefined) return;   // current value is already loaded
         if (this.isNull()) return null;
         switch(this._raw_type) {
             case IonBinary.TB_BOOL:
@@ -491,7 +492,7 @@ export class ParserBinaryRaw {
                 this._curr = this.read_timestamp_value();
                 break;
             case IonBinary.TB_SYMBOL:
-
+                this._curr = this.readUnsignedInt();
                 break;
             case IonBinary.TB_STRING:
                 this._curr = this.read_string_value();

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -274,7 +274,6 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/testfile5.ion',
     'ion-tests/iontestdata/good/testfile6.ion',
     'ion-tests/iontestdata/good/testfile7.ion',
-    'ion-tests/iontestdata/good/testfile8.ion',
     'ion-tests/iontestdata/good/utf16.ion',
     'ion-tests/iontestdata/good/utf32.ion',
     'ion-tests/iontestdata/good/whitespace.ion',


### PR DESCRIPTION
When the binary reader encountered an IVM, `this._curr` (the sid) was undefined (and thus impossible to resolve the symbol).  Adding `this._curr = this.readUnsignedInt()` to read the sid only addressed part of the problem, as IonBinaryReader's call to `_parser.numberValue()` (line 103) was causing it to read beyond the IVM, rather than returning the current numberValue (sid 3, the IVM).  The `_curr != undefined` check prevents the `*value()` methods from reading additional data, and prevents `_curr` from changing until sometime after the next invocation of `next()`.

Removes good/testfile8.ion from the eventstream skiplist (part of #186).

And as a happy side-effect, this PR also resolves #245, #247, and #248.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
