### PR TITLE
removes TypeCodes from the public API in favor of IonTypes

### DIFF
--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -26,8 +26,6 @@ import { LocalSymbolTable, defaultLocalSymbolTable } from "./IonLocalSymbolTable
 import { IonEventStream } from "./IonEventStream";
 import { decodeUtf8 } from "./IonUnicode";
 
-
-
 const e = {
   name: "IonError",
   where: undefined,
@@ -62,22 +60,21 @@ function isBinary(buf: Uint8Array) {
 /**
  * Create an Ion Reader object from a currentBuffer `buf`
  *
- *
  * @param buf the Ion data to be used by the reader. Typically a string, UTF-8 encoded buffer (text), or raw binary buffer.
  * @param options for the reader including catalog
  * @returns {Reader}
  */
-    export function makeReader(buf: any, catalog? : Catalog) : Reader {
-        if((typeof buf) === "string"){
-            return new TextReader(new StringSpan(<string>buf), catalog);
-        }
-        buf = new Uint8Array(buf);
-        if(isBinary(buf)){
-            return new BinaryReader(new BinarySpan(buf), catalog);
-        } else {
-            return new TextReader(new StringSpan(decodeUtf8(buf)), catalog);
-        }
+export function makeReader(buf: any, catalog? : Catalog) : Reader {
+    if((typeof buf) === "string"){
+        return new TextReader(new StringSpan(<string>buf), catalog);
     }
+    buf = new Uint8Array(buf);
+    if(isBinary(buf)){
+        return new BinaryReader(new BinarySpan(buf), catalog);
+    } else {
+        return new TextReader(new StringSpan(decodeUtf8(buf)), catalog);
+    }
+}
 
 /**
  * Create a new Ion Text Writer.
@@ -115,6 +112,5 @@ export { Precision } from "./IonPrecision";
 export { SharedSymbolTable } from "./IonSharedSymbolTable";
 export { Timestamp } from "./IonTimestamp";
 export { toBase64 } from "./IonText";
-export { TypeCodes } from "./IonBinary";
 export { IonEventStream } from "./IonEventStream";
 export { decodeUtf8 } from "./IonUnicode";

--- a/src/IonBinary.ts
+++ b/src/IonBinary.ts
@@ -38,21 +38,3 @@ export const TB_SEXP          = 12;  // 0xc
 export const TB_STRUCT        = 13;  // 0xd
 export const TB_ANNOTATION    = 14;  // 0xe
 
-/** Four-bit type codes per http://amzn.github.io/ion-docs/binary.html#typed-value-formats */
-export enum TypeCodes {
-  NULL = 0,
-  BOOL = 1,
-  POSITIVE_INT = 2,
-  NEGATIVE_INT = 3,
-  FLOAT = 4,
-  DECIMAL = 5,
-  TIMESTAMP = 6,
-  SYMBOL = 7,
-  STRING = 8,
-  CLOB = 9,
-  BLOB = 10,
-  LIST = 11,
-  SEXP = 12,
-  STRUCT = 13,
-  ANNOTATION = 14,
-}

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -14,13 +14,14 @@
 import {Decimal} from "./IonDecimal";
 import {encodeUtf8} from "./IonUnicode";
 import {Import} from "./IonImport";
+import {IonTypes} from "./IonTypes";
+import {IonType} from "./IonType";
 import {LocalSymbolTable} from "./IonLocalSymbolTable";
 import {LongInt} from "./IonLongInt";
 import {LowLevelBinaryWriter} from "./IonLowLevelBinaryWriter";
 import {Precision} from "./IonPrecision";
 import {Reader} from "./IonReader";
 import {Timestamp} from "./IonTimestamp";
-import {TypeCodes} from "./IonBinary";
 import {Writeable} from "./IonWriteable";
 import {Writer} from "./IonWriter";
 import {_sign, _writeValues} from "./util";
@@ -45,6 +46,25 @@ enum States {
   STRUCT_VALUE,
   /** The writer is closed, no further operations may be performed */
   CLOSED,
+}
+
+/** Four-bit type codes per http://amzn.github.io/ion-docs/binary.html#typed-value-formats */
+enum TypeCodes {
+  NULL = 0,
+  BOOL = 1,
+  POSITIVE_INT = 2,
+  NEGATIVE_INT = 3,
+  FLOAT = 4,
+  DECIMAL = 5,
+  TIMESTAMP = 6,
+  SYMBOL = 7,
+  STRING = 8,
+  CLOB = 9,
+  BLOB = 10,
+  LIST = 11,
+  SEXP = 12,
+  STRUCT = 13,
+  ANNOTATION = 14,
 }
 
 /**
@@ -75,16 +95,16 @@ export class BinaryWriter implements Writer {
   writeBlob(value: Uint8Array, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.BLOB, annotations);
+      this.writeNull(IonTypes.BLOB, annotations);
       return;
     }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.BLOB, this.encodeAnnotations(annotations), value));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.BLOB, this.encodeAnnotations(annotations), value));
   }
 
   writeBoolean(value: boolean, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.BOOL, annotations);
+      this.writeNull(IonTypes.BOOL, annotations);
       return;
     }
 
@@ -94,17 +114,17 @@ export class BinaryWriter implements Writer {
   writeClob(value: Uint8Array, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.CLOB, annotations);//TODO this is wrong
+      this.writeNull(IonTypes.CLOB, annotations);
       return;
     }
 
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.CLOB, this.encodeAnnotations(annotations), value));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.CLOB, this.encodeAnnotations(annotations), value));
   }
 
   writeDecimal(value: Decimal | string, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.DECIMAL, annotations);
+      this.writeNull(IonTypes.DECIMAL, annotations);
       return;
     }
 
@@ -114,7 +134,7 @@ export class BinaryWriter implements Writer {
     let exponent: number = value._getExponent();
     if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
       // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal
-      this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.DECIMAL, this.encodeAnnotations(annotations), new Uint8Array(0)));
+      this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.DECIMAL, this.encodeAnnotations(annotations), new Uint8Array(0)));
       return;
     }
 
@@ -128,13 +148,13 @@ export class BinaryWriter implements Writer {
     if (writeCoefficient) {
       writer.writeBytes(coefficientBytes);
     }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.DECIMAL, this.encodeAnnotations(annotations), writer.getBytes()));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.DECIMAL, this.encodeAnnotations(annotations), writer.getBytes()));
   }
 
   writeFloat32(value: number, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.FLOAT, annotations);
+      this.writeNull(IonTypes.FLOAT, annotations);
       return;
     }
 
@@ -147,13 +167,13 @@ export class BinaryWriter implements Writer {
       dataview.setFloat32(0, value, false);
       bytes = new Uint8Array(buffer);
     }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.FLOAT, this.encodeAnnotations(annotations), bytes));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.FLOAT, this.encodeAnnotations(annotations), bytes));
   }
 
   writeFloat64(value: number, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.FLOAT, annotations);
+      this.writeNull(IonTypes.FLOAT, annotations);
       return;
     }
 
@@ -166,74 +186,58 @@ export class BinaryWriter implements Writer {
       dataview.setFloat64(0, value, false);
       bytes = new Uint8Array(buffer);
     }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.FLOAT, this.encodeAnnotations(annotations), bytes));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.FLOAT, this.encodeAnnotations(annotations), bytes));
   }
 
   writeInt(value: number, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.POSITIVE_INT, annotations);
+      this.writeNull(IonTypes.INT, annotations);
       return;
     }
 
-    let typeCode: TypeCodes;
-    let bytes: Uint8Array;
-    if (value === 0) {
-      typeCode = TypeCodes.POSITIVE_INT;
-      bytes = new Uint8Array(0);
-    } else if (value > 0) {
-      typeCode = TypeCodes.POSITIVE_INT;
-      let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(LowLevelBinaryWriter.getUnsignedIntSize(value)));
-      writer.writeUnsignedInt(value);
-      bytes = writer.getBytes();
-    } else {
-      typeCode = TypeCodes.NEGATIVE_INT;
-      let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(LowLevelBinaryWriter.getUnsignedIntSize(Math.abs(value))));
-      writer.writeUnsignedInt(Math.abs(value));
-      bytes = writer.getBytes();
-    }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), typeCode, this.encodeAnnotations(annotations), bytes));
+    this.addNode(new IntNode(this.writer, this.getCurrentContainer(), this.encodeAnnotations(annotations), value));
   }
 
   writeList(annotations?: string[], isNull: boolean = false) : void {
     this.checkWriteValue();
     if (isNull) {
-      this.writeNull(TypeCodes.LIST, annotations);
+      this.writeNull(IonTypes.LIST, annotations);
       return;
     }
 
-    this.addNode(new SequenceNode(this.writer, this.getCurrentContainer(), TypeCodes.LIST, this.encodeAnnotations(annotations)));
+    this.addNode(new SequenceNode(this.writer, this.getCurrentContainer(), IonTypes.LIST, this.encodeAnnotations(annotations)));
   }
 
-  writeNull(type_: TypeCodes = TypeCodes.NULL, annotations?: string[]) {
+  writeNull(type: IonType = IonTypes.NULL, annotations?: string[]) {
     this.checkWriteValue();
-    this.addNode(new NullNode(this.writer, this.getCurrentContainer(), type_, this.encodeAnnotations(annotations)));
+    this.addNode(new NullNode(this.writer, this.getCurrentContainer(), type, this.encodeAnnotations(annotations)));
   }
 
   writeSexp(annotations?: string[], isNull: boolean = false) : void {
     this.checkWriteValue();
     if (isNull) {
-      this.writeNull(TypeCodes.SEXP, annotations);
+      this.writeNull(IonTypes.SEXP, annotations);
       return;
     }
 
-    this.addNode(new SequenceNode(this.writer, this.getCurrentContainer(), TypeCodes.SEXP, this.encodeAnnotations(annotations)));
+    this.addNode(new SequenceNode(this.writer, this.getCurrentContainer(), IonTypes.SEXP, this.encodeAnnotations(annotations)));
   }
 
   writeString(value: string, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.STRING, annotations);
+      this.writeNull(IonTypes.STRING, annotations);
       return;
     }
 
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.STRING, this.encodeAnnotations(annotations), encodeUtf8(value)));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.STRING, this.encodeAnnotations(annotations), encodeUtf8(value)));
   }
 
   writeStruct(annotations?: string[], isNull: boolean = false) : void {
     this.checkWriteValue();
     if (isNull) {
-      this.writeNull(TypeCodes.STRUCT, annotations);
+      this.writeNull(IonTypes.STRUCT, annotations);
       return;
     }
 
@@ -244,19 +248,19 @@ export class BinaryWriter implements Writer {
   writeSymbol(value: string, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null) {
-        this.writeNull(TypeCodes.SYMBOL, annotations);
+        this.writeNull(IonTypes.SYMBOL, annotations);
     } else {
         let symbolId: number = this.symbolTable.addSymbol(value);
         let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(LowLevelBinaryWriter.getUnsignedIntSize(symbolId)));
         writer.writeUnsignedInt(symbolId);
-        this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.SYMBOL, this.encodeAnnotations(annotations), writer.getBytes()));
+        this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.SYMBOL, this.encodeAnnotations(annotations), writer.getBytes()));
     }
   }
 
   writeTimestamp(value: Timestamp, annotations?: string[]) : void {
     this.checkWriteValue();
     if (value === null || value === undefined) {
-      this.writeNull(TypeCodes.TIMESTAMP, annotations);
+      this.writeNull(IonTypes.TIMESTAMP, annotations);
       return;
     }
 
@@ -293,7 +297,7 @@ export class BinaryWriter implements Writer {
         writer.writeVariableLengthUnsignedInt(seconds.numberValue());
       }
     }
-    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), TypeCodes.TIMESTAMP, this.encodeAnnotations(annotations), writer.getBytes()));
+    this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.TIMESTAMP, this.encodeAnnotations(annotations), writer.getBytes()));
   }
 
   endContainer() {
@@ -458,7 +462,7 @@ export abstract class AbstractNode implements Node {
   protected constructor(
     private readonly _writer: LowLevelBinaryWriter,
     private readonly parent: Node,
-    private readonly _typeCode: TypeCodes,
+    private readonly _type: IonType,
     private readonly annotations: Uint8Array
   ) {}
 
@@ -533,7 +537,7 @@ export abstract class AbstractNode implements Node {
   }
 
   get typeCode() : number {
-    return this._typeCode;
+    return this._type.bid;
   }
 
   get writer() : LowLevelBinaryWriter {
@@ -548,8 +552,8 @@ export abstract class AbstractNode implements Node {
 }
 
 abstract class ContainerNode extends AbstractNode {
-  protected constructor(writer: LowLevelBinaryWriter, parent: Node, typeCode: TypeCodes, annotations: Uint8Array) {
-    super(writer, parent, typeCode, annotations);
+  protected constructor(writer: LowLevelBinaryWriter, parent: Node, type: IonType, annotations: Uint8Array) {
+    super(writer, parent, type, annotations);
   }
 
   isContainer() : boolean {
@@ -561,8 +565,8 @@ class SequenceNode extends ContainerNode {
   private children: Node[] = [];
   private length: number;
 
-  constructor(writer: LowLevelBinaryWriter, parent: Node, typeCode: TypeCodes, annotations: Uint8Array) {
-    super(writer, parent, typeCode, annotations);
+  constructor(writer: LowLevelBinaryWriter, parent: Node, type: IonType, annotations: Uint8Array) {
+    super(writer, parent, type, annotations);
   }
 
   addChild(child: Node, name?: Uint8Array): void {
@@ -603,7 +607,7 @@ class StructNode extends ContainerNode {
   private length: number;
 
   constructor(writer: LowLevelBinaryWriter, parent: Node, annotations: Uint8Array) {
-    super(writer, parent, TypeCodes.STRUCT, annotations);
+    super(writer, parent, IonTypes.STRUCT, annotations);
   }
 
   addChild(child: Node, fieldName?: Uint8Array) : void {
@@ -649,7 +653,7 @@ export abstract class LeafNode extends AbstractNode {
 
 class BooleanNode extends LeafNode {
   constructor(writer: LowLevelBinaryWriter, parent: Node, annotations: Uint8Array, private readonly value: boolean) {
-    super(writer, parent, TypeCodes.BOOL, annotations);
+    super(writer, parent, IonTypes.BOOL, annotations);
   }
 
   write() : void {
@@ -662,9 +666,43 @@ class BooleanNode extends LeafNode {
   }
 }
 
+class IntNode extends LeafNode {
+  private readonly intTypeCode: TypeCodes;
+  private readonly bytes: Uint8Array;
+
+  constructor(writer: LowLevelBinaryWriter, parent: Node, annotations: Uint8Array, private readonly value: number) {
+    super(writer, parent, IonTypes.INT, annotations);
+
+    if (this.value === 0) {
+      this.intTypeCode = TypeCodes.POSITIVE_INT;
+      this.bytes = new Uint8Array(0);
+    } else if (this.value > 0) {
+      this.intTypeCode = TypeCodes.POSITIVE_INT;
+      let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(LowLevelBinaryWriter.getUnsignedIntSize(this.value)));
+      writer.writeUnsignedInt(this.value);
+      this.bytes = writer.getBytes();
+    } else {
+      this.intTypeCode = TypeCodes.NEGATIVE_INT;
+      let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(LowLevelBinaryWriter.getUnsignedIntSize(Math.abs(this.value))));
+      writer.writeUnsignedInt(Math.abs(this.value));
+      this.bytes = writer.getBytes();
+    }
+  }
+
+  write() : void {
+    this.writeAnnotations();
+    this.writeTypeDescriptorAndLength(this.intTypeCode, false, this.bytes.length);
+    this.writer.writeBytes(this.bytes);
+  }
+
+  getValueLength() : number {
+    return this.bytes.length;
+  }
+}
+
 class BytesNode extends LeafNode {
-  constructor(writer: LowLevelBinaryWriter, parent: Node, typeCode: TypeCodes, annotations: Uint8Array, private readonly value: Uint8Array) {
-    super(writer, parent, typeCode, annotations);
+  constructor(writer: LowLevelBinaryWriter, parent: Node, type: IonType, annotations: Uint8Array, private readonly value: Uint8Array) {
+    super(writer, parent, type, annotations);
   }
 
   write() : void {
@@ -679,8 +717,8 @@ class BytesNode extends LeafNode {
 }
 
 export class NullNode extends LeafNode {
-  constructor(writer: LowLevelBinaryWriter, parent: Node, typeCode: TypeCodes, annotations: Uint8Array) {
-    super(writer, parent, typeCode, annotations);
+  constructor(writer: LowLevelBinaryWriter, parent: Node, type: IonType, annotations: Uint8Array) {
+    super(writer, parent, type, annotations);
   }
 
   write() : void {

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -17,7 +17,6 @@ import { Decimal } from "./IonDecimal";
 import { Timestamp } from "./IonTimestamp";
 import { IonType } from "./IonType";
 import { Writer } from "./IonWriter";
-import { TypeCodes } from "./IonBinary";
 import { TextWriter } from "./IonTextWriter";
 import { Writeable } from "./IonWriteable";
 import { BinaryWriter } from "./IonBinaryWriter";
@@ -100,7 +99,7 @@ abstract class AbstractIonEvent implements IonEvent {
 
     writeAnnotations(writer : Writer) {
         if(this.annotations === undefined){
-            writer.writeNull(TypeCodes.LIST);
+            writer.writeNull(IonTypes.LIST);
             return;
         }
         writer.writeList();
@@ -116,7 +115,7 @@ abstract class AbstractIonEvent implements IonEvent {
     }
 
     writeImportDescriptor(writer){
-        writer.writeNull(TypeCodes.STRUCT);
+        writer.writeNull(IonTypes.STRUCT);
         /* TODO implement shared symboltable introduction event callbacks to build import descriptor value for the event.
         writer.writeStruct();
         writer.writeFieldName('import_name');
@@ -246,7 +245,7 @@ class IonNullEvent extends AbstractIonEvent {
         return expected instanceof IonNullEvent && this.ionValue === expected.ionValue;
     }
     writeIonValue(writer : Writer) : void {
-        writer.writeNull(this.ionType.bid);
+        writer.writeNull(this.ionType);
     }
 }
 

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -69,7 +69,7 @@ export class IonEventStream {
                             writer.writeFloat64(tempEvent.ionValue, tempEvent.annotations);
                             break;
                         case IonTypes.NULL :
-                            writer.writeNull(tempEvent.ionType.bid, tempEvent.annotations);
+                            writer.writeNull(tempEvent.ionType, tempEvent.annotations);
                             break;
                         case IonTypes.TIMESTAMP :
                             writer.writeTimestamp(tempEvent.ionValue, tempEvent.annotations);

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -14,7 +14,7 @@
 import {Decimal} from "./IonDecimal";
 import {Reader} from "./IonReader";
 import {Timestamp} from "./IonTimestamp";
-import {TypeCodes} from "./IonBinary";
+import {IonType} from "./IonType";
 
 /**
  * Writes values in the Ion text or binary formats.
@@ -29,7 +29,7 @@ export interface Writer {
   writeFloat64(value: number, annotations?: string[]) : void;
   writeInt(value: number, annotations?: string[]) : void;
   writeList(annotations?: string[], isNull?: boolean) : void;
-  writeNull(type_: TypeCodes, annotations?: string[]) : void;
+  writeNull(type: IonType, annotations?: string[]) : void;
   writeSexp(annotations?: string[], isNull?: boolean) : void;
   writeString(value: string, annotations?: string[]) : void;
   writeStruct(annotations?: string[], isNull?: boolean) : void;

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,7 +54,7 @@ export function _writeValue(reader: IonReader, writer: IonWriter, _depth = 0): v
         }
     }
     if (reader.isNull()) {
-        writer.writeNull(type.bid, reader.annotations());
+        writer.writeNull(type, reader.annotations());
     } else {
         switch (type) {
             case IonTypes.BOOL:      writer.writeBoolean(reader.booleanValue(), reader.annotations()); break;

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -55,7 +55,7 @@ define([
       (writer) => { writer.writeBlob(null) },
         [0xaf]);
     writerTest('Writes null blob 2',
-      (writer) => { writer.writeNull(ion.TypeCodes.BLOB) },
+      (writer) => { writer.writeNull(ion.IonTypes.BLOB) },
         [0xaf]);
     writerTest('Writes blob with annotation',
       (writer) => { writer.writeBlob(new Uint8Array([1]), ['a']) },
@@ -102,7 +102,7 @@ define([
       (writer) => { writer.writeBoolean(undefined) },
         [0x1f]);
     writerTest('Writes null boolean by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.BOOL) },
+      (writer) => { writer.writeNull(ion.IonTypes.BOOL) },
         [0x1f]);
     writerTest('Writes boolean with annotations',
       (writer) => { writer.writeBoolean(true, ['a', 'b']) },
@@ -144,7 +144,7 @@ define([
       (writer) => { writer.writeClob() },
       [0x9f]);
     writerTest('Writes null clob by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.CLOB) },
+      (writer) => { writer.writeNull(ion.IonTypes.CLOB) },
       [0x9f]);
     writerTest('Writes clob with annotation',
       (writer) => { writer.writeClob(new Uint8Array([1, 2, 3]), ['foo']) },
@@ -185,7 +185,7 @@ define([
       (writer) => { writer.writeDecimal() },
         [0x5f]);
     writerTest('Writes null decimal by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.DECIMAL) },
+      (writer) => { writer.writeNull(ion.IonTypes.DECIMAL) },
         [0x5f]);
     writerTest('Writes implicitly positive zero decimal as single byte',
       (writer) => { writer.writeDecimal(ion.Decimal.parse("0")) },
@@ -197,7 +197,7 @@ define([
       (writer) => { writer.writeDecimal(ion.Decimal.parse("-0")) },
         [0x52, 0x80, 0x80]);
     writerTest('Writes null decimal with annotation',
-      (writer) => { writer.writeNull(ion.TypeCodes.DECIMAL, ['a']) },
+      (writer) => { writer.writeNull(ion.IonTypes.DECIMAL, ['a']) },
         [
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
         0xe3, 0x81, 0x8a, 0x5f
@@ -215,7 +215,7 @@ define([
     // Floats
 
     writerTest("Writes null float by direct call",
-      (writer) => { writer.writeNull(ion.TypeCodes.FLOAT) },
+      (writer) => { writer.writeNull(ion.IonTypes.FLOAT) },
         [0x4f]);
 
     // 32-bit floats
@@ -269,11 +269,8 @@ define([
       (writer) => { writer.writeInt() },
         [0x2f]);
     writerTest('Writes null positive int by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.POSITIVE_INT) },
+      (writer) => { writer.writeNull(ion.IonTypes.INT) },
         [0x2f]);
-    writerTest('Writes null negative int by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.NEGATIVE_INT) },
-        [0x3f]);
     writerTest('Writes int +0',
       (writer) => { writer.writeInt(0) },
         [0x20]);
@@ -293,10 +290,10 @@ define([
       (writer) => { writer.writeList(null, true); },
         [0xbf]);
     writerTest('Writes null list by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.LIST) },
+      (writer) => { writer.writeNull(ion.IonTypes.LIST) },
         [0xbf]);
     writerTest('Writes null list with annotation',
-      (writer) => { writer.writeNull(ion.TypeCodes.LIST, ['a']) },
+      (writer) => { writer.writeNull(ion.IonTypes.LIST, ['a']) },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -387,7 +384,7 @@ define([
     // Nulls
 
     writerTest('Writes explicit null',
-      (writer) => { writer.writeNull(ion.TypeCodes.NULL) },
+      (writer) => { writer.writeNull(ion.IonTypes.NULL) },
         [0x0f]);
     writerTest('Writes implicit null',
       (writer) => { writer.writeNull() },
@@ -399,10 +396,10 @@ define([
       (writer) => { writer.writeSexp(null, true) },
         [0xcf]);
     writerTest('Writes null sexp by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.SEXP) },
+      (writer) => { writer.writeNull(ion.IonTypes.SEXP) },
         [0xcf]);
     writerTest('Writes null sexp with annotation',
-      (writer) => { writer.writeNull(ion.TypeCodes.SEXP, ['a']) },
+      (writer) => { writer.writeNull(ion.IonTypes.SEXP, ['a']) },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -428,7 +425,7 @@ define([
       (writer) => { writer.writeString() },
         [0x8f]);
     writerTest('Writes null string by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.STRING) },
+      (writer) => { writer.writeNull(ion.IonTypes.STRING) },
         [0x8f]);
     writerTest('Writes two top-level strings one with annotation',
       (writer) => { writer.writeString("foo"); writer.writeString("bar", ['a']) },
@@ -475,9 +472,9 @@ define([
       (writer) => {
         writer.writeStruct();
         writer.writeFieldName('a');
-        writer.writeNull(ion.TypeCodes.NULL);
+        writer.writeNull(ion.IonTypes.NULL);
         writer.writeFieldName('a');
-        writer.writeNull(ion.TypeCodes.NULL);
+        writer.writeNull(ion.IonTypes.NULL);
         writer.endContainer();
       },
         [
@@ -639,7 +636,7 @@ define([
       (writer) => { writer.writeSymbol() },
         [0x7f]);
     writerTest('Writes null symbol by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.SYMBOL) },
+      (writer) => { writer.writeNull(ion.IonTypes.SYMBOL) },
         [0x7f]);
     writerTest('Writes symbol with identical annotation',
       (writer) => { writer.writeSymbol('a', ['a']) },
@@ -667,7 +664,7 @@ define([
       (writer) => { writer.writeTimestamp() },
         [0x6f]);
     writerTest('Writes null timestamp by direct call',
-      (writer) => { writer.writeNull(ion.TypeCodes.TIMESTAMP) },
+      (writer) => { writer.writeNull(ion.IonTypes.TIMESTAMP) },
         [0x6f]);
     writerTest('Writes 2000-01-01T12:34:56.789 with year precision',
       (writer) => { writer.writeTimestamp(new ion.Timestamp(ion.Precision.YEAR, 0, 2000, 1, 1, 12, 34, 56.789)) },
@@ -841,7 +838,7 @@ define([
     suite['Calculates node lengths correctly'] = function() {
       var writeable = new ion.Writeable();
       var writer = new ion.LowLevelBinaryWriter(writeable);
-      var node = new ion.NullNode(writer, null, ion.TypeCodes.LIST, [10 | 0x80]);
+      var node = new ion.NullNode(writer, null, ion.IonTypes.LIST, [10 | 0x80]);
       assert.equal(node.getAnnotatedContainerLength(), 3);
       assert.equal(node.getAnnotationsLength(), 3);
       assert.equal(node.getLength(), 4);

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -85,7 +85,7 @@
       writer => writer.writeBlob(),
       'null.blob');
     writerTest('Writes null blob using type',
-      writer => writer.writeNull(ion.TypeCodes.BLOB),
+      writer => writer.writeNull(ion.IonTypes.BLOB),
       'null.blob');
     writerTest('Writes blob with identifier annotations',
       writer => writer.writeBlob([1, 2, 3], ['foo', 'bar']),
@@ -109,7 +109,7 @@
       writer => writer.writeBoolean(),
       'null.bool');
     writerTest('Writes null boolean using type',
-      writer => writer.writeNull(ion.TypeCodes.BOOL),
+      writer => writer.writeNull(ion.IonTypes.BOOL),
       'null.bool');
     writerTest('Writes boolean with annotations',
       writer => writer.writeBoolean(true, ['abc', '123']),
@@ -127,7 +127,7 @@
       writer => writer.writeClob(),
       'null.clob'); 
     writerTest('Writes null clob using type',
-      writer => writer.writeNull(ion.TypeCodes.CLOB),
+      writer => writer.writeNull(ion.IonTypes.CLOB),
       'null.clob'); 
     writerTest('Writes clob with annotations',
       writer => writer.writeClob(['A'.charCodeAt(0)], ['baz', 'qux']),
@@ -155,7 +155,7 @@
       writer => writer.writeDecimal(),
       'null.decimal');
     writerTest('Writes null decimal using type',
-      writer => writer.writeNull(ion.TypeCodes.DECIMAL),
+      writer => writer.writeNull(ion.IonTypes.DECIMAL),
       'null.decimal');
     writerTest('Writes decimal with annotations',
       writer => writer.writeDecimal(ion.Decimal.parse('123.456'), ['foo', 'bar']),
@@ -194,7 +194,7 @@
       writer => writer.writeInt(),
       'null.int');
     writerTest('Writes null using type',
-      writer => writer.writeNull(ion.TypeCodes.POSITIVE_INT),
+      writer => writer.writeNull(ion.IonTypes.INT),
       'null.int');
 
     // Lists
@@ -225,19 +225,19 @@
       // Nulls
 
       writerTest('Writes null',
-          writer => writer.writeNull(ion.TypeCodes.NULL),
+          writer => writer.writeNull(ion.IonTypes.NULL),
           'null.null');
       writerTest('Writes null with annotations',
-          writer => writer.writeNull(ion.TypeCodes.NULL, ['foo', 'bar']),
+          writer => writer.writeNull(ion.IonTypes.NULL, ['foo', 'bar']),
           'foo::bar::null.null');
 
     // Nulls
 
     writerTest('Writes null',
-      writer => writer.writeNull(ion.TypeCodes.NULL),
+      writer => writer.writeNull(ion.IonTypes.NULL),
       'null.null');
     writerTest('Writes null with annotations',
-      writer => writer.writeNull(ion.TypeCodes.NULL, ['foo', 'bar']),
+      writer => writer.writeNull(ion.IonTypes.NULL, ['foo', 'bar']),
       'foo::bar::null.null');
 
     // S-Expressions
@@ -246,7 +246,7 @@
           writer => writer.writeSexp(),
           '()');
       writerTest('Writes null sexp',
-          writer => writer.writeNull(ion.TypeCodes.SEXP),
+          writer => writer.writeNull(ion.IonTypes.SEXP),
           'null.sexp');
       writerTest('Writes empty sexp with annotations',
           writer => writer.writeSexp(['foo', 'bar']),
@@ -375,7 +375,7 @@
         writer.writeFieldName('symbol');
         writer.writeSymbol('symbol', ['a5']);
         writer.writeFieldName('symbol');
-        writer.writeNull(ion.TypeCodes.SYMBOL);
+        writer.writeNull(ion.IonTypes.SYMBOL);
         writer.writeFieldName('timestamp');
         writer.writeTimestamp(ion.Timestamp.parse('2017-04-03T00:00:00.000Z'), ['a8']);
         writer.writeFieldName('decimal');
@@ -399,9 +399,9 @@
         writer.endContainer();
         writer.writeFieldName('sexp');
         writer.writeSexp(['a23']);
-        writer.writeNull(ion.TypeCodes.SYMBOL, ['a24']);
-        writer.writeNull(ion.TypeCodes.STRING, ['a25']);
-        writer.writeNull(ion.TypeCodes.NULL, ['a26']);
+        writer.writeNull(ion.IonTypes.SYMBOL, ['a24']);
+        writer.writeNull(ion.IonTypes.STRING, ['a25']);
+        writer.writeNull(ion.IonTypes.NULL, ['a26']);
         writer.endContainer();
       },
         `a1::{


### PR DESCRIPTION
Localizes TypeCodes to IonBinaryWriter.ts.  Biggest hiccup was `BinaryWriter.writeInt()` which writes a different T value for positive/negative ints.

This change removes the ability to write a negative null.int (`0x3f`) and the associated unit test.  I'd suggest we revisit if/when someone demonstrates a need to do so.

Resolves #309.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
