### PR TITLE
Removed LongInt from public API.

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -130,15 +130,15 @@ export class BinaryWriter implements Writer {
 
     if (typeof value == 'string') value = Decimal.parse(value);
 
-    let isPositiveZero: boolean = value.numberValue() === 0 && !value.isNegative();
     let exponent: number = value._getExponent();
+    let coefficient: LongInt = value._getCoefficient();
+    let isPositiveZero: boolean = coefficient.isZero() && !value.isNegative();
     if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
       // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal
       this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.DECIMAL, this.encodeAnnotations(annotations), new Uint8Array(0)));
       return;
     }
 
-    let coefficient: LongInt = value._getCoefficient();
     let writeCoefficient = !(coefficient.isZero() && coefficient.signum() === 1);  // no need to write a coefficient of 0
     let coefficientBytes: Uint8Array | null = writeCoefficient ? coefficient.intBytes() : null;
 

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -23,18 +23,31 @@ export class Decimal {
     private _coefficient: LongInt;
     private _exponent: number;
 
-    public static readonly ZERO : Decimal = new Decimal(new LongInt(0), 0);
+    public static readonly ZERO : Decimal = new Decimal(0, 0);
     public static ONE = new Decimal(1, 0);
 
-    constructor(coefficient: LongInt | number, exponent: number) {
-        if (typeof coefficient === "number") {
-            if (!Number.isInteger(coefficient)) {
-                throw new Error("The provided coefficient was not an integer. (" + coefficient + ")");
-            }
-            this._coefficient = new LongInt(coefficient);
-        } else {
-            this._coefficient = coefficient;
+    constructor(coefficient: number, exponent: number) {
+        if (!Number.isInteger(coefficient)) {
+            throw new Error("The provided coefficient was not an integer. (" + coefficient + ")");
         }
+        this._initialize(new LongInt(coefficient), exponent);
+    }
+
+    /**
+     * Allows a Decimal to be constructed using a coefficient of arbitrary size without exposing the LongInt class
+     * as part of the public API.
+     */
+    static _fromLongIntCoefficient(coefficient: LongInt, exponent: number) {
+        let value = Object.create(this.prototype);
+        value._initialize(coefficient, exponent);
+        return value;
+    }
+
+    /**
+     * Constructor helper shared by the public constructor and _fromLongIntCoefficient
+     */
+    private _initialize(coefficient: LongInt, exponent: number) {
+        this._coefficient = coefficient;
         this._exponent = exponent;
     }
 
@@ -120,8 +133,8 @@ export class Decimal {
      * does not.
      */
     compareTo(that : Decimal) : number {
-        if (this._coefficient.numberValue() === 0
-            && that._getCoefficient().numberValue() === 0) {
+        if (this._coefficient.isZero()
+            && that._getCoefficient().isZero()) {
             return 0;
         }
 
@@ -212,9 +225,9 @@ export class Decimal {
         let f  = str.match('\\.');
         if (f) {
             let exponentShift = d ? (d.index - 1) - f.index : (str.length - 1) - f.index;
-            return new Decimal(new LongInt(str.substring(0, f.index) + str.substring(f.index + 1, exponentDelimiterIndex)), exponent - exponentShift);
+            return Decimal._fromLongIntCoefficient(new LongInt(str.substring(0, f.index) + str.substring(f.index + 1, exponentDelimiterIndex)), exponent - exponentShift);
         } else {
-            return new Decimal(new LongInt(str.substring(0, exponentDelimiterIndex)), exponent);
+            return Decimal._fromLongIntCoefficient(new LongInt(str.substring(0, exponentDelimiterIndex)), exponent);
         }
     }
 }

--- a/tests/unit/iontests.js
+++ b/tests/unit/iontests.js
@@ -344,6 +344,16 @@ let goodSkipList = toSkipList([
     'ion-tests/iontestdata/good/symbolZero.ion',
     'ion-tests/iontestdata/good/utf16.ion',
     'ion-tests/iontestdata/good/utf32.ion',
+
+    // Support for reading LongInts was removed as part of: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
+    'ion-tests/iontestdata/good/intBigSize1201.10n',
+    'ion-tests/iontestdata/good/intBigSize13.10n',
+    'ion-tests/iontestdata/good/intBigSize14.10n',
+    'ion-tests/iontestdata/good/intBigSize16.10n',
+    'ion-tests/iontestdata/good/intBigSize256.10n',
+    'ion-tests/iontestdata/good/intLongMaxValuePlusOne.10n',
+    'ion-tests/iontestdata/good/intLongMinValue.10n',
 ]);
 
 let badSkipList = toSkipList([
@@ -466,6 +476,9 @@ let equivsSkipList = toSkipList([
     'ion-tests/iontestdata/good/equivs/timestampsLargeFractionalPrecision.ion',
     'ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion',
     'ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion',
+
+    // See: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
 ]);
 
 let nonEquivsSkipList = toSkipList([
@@ -473,6 +486,9 @@ let nonEquivsSkipList = toSkipList([
     'ion-tests/iontestdata/good/non-equivs/floats.ion',
     'ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion',
     'ion-tests/iontestdata/good/non-equivs/timestamps.ion',
+
+    // See: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/non-equivs/ints.ion',
 ]);
 
 ////// end of generated skiplists


### PR DESCRIPTION
*Issue #, if available:* #310, #210 

*Description of changes:*
* Created a new static factory method `Decimal#_fromLongIntCoefficient` that accepts a `LongInt` coefficient instead of a `Number`.
* Reading a binary integer that requires more than 31 bits to store will throw an `Error`.
* Added 10 tests (all related to reading large ints) to the skip lists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
