### PR TITLE
aligns Decimal's compareTo() and equals() contracts with those of ion-java

### DIFF
--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -12,7 +12,8 @@
  * language governing permissions and limitations under the License.
  */
 
-import { LongInt } from "./IonLongInt";
+import {LongInt} from "./IonLongInt";
+import {_sign} from "./util";
 
 /**
  * This class provides the additional semantics necessary for decimal values.
@@ -36,16 +37,28 @@ export class Decimal {
         this._exponent = exponent;
     }
 
+    /**
+     * Returns true if this Decimal is negative; otherwise false.
+     */
     isNegative() : boolean {
         return this._coefficient.signum() === -1;
     }
 
+    /**
+     * Returns a number representing the value of this Decimal.  Note that
+     * some Decimal (base-10) values cannot be precisely expressed in
+     * JavaScript's base-2 number type.
+     */
     numberValue(): number {
         return this._coefficient.numberValue() * Math.pow(10, this._exponent);
     }
 
-    // based on the algorithm defined in https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+    /**
+     * Returns a string representation of this Decimal, using exponential
+     * notation when appropriate.
+     */
     toString(): string {
+        // based on the algorithm defined in https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
         let cStr = Math.abs(this._coefficient.numberValue())+'';
         let precision = cStr.length;
         let adjustedExponent = this._exponent + (precision - 1);
@@ -82,98 +95,91 @@ export class Decimal {
         return this._exponent;
     }
 
-    equals(dec : Decimal) : boolean {
-        return this.compare(dec) === 0;
+    /**
+     * Compares this Decimal with another and returns true if they are
+     * equivalent in value and precision; otherwise returns false.
+     * Note that this differs from compareTo(), which doesn't require
+     * precision to match when returning 0.
+     */
+    equals(that : Decimal) : boolean {
+        return this._getExponent() === that._getExponent()
+            && _sign(this._getExponent()) === _sign(that._getExponent())
+            && this.isNegative() === that.isNegative()
+            && this._getCoefficient().equals(that._getCoefficient());
     }
 
-    compare(dec : Decimal) : number {
-        let neg = this.isNegative();
-        if(neg !== dec.isNegative()) return neg ? -1 : 1;
-        //were the same sign
-        //compare order to normalize exponents.
-        let leftDigits = this._coefficient.toString();
-        let leftLength = leftDigits.length;
-        let rightDigits = dec._coefficient.toString();
-        let rightLength = rightDigits.length;
-        let leftOrder = leftLength + this._exponent;
-        let rightOrder = rightLength + dec._exponent;
-        if (leftOrder > rightOrder) {
-            if (neg) {
-                return -1;
-            } else {
-                return 1;
-            }
-        } else if(leftOrder < rightOrder) {
-            if (neg) {
-                1;
-            } else {
-                -1;
-            }
-        } else {
-            //we have two decimals of the same size(including exponents) and sign, need to compare the actual values
-            if(leftDigits < rightDigits) {
-                //shift the smaller left value to the same number of digits as our right.
-                let shift = rightLength - leftLength;
-                let textShift = '';
-                while (shift > 0) {
-                    textShift = textShift + '0';
-                    shift--;
-                }
-                leftDigits = leftDigits + textShift;
-            } else if(leftDigits > rightDigits) {
-                //shift the smaller right value to the same number of digits as our left.
-                let shift = leftLength - rightLength;
-                let textShift = '';
-                while (shift > 0) {
-                    textShift = textShift + '0';
-                    shift--;
-                }
-                rightDigits = rightDigits + textShift;
-            } else {
-                //number of digits is the same
-                //no op?
-            }
-            let left = new LongInt(leftDigits);
-            let right = new LongInt(rightDigits);
-            if (left.lessThan(right)) {
-                //left is smaller
-                if(neg) {
-                    //left is greaterThan when smaller and negative
-                    return 1;
-                } else {
-                    //left is lessThan when larger and negative
-                    return -1;
-                }
-            } else if(left.greaterThan(right)){
-                //right is smaller
-                if(neg) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            } else {
-                return 0;
-            }
+    /**
+     * Compares this Decimal with another and returns -1, 0, or 1 if this
+     * Decimal is less than, equal to, or greater than the other Decimal.
+     *
+     * Note that a return value of 0 doesn't guarantee that equals() would
+     * return true, as compareTo() doesn't require the values to have the
+     * same precision to be considered equal, whereas equals() does.
+     * Additionally, compareTo() treats 0. and -0. as equal, but equals()
+     * does not.
+     */
+    compareTo(that : Decimal) : number {
+        if (this._coefficient.numberValue() === 0
+                && that._getCoefficient().numberValue() === 0) {
+            return 0;
         }
+
+        let neg = this.isNegative();
+        if (neg !== that.isNegative()) {
+            return neg ? -1 : 1;
+        }
+
+        // decimals have the same sign; compare magnitudes
+        let thisCoefficientStr = this._coefficient.toString();
+        let thisPrecision = thisCoefficientStr.length;
+        let thisMagnitude = thisPrecision + this._exponent;
+
+        let thatCoefficientStr = that._coefficient.toString();
+        let thatPrecision = thatCoefficientStr.length;
+        let thatMagnitude = thatPrecision + that._exponent;
+
+        if (thisMagnitude > thatMagnitude) {
+            return neg ? -1 : 1;
+        } else if (thisMagnitude < thatMagnitude) {
+            return neg ? 1 : -1;
+        }
+
+        // decimals have the same sign and magnitude; append zeros so comparison is
+        // independent of precision
+        if (thisCoefficientStr.length < thatCoefficientStr.length) {
+            thisCoefficientStr += '0'.repeat(thatPrecision - thisPrecision);
+        } else if (thisCoefficientStr.length > thatCoefficientStr.length) {
+            thatCoefficientStr += '0'.repeat(thisPrecision - thatPrecision);
+        }
+
+        let thisLongInt = new LongInt(thisCoefficientStr);
+        let thatLongInt = new LongInt(thatCoefficientStr);
+        if (thisLongInt.greaterThan(thatLongInt)) {
+            return neg ? -1 : 1;
+        } else if(thisLongInt.lessThan(thatLongInt)){
+            return neg ? 1 : -1;
+        }
+
+        return 0;
     }
 
-    DataModelequals(expected : Decimal) : boolean {
-        return this._getExponent() === expected._getExponent()
-            && this.isNegative() === expected.isNegative()
-            && this._getCoefficient().equals(expected._getCoefficient());
-    }
-
+    /**
+     * Given a string containing the Ion text representation of a decimal value,
+     * returns a new Decimal object corresponding to the value.  If a string such as
+     * '5' is provided, a 'd0' suffix is assumed.
+     */
     static parse(str: string) : Decimal {
         let exponent = 0;
         if (str === 'null' || str === 'null.decimal') return null;
         let d = str.match('[d|D]');
         let f = str.match('\\.');
+
         let exponentDelimiterIndex = str.length;
-        if(d) {
+        if (d) {
             exponent = Number(str.substring(d.index + 1, str.length));
             exponentDelimiterIndex = d.index;
         }
-        if(f) {
+        if (f) {
             let exponentShift = d ? (d.index - 1) - f.index : (str.length - 1) - f.index;
             return new Decimal(new LongInt(str.substring(0, f.index) + str.substring(f.index + 1, exponentDelimiterIndex)), exponent - exponentShift);
         } else {

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -296,7 +296,7 @@ class IonDecimalEvent extends AbstractIonEvent {
 
     }
     valueEquals(expected : IonDecimalEvent) : boolean {
-        return expected instanceof IonDecimalEvent && this.ionValue.DataModelequals(expected.ionValue);
+        return expected instanceof IonDecimalEvent && this.ionValue.equals(expected.ionValue);
     }
     writeIonValue(writer : Writer) : void {
         writer.writeDecimal(this.ionValue);

--- a/tests/unit/IonDecimalTest.js
+++ b/tests/unit/IonDecimalTest.js
@@ -54,18 +54,72 @@ define([
       '123456.0'  : () => test('123456.0', '1234560', -1, 123456.0, '123456.0'),
       '1234560d-1': () => test('1234560d-1', '1234560', -1, 123456.0, '123456.0'),
 
-      'compare()' : () => {
-        // this first assertion should fail;  2.1 and 2.10 are not equivalent
-        assert.equal(ion.Decimal.parse('2.1').compare(ion.Decimal.parse('2.10')), 0);
-        assert.equal(ion.Decimal.parse('2.15').compare(ion.Decimal.parse('2.10')), 1);
-        assert.equal(ion.Decimal.parse('2.1').compare(ion.Decimal.parse('2.15')), -1);
-        assert.equal(ion.Decimal.parse('2.5d1').compare(ion.Decimal.parse('25')), 0);
-        assert.equal(ion.Decimal.parse('25').compare(ion.Decimal.parse('2.1d1')), 1);
-        assert.equal(ion.Decimal.parse('.00005').compare(ion.Decimal.parse('0.05d-10')), 1);
-      },
-      // TBD:  'equals': () => { this.skip() },
-      // TBD:  'DataModelequals': () => { this.skip() },
-      // TBD:  'parse': () => { this.skip() },
+      'compareTo(0, 0)'               : () => testCompareTo('0', '0', 0),
+      'compareTo(0, 0d0)'             : () => testCompareTo('0', '0d0', 0),
+      'compareTo(0, 0d1)'             : () => testCompareTo('0', '0d1', 0),
+      'compareTo(0, 0d-1)'            : () => testCompareTo('0', '0d-1', 0),
+      'compareTo(0, 0d-0)'            : () => testCompareTo('0', '0d-0', 0),
+
+      'compareTo(-0, -0)'             : () => testCompareTo('-0', '-0', 0),
+      'compareTo(-0, -0d0)'           : () => testCompareTo('-0', '-0d0', 0),
+      'compareTo(-0, -0d1)'           : () => testCompareTo('-0', '-0d1', 0),
+      'compareTo(-0, -0d-1)'          : () => testCompareTo('-0', '-0d-1', 0),
+      'compareTo(-0, -0d-0)'          : () => testCompareTo('-0', '-0d-0', 0),
+
+      'compareTo(0, -0)'              : () => testCompareTo('0', '-0', 0),
+      'compareTo(0, -0d0)'            : () => testCompareTo('0', '-0d0', 0),
+      'compareTo(0, -0d1)'            : () => testCompareTo('0', '-0d1', 0),
+      'compareTo(0, -0d-1)'           : () => testCompareTo('0', '-0d-1', 0),
+      'compareTo(0, -0d-0)'           : () => testCompareTo('0', '-0d-0', 0),
+
+      'compareTo(0d-0, 0d-0)'         : () => testCompareTo('0d-0', '0d-0', 0),
+      'compareTo(-0d-0, -0d-0)'       : () => testCompareTo('-0d-0', '-0d-0', 0),
+
+      'compareTo(2.1, 2.1)'           : () => testCompareTo('2.1', '2.1', 0),
+      'compareTo(2.1, 2.10)'          : () => testCompareTo('2.1', '2.10', 0),
+      'compareTo(2.1, 2.11)'          : () => testCompareTo('2.1', '2.11', -1),
+      'compareTo(2.11, 2.10)'         : () => testCompareTo('2.11', '2.10', 1),
+      'compareTo(2.1d1, 21)'          : () => testCompareTo('2.1d1', '21', 0),
+      'compareTo(22, 2.1d1)'          : () => testCompareTo('22', '2.1d1', 1),
+      'compareTo(123d-101, 123d-100)' : () => testCompareTo('123d-101', '123d-100', -1),
+      'compareTo(123d-100, 123d-100)' : () => testCompareTo('123d-100', '123d-100', 0),
+      'compareTo(123d-99, 123d-100)'  : () => testCompareTo('123d-99', '123d-100', 1),
+      'compareTo(123d99, 123d100)'    : () => testCompareTo('123d99', '123d100', -1),
+      'compareTo(123d100, 123d100)'   : () => testCompareTo('123d100', '123d100', 0),
+      'compareTo(123d101, 123d100)'   : () => testCompareTo('123d101', '123d100', 1),
+
+
+      'equals(0, 0)':         () => testEquals('0', '0', true),
+      'equals(0, 0d0)':       () => testEquals('0', '0d0', true),
+      'equals(0, 0d1)':       () => testEquals('0', '0d1', false),
+      'equals(0, 0d-1)':      () => testEquals('0', '0d-1', false),
+      'equals(0, 0d-0)':      () => testEquals('0', '0d-0', false),
+
+      'equals(-0, -0)':       () => testEquals('-0', '-0', true),
+      'equals(-0, -0d0)':     () => testEquals('-0', '-0d0', true),
+      'equals(-0, -0d1)':     () => testEquals('-0', '-0d1', false),
+      'equals(-0, -0d-1)':    () => testEquals('-0', '-0d-1', false),
+      'equals(-0, -0d-0)':    () => testEquals('-0', '-0d-0', false),
+
+      'equals(0, -0)':        () => testEquals('0', '-0', false),
+      'equals(0, -0d0)':      () => testEquals('0', '-0d0', false),
+      'equals(0, -0d1)':      () => testEquals('0', '-0d1', false),
+      'equals(0, -0d-1)':     () => testEquals('0', '-0d-1', false),
+      'equals(0, -0d-0)':     () => testEquals('0', '-0d-0', false),
+
+      'equals(0d-0, 0d-0)':   () => testEquals('0d-0', '0d-0', true),
+      'equals(-0d-0, -0d-0)': () => testEquals('-0d-0', '-0d-0', true),
+
+      'equals(1, 1)':         () => testEquals('1', '1', true),
+      'equals(1, 2)':         () => testEquals('1', '2', false),
+      'equals(2.1, 2.10)':    () => testEquals('2.1', '2.10', false),
+
+      'equals(10000000000000000.00000000000000001, 10000000000000000.00000000000000001)': () =>
+          testEquals('10000000000000000.00000000000000001', '10000000000000000.00000000000000001', true),
+      'equals(10000000000000000.00000000000000001, 10000000000000000.00000000000000002)': () =>
+          testEquals('10000000000000000.00000000000000001', '10000000000000000.00000000000000002', false),
+      'equals(10000000000000000.00000000000000000, 10000000000000000.0000000000000000)': () =>
+          testEquals('10000000000000000.00000000000000000', '10000000000000000.0000000000000000', false),
     });
 
     function test(decimalString,
@@ -88,6 +142,20 @@ define([
         assert.equal(util._sign(decimal.numberValue()), util._sign(expectedNumberValue), 'numberValue sign');
 
         assert.equal(decimal.toString(), expectedToString, 'toString()');
+    }
+
+    function testEquals(decimalString1, decimalString2, expected) {
+      let dec1 = ion.Decimal.parse(decimalString1);
+      let dec2 = ion.Decimal.parse(decimalString2);
+      assert.equal(dec1.equals(dec2), expected);
+      assert.equal(dec2.equals(dec1), expected);
+    }
+
+    function testCompareTo(decimalString1, decimalString2, expected) {
+      let dec1 = ion.Decimal.parse(decimalString1);
+      let dec2 = ion.Decimal.parse(decimalString2);
+      assert.equal(dec1.compareTo(dec2), expected);
+      assert.equal(dec2.compareTo(dec1), -expected);
     }
   }
 );


### PR DESCRIPTION
Proposed changes update Decimal's compareTo() and equals() methods to follow the behavior found in ion-java's Decimal class.  Also adds some minimal API documentation.

Resolves #295 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
