### PR TITLE
Added tests for annotations and corrected writeValues signature.

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -417,8 +417,8 @@ export class BinaryWriter implements Writer {
     this.stepOut();
   }
 
-  writeValues(reader: Reader, writer: Writer): void {
-    _writeValues(reader, this);
+  writeValues(reader: Reader, depth: number = 0): void {
+    _writeValues(reader, this, depth);
   }
 }
 

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -417,8 +417,8 @@ export class BinaryWriter implements Writer {
     this.stepOut();
   }
 
-  writeValues(reader: Reader, depth: number = 0): void {
-    _writeValues(reader, this, depth);
+  writeValues(reader: Reader): void {
+    _writeValues(reader, this);
   }
 }
 

--- a/src/IonPrettyTextWriter.ts
+++ b/src/IonPrettyTextWriter.ts
@@ -165,7 +165,7 @@ export class PrettyTextWriter extends TextWriter {
         }
     }
 
-    writeValues(reader: Reader, writer: Writer): void {
-        _writeValues(reader, this);
+    writeValues(reader: Reader, depth: number = 0): void {
+        _writeValues(reader, this, depth);
     }
 }

--- a/src/IonPrettyTextWriter.ts
+++ b/src/IonPrettyTextWriter.ts
@@ -165,7 +165,7 @@ export class PrettyTextWriter extends TextWriter {
         }
     }
 
-    writeValues(reader: Reader, depth: number = 0): void {
-        _writeValues(reader, this, depth);
+    writeValues(reader: Reader): void {
+        _writeValues(reader, this);
     }
 }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -370,7 +370,9 @@ export class TextWriter implements Writer {
         }
     }
 
-    writeValues(reader: Reader, depth: number = 0): void {
+    writeValues(reader: Reader): void {
+        let depth = 0;
+        if (this.currentContainer.state == State.STRUCT_FIELD) depth++;
         _writeValues(reader, this, depth);
     }
 }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -370,7 +370,7 @@ export class TextWriter implements Writer {
         }
     }
 
-    writeValues(reader: Reader, writer: Writer): void {
-        _writeValues(reader, this);
+    writeValues(reader: Reader, depth: number = 0): void {
+        _writeValues(reader, this, depth);
     }
 }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -371,8 +371,6 @@ export class TextWriter implements Writer {
     }
 
     writeValues(reader: Reader): void {
-        let depth = 0;
-        if (this.currentContainer.state == State.STRUCT_FIELD) depth++;
-        _writeValues(reader, this, depth);
+        _writeValues(reader, this);
     }
 }

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -43,5 +43,5 @@ export interface Writer {
    * of the current container.  If there's no current value then this method
    * calls {@link next()} to get started.
    */
-  writeValues(reader: Reader, writer: Writer) : void;
+  writeValues(reader: Reader, _depth?: number) : void;
 }

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -43,5 +43,5 @@ export interface Writer {
    * of the current container.  If there's no current value then this method
    * calls {@link next()} to get started.
    */
-  writeValues(reader: Reader, _depth?: number) : void;
+  writeValues(reader: Reader) : void;
 }

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -36,5 +36,6 @@ define({
     'tests/unit/IonBinaryTimestampTest',
     'tests/unit/IonTextReaderTest',
     'tests/unit/utilTest',
+    'tests/unit/IonAnnotationsTest'
   ],
 });

--- a/tests/unit/IonAnnotationsTest.js
+++ b/tests/unit/IonAnnotationsTest.js
@@ -76,7 +76,7 @@ define([
         reader.stepIn();
         reader.next();
 
-        util._writeValue(reader, writer, 1);
+        writer.writeValues(reader, 1);
 
         reader.stepOut();
 

--- a/tests/unit/IonAnnotationsTest.js
+++ b/tests/unit/IonAnnotationsTest.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+define([
+  'intern!object',
+  'intern/chai!assert',
+  'dist/amd/es6/IonTests',
+  'dist/amd/es6/util',
+  ],
+  function(registerSuite, assert, ion, util) {
+      let suite = {
+          name: 'Annotations'
+      };
+
+      function readerToBytes(reader) {
+        let writer = ion.makeTextWriter();
+        writer.writeValues(reader);
+        writer.close();
+        return writer.getBytes();        
+      }
+
+      function readerToString(reader) {
+        return ion.decodeUtf8(readerToBytes(reader));
+      }
+
+      suite['Read annotations'] = function() {
+        let data = "a::b::123";
+        let reader = ion.makeReader(data);
+        reader.next();
+        assert.deepEqual(reader.annotations(), ['a', 'b']);
+        assert.equal(reader.value(), '123');
+        assert.equal(readerToString(reader), 'a::b::123');
+      };
+
+      suite['Create annotation'] = function() {
+        let data = "123";
+        let reader = ion.makeReader(data);
+        reader.next();
+        let writer = ion.makeTextWriter();
+        writer.writeInt(reader.numberValue(), ['a']);
+        reader.next();
+        writer.writeValues(reader);
+        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::123');
+      };
+
+      suite['Add annotation'] = function() {
+        let data = "a::b::123";
+        let reader = ion.makeReader(data);
+        reader.next();
+        let writer = ion.makeTextWriter();
+        writer.writeInt(reader.numberValue(), reader.annotations().concat('c'));
+        reader.next();
+        writer.writeValues(reader);
+        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::b::c::123');
+      };
+
+      suite['Wrap annotation'] = function() {
+        let data = "{ x: 1 }";
+        let reader = ion.makeReader(data);
+        let writer = ion.makeTextWriter();
+        writer.stepIn(ion.IonTypes.STRUCT);
+        writer.stepIn(ion.IonTypes.STRUCT, ['a', 'b']);
+
+        reader.next();
+        reader.stepIn();
+        reader.next();
+
+        util._writeValue(reader, writer, 1);
+
+        reader.stepOut();
+
+        writer.stepOut();
+        writer.stepOut();
+        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), '{a::b::{x:1}}');
+      }
+
+      registerSuite(suite);
+  }
+);

--- a/tests/unit/IonAnnotationsTest.js
+++ b/tests/unit/IonAnnotationsTest.js
@@ -76,7 +76,7 @@ define([
         reader.stepIn();
         reader.next();
 
-        writer.writeValues(reader, 1);
+        writer.writeValues(reader);
 
         reader.stepOut();
 

--- a/tests/unit/IonAnnotationsTest.js
+++ b/tests/unit/IonAnnotationsTest.js
@@ -69,20 +69,18 @@ define([
         let data = "{ x: 1 }";
         let reader = ion.makeReader(data);
         let writer = ion.makeTextWriter();
-        writer.stepIn(ion.IonTypes.STRUCT);
         writer.stepIn(ion.IonTypes.STRUCT, ['a', 'b']);
 
         reader.next();
         reader.stepIn();
         reader.next();
 
-        writer.writeValues(reader);
+        util._writeValues(reader, writer, 1);
 
         reader.stepOut();
 
         writer.stepOut();
-        writer.stepOut();
-        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), '{a::b::{x:1}}');
+        assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::b::{x:1}');
       }
 
       registerSuite(suite);


### PR DESCRIPTION
This adds a rudimentary test for reading and writing annotations. However the add part can't be right, I'm adding it to a reader. 

```js
        var data = "a::b::123";
        var reader = ion.makeReader(data);
        reader.next();
        reader.annotations().push('c');
```

What's the right way to add an annotation? How do I get to `IonValue#addTypeAnnotation`?

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
