### PR TITLE
throws an error if too many bytes are requested from a BinarySpan

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -130,7 +130,7 @@ export class ParserBinaryRaw {
     private _as: number = -1;
     private _ae: number = -1;
     private _a = [];
-    private _ts = [ TB_DATAGRAM ];//this looks sketch af.
+    private _ts = [ TB_DATAGRAM ];
     private _in_struct: boolean = false;
 
     constructor(source : BinarySpan) {

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -227,14 +227,16 @@ export class BinarySpan extends Span {
 
   //returns an array with the same backing buffer as the source.
   view(length : number) : Uint8Array {
-      return this._src.subarray(this._pos, this._pos +=length);
+      if (this._pos + length > this._limit) {
+          throw new Error('Unable to read ' + length + ' bytes (position: '
+              + this.position() + ', limit: ' + this._limit + ')');
+      }
+      return this._src.subarray(this._pos, this._pos += length);
   }
 
   //returns an array with a new backing buffer.
   chunk(length : number) : Uint8Array {
-      let buf = new Uint8Array(length);
-      buf.set(this._src.subarray(this._pos, this._pos += length));
-      return buf;
+      return new Uint8Array(this.view(length));
   }
 
   unread(b: number) : void {

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -162,7 +162,6 @@ let badSkipList = toSkipList([
     'ion-tests/iontestdata/bad/annotationWithNoValue.10n',
     'ion-tests/iontestdata/bad/blobLenTooLarge.10n',
     'ion-tests/iontestdata/bad/clobLenTooLarge.10n',
-    'ion-tests/iontestdata/bad/decimalLenTooLarge.10n',
     'ion-tests/iontestdata/bad/emptyAnnotatedInt.10n',
     'ion-tests/iontestdata/bad/floatLenTooLarge.10n',
     'ion-tests/iontestdata/bad/localSymbolTableImportNullMaxId.ion',


### PR DESCRIPTION
The length field of the value in `bad/decimalLenTooLarge.10n` indicates more bytes need to be read than are available.  This PR adds logic to throw an error in this scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
