### PR TITLE
eliminates extraneous eventstream comparisons

### DIFF
--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -192,6 +192,7 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
     'ion-tests/iontestdata/good/equivs/paddedInts.10n',
     'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
+    'ion-tests/iontestdata/good/equivs/sexps.ion',
     'ion-tests/iontestdata/good/equivs/timestampFractions.10n',
     'ion-tests/iontestdata/good/equivs/timestampFractions.ion',
     'ion-tests/iontestdata/good/equivs/timestampSuperfluousOffset.10n',

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -107,9 +107,9 @@ define([
             streams[0].writeIon(eventBinaryWriter);
             streams.push(new ion.IonEventStream(new ion.makeReader(eventBinaryWriter.getBytes())));
 
-            for(let i = 0;  i < streams.length - 1; i++){
-                for(let j = i; j < streams.length; j++){
-                    if(!streams[i].equals(streams[(j + i) % streams.length])) {
+            for (let i = 0; i < streams.length - 1; i++) {
+                for (let j = i + 1; j < streams.length; j++) {
+                    if (!streams[i].equals(streams[j])) {
                         throw new Error("Streams unequal.");
                     }
                 }


### PR DESCRIPTION
Previous loop logic compared stream 0 to 0 (which is unnecessary), as well as two comparisons of 1 to 0, 2 to 0, 3 to 0, and 4 to 0.  This change eliminates these unnecessary and redundant comparisons.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
