### PR TITLE
adds Writer.writeValues() to transfer the contents of a reader to a writer

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -11,18 +11,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { Decimal } from "./IonDecimal";
-import { encodeUtf8 } from "./IonUnicode";
-import { Import } from "./IonImport";
-import { LocalSymbolTable } from "./IonLocalSymbolTable";
-import { LongInt } from "./IonLongInt";
-import { LowLevelBinaryWriter } from "./IonLowLevelBinaryWriter";
-import { Precision } from "./IonPrecision";
-import { Timestamp } from "./IonTimestamp";
-import { TypeCodes } from "./IonBinary";
-import { Writeable } from "./IonWriteable";
-import { Writer } from "./IonWriter";
-import { _sign } from "./util";
+import {Decimal} from "./IonDecimal";
+import {encodeUtf8} from "./IonUnicode";
+import {Import} from "./IonImport";
+import {LocalSymbolTable} from "./IonLocalSymbolTable";
+import {LongInt} from "./IonLongInt";
+import {LowLevelBinaryWriter} from "./IonLowLevelBinaryWriter";
+import {Precision} from "./IonPrecision";
+import {Reader} from "./IonReader";
+import {Timestamp} from "./IonTimestamp";
+import {TypeCodes} from "./IonBinary";
+import {Writeable} from "./IonWriteable";
+import {Writer} from "./IonWriter";
+import {_sign, _writeValues} from "./util";
 
 const MAJOR_VERSION: number = 1;
 const MINOR_VERSION: number = 0;
@@ -439,6 +440,10 @@ export class BinaryWriter implements Writer {
     this.writeFieldName('max_id');
     this.writeInt(import_.length);
     this.endContainer();
+  }
+
+  writeValues(reader: Reader, writer: Writer): void {
+    _writeValues(reader, this);
   }
 }
 

--- a/src/IonPrettyTextWriter.ts
+++ b/src/IonPrettyTextWriter.ts
@@ -12,10 +12,13 @@
  * language governing permissions and limitations under the License.
  */
 
-import { State, TextWriter } from "./IonTextWriter";
-import { Writeable } from "./IonWriteable";
-import { TypeCodes } from "./IonBinary";
-import { CharCodes } from "./IonText";
+import {State, TextWriter} from "./IonTextWriter";
+import {Writeable} from "./IonWriteable";
+import {TypeCodes} from "./IonBinary";
+import {CharCodes} from "./IonText";
+import {Reader} from "./IonReader";
+import {_writeValues} from "./util";
+import {Writer} from "./IonWriter";
 type Serializer<T> = (value: T) => void;
 /*
  * This class and functionality carry no guarantees of correctness or support.
@@ -200,5 +203,9 @@ export class PrettyTextWriter extends TextWriter {
                 }
             }
         }
+    }
+
+    writeValues(reader: Reader, writer: Writer): void {
+        _writeValues(reader, this);
     }
 }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -24,11 +24,12 @@ import {
     ClobEscapes,
     is_keyword
 } from "./IonText";
+import {Reader} from "./IonReader";
 import {Timestamp} from "./IonTimestamp";
 import {TypeCodes} from "./IonBinary";
 import {Writeable} from "./IonWriteable";
 import {Writer} from "./IonWriter";
-import {_sign} from "./util";
+import {_sign, _writeValues} from "./util";
 
 type Serializer<T> = (value: T) => void;
 
@@ -405,5 +406,9 @@ export class TextWriter implements Writer {
         } else {
             this.writeUtf8(s);
         }
+    }
+
+    writeValues(reader: Reader, writer: Writer): void {
+        _writeValues(reader, this);
     }
 }

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -11,9 +11,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { Decimal } from "./IonDecimal";
-import { Timestamp } from "./IonTimestamp";
-import { TypeCodes } from "./IonBinary";
+import {Decimal} from "./IonDecimal";
+import {Reader} from "./IonReader";
+import {Timestamp} from "./IonTimestamp";
+import {TypeCodes} from "./IonBinary";
 
 /**
  * Writes values in the Ion text or binary formats.
@@ -38,4 +39,11 @@ export interface Writer {
 
   close() : void;
   endContainer() : void;
+
+  /**
+   * Writes a reader's current value and all following values until the end
+   * of the current container.  If there's no current value then this method
+   * calls {@link next()} to get started.
+   */
+  writeValues(reader: Reader, writer: Writer) : void;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,60 @@
  * language governing permissions and limitations under the License.
  */
 
