### PR TITLE
corrects the value of the IVM.sid constant

### DIFF
--- a/src/IonConstants.ts
+++ b/src/IonConstants.ts
@@ -16,5 +16,6 @@ export const EOF = -1;
 export const IVM = {
   text: "$ion_1_0",
   binary: new Uint8Array([ 0xE0, 0x01, 0x00, 0xEA ]),
-  sid : 3
-}
+  sid: 2,
+};
+

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -244,7 +244,6 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/symbolWithDel.ion',
     'ion-tests/iontestdata/good/symbolWithSpecialWhitespace.ion',
     'ion-tests/iontestdata/good/symbolZero.ion',
-    'ion-tests/iontestdata/good/symbols.ion',
     'ion-tests/iontestdata/good/testfile0.ion',
     'ion-tests/iontestdata/good/testfile1.ion',
     'ion-tests/iontestdata/good/testfile10.ion',


### PR DESCRIPTION
Resolves #192 

Per [the spec](https://amzn.github.io/ion-docs/docs/symbols.html#system-symbols), the Symbol ID for `$ion_1_0` is `2` (not `3`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
