### PR TITLE
Fix: IonTextReader.next returns null

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -124,7 +124,7 @@ export class TextReader implements Reader {
 
   next() {
     this._raw = undefined;
-    if (this._raw_type === EOF) return undefined;
+    if (this._raw_type === EOF) return null;
 
     let should_skip: boolean =
     this._raw_type !== BEGINNING_OF_CONTAINER

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -79,6 +79,8 @@ define(
 
             assert.equal(ionReader.fieldName(), "key");
             assert.equal(ionReader.value(), "string");
+
+            assert.isNull(ionReader.next());
         };
 
         suite['Parse through struct can skip over container'] = function() {
@@ -102,6 +104,8 @@ define(
 
             assert.equal(ionReader.fieldName(), "key2");
             assert.equal(ionReader.value(), "string2");
+
+            assert.isNull(ionReader.next());
         };
 
         suite['Parse through struct can skip over nested containers'] = function() {
@@ -124,8 +128,64 @@ define(
             ionReader.next();
 
             assert.equal(ionReader.fieldName(), "innerkey2");
+
+            assert.isNull(ionReader.next());
         };
 
+        suite['Reads an array'] = function() {
+            var ionToRead = "{ key : ['v1', 'v2'] }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
+
+            assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+            ionReader.stepIn(); // Step into the base struct.
+            ionReader.next();
+
+            assert.equal(ionReader.fieldName(), "key");
+
+            ionReader.stepIn(); // Step into the array.
+
+            ionReader.next();
+            assert.equal(ionReader.value(), "v1");
+
+            ionReader.next();
+            assert.equal(ionReader.value(), "v2");
+
+            assert.isNull(ionReader.next());
+        };
+
+        suite['Reads a nested array'] = function() {
+            var ionToRead = "{ key : [['v1', 'v2']] }";
+            var ionReader = ion.makeReader(ionToRead);
+            ionReader.next();
+
+            assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+            ionReader.stepIn(); // Step into the base struct.
+            ionReader.next();
+
+            assert.equal(ionReader.fieldName(), "key");
+
+            ionReader.stepIn(); // Step into the outer array.            
+            ionReader.next();
+            ionReader.stepIn(); // Step into the inner array.
+
+            ionReader.next();
+            assert.equal(ionReader.value(), "v1");
+
+            ionReader.next();
+            assert.equal(ionReader.value(), "v2");
+
+            assert.isNull(ionReader.next());
+        };
+        
+        suite['Returns null on EOF'] = function() {
+            var ionToRead = "";
+            var ionReader = ion.makeReader(ionToRead);
+            assert.isNull(ionReader.next());
+            assert.isNull(ionReader.next()); // EOF
+        };
 
         suite['text IVM'] = function() {
             var textReader = ion.makeReader("");


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/amzn/ion-js/issues/328

*Description of changes:*

Fixes `IonTextReader.next()` to return null fon EOF as the other scenarios for `next()`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