+import {IonTypes} from "./IonTypes";
+import {IonType} from "./IonType";
+import {Reader as IonReader} from "./IonReader";
+import {Writer as IonWriter} from "./IonWriter";
+
+/**
+ * Returns -1 if x is negative (including -0); otherwise returns 1.
+ */
 export function _sign(x: number): number {
     return (x < 0 || (x === 0 && (1 / x) === -Infinity)) ? -1 : 1
+}
+
+/**
+ * Writes a reader's current value and all following values until the end
+ * of the current container.  If there's no current value then this method
+ * calls Reader.next() to get started.
+ */
+export function _writeValues(reader: IonReader, writer: IonWriter, _depth = 0): void {
+    let type: IonType = reader.type();
+    if (type === null) {
+        type = reader.next();
+    }
+    while (type !== null) {
+        if (_depth > 0) {
+            if (reader.fieldName() != null) {
+                writer.writeFieldName(reader.fieldName());
+            }
+        }
+        if (reader.isNull()) {
+            writer.writeNull(type.bid, reader.annotations());
+        } else {
+            switch (type) {
+                case IonTypes.BOOL:      writer.writeBoolean(reader.booleanValue(), reader.annotations()); break;
+                case IonTypes.INT:       writer.writeInt(reader.numberValue(), reader.annotations()); break;
+                case IonTypes.FLOAT:     writer.writeFloat64(reader.numberValue(), reader.annotations()); break;
+                case IonTypes.DECIMAL:   writer.writeDecimal(reader.decimalValue(), reader.annotations()); break;
+                case IonTypes.TIMESTAMP: writer.writeTimestamp(reader.timestampValue(), reader.annotations()); break;
+                case IonTypes.SYMBOL:    writer.writeSymbol(reader.stringValue(), reader.annotations()); break;
+                case IonTypes.STRING:    writer.writeString(reader.stringValue(), reader.annotations()); break;
+                case IonTypes.CLOB:      writer.writeClob(reader.byteValue(), reader.annotations()); break;
+                case IonTypes.BLOB:      writer.writeBlob(reader.byteValue(), reader.annotations()); break;
+                case IonTypes.LIST:      writer.writeList(reader.annotations()); break;
+                case IonTypes.SEXP:      writer.writeSexp(reader.annotations()); break;
+                case IonTypes.STRUCT:    writer.writeStruct(reader.annotations()); break;
+                default: throw new Error('Unrecognized type ' + (type !== null ? type.name : type));
+            }
+            if (type.container) {
+                reader.stepIn();
+                _writeValues(reader, writer, _depth + 1);
+                writer.endContainer();
+                reader.stepOut();
+            }
+        }
+        type = reader.next();
+    }
 }
 

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -35,5 +35,6 @@ define({
     'tests/unit/IonBinaryWriterTest',
     'tests/unit/IonBinaryTimestampTest',
     'tests/unit/IonTextReaderTest',
+    'tests/unit/utilTest',
   ],
 });

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -78,7 +78,7 @@ define([
         function readerCompareTest(source) {
             function toBytes(source, writer) {
                 let reader = ion.makeReader(source);
-                writeTo(reader, writer);
+                writer.writeValues(reader);
                 writer.close();
                 return writer.getBytes();
             }
@@ -154,42 +154,6 @@ define([
             assert(r1.type() !== undefined, 'type() is undefined');
             assert.equal(r1.type(), type, "type() doesn't match expected type");
             assert.equal(r1.type(), r2.type(), "types don't match");
-        }
-
-        // TBD:  move this (or equivalent code) to a public API (pending addition of IonReader.type())
-        function writeTo(reader, writer, depth = 0) {
-            for (let type; type = reader.next(); ) {
-                if (depth > 0) {
-                    if (reader.fieldName() != undefined) {
-                        writer.writeFieldName(reader.fieldName());
-                    }
-                }
-                if (reader.isNull()) {
-                    writer.writeNull(type.bid, reader.annotations());
-                } else {
-                    switch (type) {
-                        case ion.IonTypes.BOOL:      writer.writeBoolean(reader.booleanValue(), reader.annotations()); break;
-                        case ion.IonTypes.INT:       writer.writeInt(reader.numberValue(), reader.annotations()); break;
-                        case ion.IonTypes.FLOAT:     writer.writeFloat64(reader.numberValue(), reader.annotations()); break;
-                        case ion.IonTypes.DECIMAL:   writer.writeDecimal(reader.decimalValue(), reader.annotations()); break;
-                        case ion.IonTypes.TIMESTAMP: writer.writeTimestamp(reader.timestampValue(), reader.annotations()); break;
-                        case ion.IonTypes.SYMBOL:    writer.writeSymbol(reader.stringValue(), reader.annotations()); break;
-                        case ion.IonTypes.STRING:    writer.writeString(reader.stringValue(), reader.annotations()); break;
-                        case ion.IonTypes.CLOB:      writer.writeClob(reader.byteValue(), reader.annotations()); break;
-                        case ion.IonTypes.BLOB:      writer.writeBlob(reader.byteValue(), reader.annotations()); break;
-                        case ion.IonTypes.LIST:      writer.writeList(reader.annotations()); break;
-                        case ion.IonTypes.SEXP:      writer.writeSexp(reader.annotations()); break;
-                        case ion.IonTypes.STRUCT:    writer.writeStruct(reader.annotations()); break;
-                        default: throw new Error('Unrecognized type' + type);
-                    }
-                    if (type.container) {
-                        reader.stepIn();
-                        writeTo(reader, writer, depth + 1);
-                        writer.endContainer();
-                        reader.stepOut();
-                    }
-                }
-            }
         }
 
         function getInput(path){

--- a/tests/unit/utilTest.js
+++ b/tests/unit/utilTest.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+define([
+    'intern',
+    'intern!object',
+    'intern/chai!assert',
+    'dist/amd/es6/IonTests',
+    'dist/amd/es6/util',
+  ],
+  function(intern, registerSuite, assert, ion, util) {
+    registerSuite({
+      name: 'util',
+
+      '_sign(-1)': () => assert.equal(util._sign(-1), -1),
+      '_sign(-0)': () => assert.equal(util._sign(-0), -1),
+      '_sign(0)' : () => assert.equal(util._sign(0), 1),
+      '_sign(1)' : () => assert.equal(util._sign(1), 1),
+
+      '_writeValues(), reader.type() == null': () => {
+        let expected = 'abc::{a:a::true,b:b::[two::2,three::3e3,'
+            + 'sexp::(four::4d4 five::2019T six::hello seven::"hello" eight::{{"hello"}}'
+            + ' nine::{{aGVsbGA=}})],c:c::null.symbol,d:d::null.null}';
+        let reader = ion.makeReader(expected);
+        assert.isNull(reader.type());
+        let writer = ion.makeTextWriter();
+        util._writeValues(reader, writer);
+        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), expected);
+      },
+      '_writeValues(), reader.type() != null': () => {
+        let expected = 'abc::{a:a::true,b:b::[two::2,three::3e3,'
+            + 'sexp::(four::4d4 five::2019T six::hello seven::"hello" eight::{{"hello"}}'
+            + ' nine::{{aGVsbGA=}})],c:c::null.symbol,d:d::null.null}';
+        let reader = ion.makeReader(expected);
+        reader.next();
+        assert.isNotNull(reader.type());
+        testWriteValues(reader, expected);
+      },
+      '_writeValues(), datagram': () => {
+        let expected = '1\n2\n3';
+        let reader = ion.makeReader(expected);
+        assert.isNull(reader.type());
+        testWriteValues(reader, expected);
+      },
+      '_writeValues(), start within container': () => {
+        let s = 'abc::{a:a::1,b:b::[two::2,three::3,sexp::(four::4)],c:c::null.symbol}';
+        let reader = ion.makeReader(s);
+        reader.next();
+        reader.stepIn();
+        testWriteValues(reader, 'a::1\nb::[two::2,three::3,sexp::(four::4)]\nc::null.symbol');
+        reader.stepOut();
+      },
+    });
+
+    function testWriteValues(reader, expected) {
+      let writer = ion.makeTextWriter();
+      util._writeValues(reader, writer);
+      assert.equal(String.fromCharCode.apply(null, writer.getBytes()), expected);
+    }
+  }
+);
+


### PR DESCRIPTION
This PR removes the `writeTo()` function from tests/unit/iontests.js in favor of a new `Writer.writeValues()` method.

Resolves #284 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
