### PR TITLE
Cleans up build and adds tsconfig for TypeScript compiler.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,33 +65,14 @@ module.exports = function(grunt) {
       }
     },
     ts: {
-      'amd-es6-debug': {
-        src: ['src/**/*.ts'],
-        outDir: 'dist/amd/es6',
-        options: {
-          target: "es6",
-          module: "amd",
-          declaration: true
-        }
+      'es6-es6': {
+        tsconfig: 'tsconfig.json'
       },
-
       'amd-es6': {
-        src: ['src/**/*.ts'],
-        outDir: 'dist/amd/es6',
-        options: {
-          target: "es6",
-          module: "amd",
-          declaration: true
-        }
+        tsconfig: 'tsconfig.amd.json'
       },
       'commonjs-es6': {
-        src: ['src/**/*.ts'],
-        outDir: 'dist/commonjs/es6',
-        options: {
-          target: "es6",
-          module: "commonjs",
-          declaration: true
-        }
+        tsconfig: 'tsconfig.commonjs.json'
       }
     },
       /**
@@ -120,12 +101,22 @@ module.exports = function(grunt) {
       bigInt: {
         files: [
           {
-            src: ['BigInteger.js','./src/BigInteger.d.ts'],
-            dest: 'dist/commonjs/es6/'
+            expand: true,
+            src: ['BigInteger.js', 'src/BigInteger.d.ts'],
+            dest: 'dist/es6/es6/',
+            flatten: true
           },
           {
+            expand: true,
             src: ['BigInteger.js','./src/BigInteger.d.ts'],
-            dest: 'dist/amd/es6/'
+            dest: 'dist/commonjs/es6/',
+            flatten: true
+          },
+          {
+            expand: true,
+            src: ['BigInteger.js','./src/BigInteger.d.ts'],
+            dest: 'dist/amd/es6/',
+            flatten: true
           }
         ]
       }
@@ -214,10 +205,12 @@ module.exports = function(grunt) {
   // Build and Translation tasks 
   grunt.registerTask('build:browser', ['build', 'browserify:prod', 'uglify']); // standalone for browser
   grunt.registerTask('trans:browser', ['browserify:prod', 'uglify']); // browserify (assumes 'build' was run)
+  grunt.registerTask('build:es6', ['ts:es6-es6']);
   grunt.registerTask('build:cjs', ['ts:commonjs-es6']);
   grunt.registerTask('build:amd', ['ts:amd-es6']);
-  grunt.registerTask('build:amd:debug', ['ts:amd-es6-debug']);
-  grunt.registerTask('build', ['clean', 'build:amd', 'build:cjs', 'copy:bigInt', 'trans:browser', 'copy:all']);
+  grunt.registerTask('build', [
+      'clean', 'build:es6', 'build:amd', 'build:cjs', 'copy:bigInt', 'trans:browser', 'copy:all'
+  ]);
 
   // Tests
   grunt.registerTask('test', ['build', 'intern:es6']);     // build and test

--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ Or you could use the locally installed Grunt:
 $ ./node_modules/.bin/grunt release
 ```
 
+## Build Output
+
+The build above will compile the library into the `dist` directory.  This directory has subdirectories of
+the form `<module type>/<target ES version>`.  In general, we target ES6 and rely on polyfills to support earlier
+versions.
+
+* `dist/es6/es6` - Targets the ES6 module system and ES6
+* `dist/commonjs/es6` - Targets the CommonJS module system and ES6 
+* `dist/amd/es6` - Targets the AMD module system and ES6
+
+A distribution using `browserify` and `babelify` creates a browser friendly polyfilled distribution targeting ES6:
+at `dist/browser/js/ion-bundle.js`.
+
 # Contribute
 
 [CONTRIBUTE.md](CONTRIBUTE.md)

--- a/tsconfig.amd.json
+++ b/tsconfig.amd.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "amd",
+    "outDir": "dist/amd/es6"
+  }
+}

--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/commonjs/es6"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+// Base Typscript Compiler Configuration
+// Targets ES6 Module system and ES6 feature set.
+{
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/*.d.ts"
+  ],
+  "compilerOptions": {
+    "target": "es6",
+    "module": "es6",
+    "lib": ["es6"],
+    "declaration": true,
+    "inlineSources": true,
+    "sourceMap": true,
+    // TODO enable this to have stricter checking
+    "strict": false,
+    "rootDir": "src",
+    "outDir": "dist/es6/es6"
+  }
+}


### PR DESCRIPTION
* Adds a vanilla `tsconfig.json` that targets native ES6 modules.
* Adds extension `tsconfig*.json` for AMD and CommonJS targets.
* Reconfigures Grunt to use `tsconfig*.json` for `ts` targets.
* Fixes copy target in to put `BigInteger.d.ts` in the right place.
* Removes seemingly redundant `amd-debug` build target.
* Adds some README around the build distribution format.

Fixes #360

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
