### PR TITLE
Decimal negative zero coefficient/exponent fixes

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -22,6 +22,7 @@ import { Timestamp } from "./IonTimestamp";
 import { TypeCodes } from "./IonBinary";
 import { Writeable } from "./IonWriteable";
 import { Writer } from "./IonWriter";
+import { _sign } from "./util";
 
 const MAJOR_VERSION: number = 1;
 const MINOR_VERSION: number = 0;
@@ -110,7 +111,7 @@ export class BinaryWriter implements Writer {
 
     let isPositiveZero: boolean = value.isZero() && !value.isNegative();
     let exponent: number = value.getExponent();
-    if (isPositiveZero && exponent === 0 && !((1 / exponent) === -Infinity)) {
+    if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
       // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal
       this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.DECIMAL, this.encodeAnnotations(annotations), new Uint8Array(0)));
       return;

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -35,6 +35,7 @@
 //    the exponent (in addition to 'd' and 'D').
 
 import { LongInt } from "./IonLongInt";
+import { _sign } from "./util";
 
 export class Decimal {
     private _coefficient: LongInt;
@@ -99,7 +100,7 @@ export class Decimal {
         }
         s += this._coefficient.toString() + 'd';
 
-        if (this._exponent === 0 && Decimal._sign(this._exponent) === -1) {
+        if (this._exponent === 0 && _sign(this._exponent) === -1) {
             s += '-';
         }
         s += this._exponent;
@@ -234,9 +235,5 @@ export class Decimal {
         } else {
             return new Decimal(new LongInt(str.substring(0, exponentDelimiterIndex)), exponent);
         }
-    }
-
-    private static _sign(x) {
-        return (x < 0 || (x===0 && (1/x)===-Infinity)) ? -1 : 1;
     }
 }

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -93,11 +93,17 @@ export class Decimal {
     stringValue(): string {
         if (this.isNull()) return "null.decimal";
 
-        let s = this._coefficient.toString() + 'd';
+        let s = '';
+        if (this._coefficient.isZero() && this._coefficient.signum() === -1) {
+            s = '-';
+        }
+        s += this._coefficient.toString() + 'd';
+
         if (this._exponent === 0 && Decimal._sign(this._exponent) === -1) {
             s += '-';
         }
         s += this._exponent;
+
         return s;
     }
 
@@ -216,7 +222,7 @@ export class Decimal {
         let exponent = 0;
         if (str === 'null' || str === 'null.decimal') return null;
         let d = str.match('[d|D]');
-        let f  = str.match('\\.');
+        let f = str.match('\\.');
         let exponentDelimiterIndex = str.length;
         if(d) {
             exponent = Number(str.substring(d.index + 1, str.length));
@@ -224,9 +230,9 @@ export class Decimal {
         }
         if(f) {
             let exponentShift = d ? (d.index - 1) - f.index : (str.length - 1) - f.index;
-            return new Decimal(new LongInt(str.substring(0, f.index) +  str.substring(f.index + 1, exponentDelimiterIndex)),  exponent - exponentShift);
+            return new Decimal(new LongInt(str.substring(0, f.index) + str.substring(f.index + 1, exponentDelimiterIndex)), exponent - exponentShift);
         } else {
-            return new Decimal(new LongInt(str.substring(0,  exponentDelimiterIndex)), exponent);
+            return new Decimal(new LongInt(str.substring(0, exponentDelimiterIndex)), exponent);
         }
     }
 

--- a/src/IonLongInt.ts
+++ b/src/IonLongInt.ts
@@ -17,17 +17,24 @@ import { BigInteger } from "./BigInteger";
 
 
 export class LongInt {
-    public static readonly intZero : LongInt = new LongInt(0);
-    public static readonly intPosOne : LongInt = new LongInt(1);
-    public static readonly intNegZero : LongInt = new LongInt(-0);
-    public static readonly intNegOne : LongInt = new LongInt(-1);
     private int : BigInteger;
 
     constructor(input: string | number | BigInteger) {
         if(typeof input === 'string') {
-            this.int = bigInt(input);
+            let s = input.trim();
+            if (s[0] === '-') {
+                // this ensures this.int.sign is correct for -0:
+                this.int = bigInt(s.substr(1)).negate();
+            } else {
+                this.int = bigInt(s);
+            }
         } else if(typeof input === 'number') {
-            this.int = bigInt(input);
+            if (input === 0 && (1 / input) === -Infinity) {
+                // this ensures this.int.sign is correct for -0:
+                this.int = bigInt(0).negate();
+            } else {
+                this.int = bigInt(input);
+            }
         } else if(input instanceof bigInt) {
             this.int = input;
         } else {
@@ -46,7 +53,7 @@ export class LongInt {
             // so prepend a byte to allow for encoding of the sign bit
             array.splice(0, 0, 0);
         }
-        if(this.int.isNegative()) array[0] += 0x80;
+        if(this.signum() === -1) array[0] += 0x80;
         return new Uint8Array(array);
     }
 
@@ -56,7 +63,7 @@ export class LongInt {
             array[0] -= 0x80;
             array.splice(0, 0, 1);
         }
-        if(this.int.isNegative()) array[0] += 0x40;
+        if(this.signum() === -1) array[0] += 0x40;
         array[array.length - 1] += 0x80;
         return new Uint8Array(array);
     }

--- a/src/IonLongInt.ts
+++ b/src/IonLongInt.ts
@@ -14,7 +14,7 @@
 
 import * as bigInt from "./BigInteger.js";
 import { BigInteger } from "./BigInteger";
-
+import { _sign } from "./util";
 
 export class LongInt {
     private int : BigInteger;
@@ -29,7 +29,7 @@ export class LongInt {
                 this.int = bigInt(s);
             }
         } else if(typeof input === 'number') {
-            if (input === 0 && (1 / input) === -Infinity) {
+            if (input === 0 && _sign(input) === -1) {
                 // this ensures this.int.sign is correct for -0:
                 this.int = bigInt(0).negate();
             } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+export function _sign(x: number): number {
+    return (x < 0 || (x === 0 && (1 / x) === -Infinity)) ? -1 : 1
+}
+

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -22,6 +22,7 @@ define({
     'tests/unit/IonCatalogTest',
     'tests/unit/IonImportTest',
     'tests/unit/IonLocalSymbolTableTest',
+    'tests/unit/IonLongIntTest',
     'tests/unit/IonDecimalTest',
     'tests/unit/IonWriteableTest',
     'tests/unit/IonTimestampTest',

--- a/tests/unit/IonLongIntTest.js
+++ b/tests/unit/IonLongIntTest.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+define([
+      'intern',
+      'intern!object',
+      'intern/chai!assert',
+      'dist/amd/es6/IonLongInt',
+    ],
+    function(intern, registerSuite, assert, li) {
+        registerSuite({
+            name: 'LongInt',
+
+             '0': () => test(0, false, 1),
+             '1': () => test(1, false, 1),
+            '-1': () => test(-1, true, -1),
+            '-0': () => test(-0, true, -1),
+
+              '"0"': () => test("0", false, 1),
+              '"1"': () => test("1", false, 1),
+             '"-1"': () => test("-1", true, -1),
+             '"-0"': () => test("-0", true, -1),
+            '" -1"': () => test(" -1", true, -1),
+            '" -0"': () => test(" -0", true, -1),
+        });
+
+        function test(value, expectedSign, expectedSignum) {
+            let i = new li.LongInt(value);
+            assert.equal(i.int.sign, expectedSign);
+            assert.equal(i.signum(), expectedSignum);
+        }
+    }
+);
+

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -317,7 +317,6 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/clobWithNonAsciiCharacter.10n',
     'ion-tests/iontestdata/good/clobs.ion',
     'ion-tests/iontestdata/good/decimal64BitBoundary.ion',
-    'ion-tests/iontestdata/good/decimalNegativeOneDotTwoEight.ion',
     'ion-tests/iontestdata/good/decimalsWithUnderscores.ion',
     'ion-tests/iontestdata/good/equivs/bigInts.ion',
     'ion-tests/iontestdata/good/equivs/binaryInts.ion',
@@ -387,12 +386,6 @@ let eventSkipList = toSkipList([
     'ion-tests/iontestdata/good/timestamp/timestamps.ion',
     'ion-tests/iontestdata/good/utf16.ion',
     'ion-tests/iontestdata/good/utf32.ion',
-    'ion-tests/iontestdata/good/decimalNegativeZeroDot.10n',
-    'ion-tests/iontestdata/good/decimalNegativeZeroDotZero.10n',
-    'ion-tests/iontestdata/good/decimal_zeros.ion',
-    'ion-tests/iontestdata/good/equivs/zeroDecimals.ion',
-    'ion-tests/iontestdata/good/non-equivs/decimals.ion',
-    'ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion',
     'ion-tests/iontestdata/good/non-equivs/nonNulls.ion',
     'ion-tests/iontestdata/good/nonNulls.ion',
 
@@ -400,7 +393,6 @@ let eventSkipList = toSkipList([
 ]);
 
 let readerCompareSkipList = toSkipList([
-    'ion-tests/iontestdata/good/decimal_zeros.ion',
     'ion-tests/iontestdata/good/subfieldInt.ion',
     'ion-tests/iontestdata/good/subfieldUInt.ion',
     'ion-tests/iontestdata/good/subfieldVarInt.ion',


### PR DESCRIPTION
Addresses the following issues related to Decimal coefficients and exponents with value -0:
- third-party `BigInteger.sign` is supposed to be `true` for negative numbers, but sign is `false` for `BigInteger(-0)` and `BigInteger('-0')`;  constructing `BigInteger(0)` and calling `negate()` achieves the desired behavior
- `BinaryWriter.writeDecimal()` was producing an unnecessary byte when the coefficient is (+)0
- `BinaryWriter.writeDecimal()` special case for `0d0` was also (incorrectly) catching decimals with a 0 coefficient but _non-zero_ exponent 
- `Decimal.stringValue()` wasn't including `-` for negative coefficients and exponents

Resolves #289 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
