### PR TITLE
fixes IonLongInt.intBytes() to ensure there's room for the sign bit

### DIFF
--- a/src/IonLongInt.ts
+++ b/src/IonLongInt.ts
@@ -36,8 +36,9 @@ export class LongInt {
     public intBytes() : Uint8Array {
         let array =  this.int.toArray(256).value;
         if(array[0] > 127) {
-            array[0] -= 0x80;
-            array.splice(0, 0, 1);
+            // highest-order bit is being used to represent part of the value,
+            // so prepend a byte to allow for encoding of the sign bit
+            array.splice(0, 0, 0);
         }
         if(this.int.isNegative()) array[0] += 0x80;
         return new Uint8Array(array);

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -239,7 +239,6 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/testfile22.ion',
     'ion-tests/iontestdata/good/testfile23.ion',
     'ion-tests/iontestdata/good/testfile25.ion',
-    'ion-tests/iontestdata/good/testfile31.ion',
     'ion-tests/iontestdata/good/testfile33.ion',
     'ion-tests/iontestdata/good/testfile34.ion',
     'ion-tests/iontestdata/good/testfile35.ion',


### PR DESCRIPTION
Resolves #182 

Subtracting `0x80` from `array[0]` alters the value of some numbers (if that high-order bit is part of the value's representation).  Modified `intBytes()` to prepend a byte for the sign if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
