### PR TITLE
avoids use of bitwise operator in writeUnsignedInt, which treats operands as 32-bit values

### DIFF
--- a/src/IonLowLevelBinaryWriter.ts
+++ b/src/IonLowLevelBinaryWriter.ts
@@ -54,8 +54,10 @@ export class LowLevelBinaryWriter {
     let i: number = tempBuf.length;
 
     while (value > 0) {
-      tempBuf[--i] = value;
-      value >>>= 8;
+      // JavaScript bitwise operators treat operands as 32-bit sequences,
+      // so we avoid using >>> in order to support values requiring more than 32 bits
+      tempBuf[--i] = value % 256;
+      value = Math.trunc(value / 256);
     }
 
     this.writeable.writeBytes(tempBuf);

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -191,6 +191,7 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n',
     'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
     'ion-tests/iontestdata/good/equivs/paddedInts.10n',
+    'ion-tests/iontestdata/good/equivs/sexps.ion',
     'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
     'ion-tests/iontestdata/good/equivs/timestampFractions.10n',
     'ion-tests/iontestdata/good/equivs/timestampFractions.ion',


### PR DESCRIPTION
Resolves #162, but isn't sufficient to remove good/equivs/ints.ion and good/non-equivs/ints.ion from the skiplist due to those files containing larger ints -- addressing those will require additional effort.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
