### PR TITLE
adds Writer.addAnnotation() and .setAnnotations(), and removes annotations param from write*() and stepIn() methods

### DIFF
--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -13,7 +13,7 @@
  */
 import {Writer} from "./IonWriter";
 
-// @ts-ignore
+// @ts-ignore: 'AbstractWriter' is missing properties from type 'Writer'
 export abstract class AbstractWriter implements Writer {
     protected _annotations = [];
 

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import {Writer} from "./IonWriter";
+
+// @ts-ignore
+export abstract class AbstractWriter implements Writer {
+    protected _annotations = [];
+
+    addAnnotation(annotation: string): void {
+        this._annotations.push(annotation);
+    }
+
+    setAnnotations(annotations: string[]): void {
+        this._annotations = annotations;
+    }
+
+    protected _clearAnnotations(): void {
+        this._annotations = [];
+    }
+}
+

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -47,45 +47,46 @@ export class IonEventStream {
             if(tempEvent.fieldName !== null) {
                 writer.writeFieldName(tempEvent.fieldName);
             }
+            writer.setAnnotations(tempEvent.annotations);
             switch(tempEvent.eventType){
                 case IonEventType.SCALAR:
                     switch(tempEvent.ionType) {
                         case IonTypes.BOOL :
-                            writer.writeBoolean(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeBoolean(tempEvent.ionValue);
                             break;
                         case IonTypes.STRING:
-                            writer.writeString(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeString(tempEvent.ionValue);
                             break;
                         case IonTypes.SYMBOL :
-                            writer.writeSymbol(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeSymbol(tempEvent.ionValue);
                             break;
                         case IonTypes.INT :
-                            writer.writeInt(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeInt(tempEvent.ionValue);
                             break;
                         case IonTypes.DECIMAL :
-                            writer.writeDecimal(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeDecimal(tempEvent.ionValue);
                             break;
                         case IonTypes.FLOAT :
-                            writer.writeFloat64(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeFloat64(tempEvent.ionValue);
                             break;
                         case IonTypes.NULL :
-                            writer.writeNull(tempEvent.ionType, tempEvent.annotations);
+                            writer.writeNull(tempEvent.ionType);
                             break;
                         case IonTypes.TIMESTAMP :
-                            writer.writeTimestamp(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeTimestamp(tempEvent.ionValue);
                             break;
                         case IonTypes.CLOB :
-                            writer.writeClob(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeClob(tempEvent.ionValue);
                             break;
                         case IonTypes.BLOB :
-                            writer.writeBlob(tempEvent.ionValue, tempEvent.annotations);
+                            writer.writeBlob(tempEvent.ionValue);
                             break;
                         default :
                             throw new Error("unexpected type: " + tempEvent.ionType.name);
                     }
                     break;
                 case IonEventType.CONTAINER_START:
-                    writer.stepIn(tempEvent.ionType, tempEvent.annotations);
+                    writer.stepIn(tempEvent.ionType);
                     break;
                 case IonEventType.CONTAINER_END:
                     writer.stepOut();

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -20,21 +20,33 @@ import {Timestamp} from "./IonTimestamp";
  * Writes values in the Ion text or binary formats.
  */
 export interface Writer {
-  writeBlob(value: Uint8Array, annotations?: string[]) : void;
-  writeBoolean(value: boolean, annotations?: string[]) : void;
-  writeClob(value: Uint8Array, annotations?: string[]) : void;
-  writeDecimal(value: Decimal, annotations?: string[]) : void;
+  writeBlob(value: Uint8Array) : void;
+  writeBoolean(value: boolean) : void;
+  writeClob(value: Uint8Array) : void;
+  writeDecimal(value: Decimal) : void;
   writeFieldName(fieldName: string) : void;
-  writeFloat32(value: number, annotations?: string[]) : void;
-  writeFloat64(value: number, annotations?: string[]) : void;
-  writeInt(value: number, annotations?: string[]) : void;
-  writeNull(type: IonType, annotations?: string[]) : void;
-  writeString(value: string, annotations?: string[]) : void;
-  writeSymbol(value: string, annotations?: string[]) : void;
-  writeTimestamp(value: Timestamp, annotations?: string[]) : void;
-  stepIn(type: IonType, annotations?: string[]) : void;
+  writeFloat32(value: number) : void;
+  writeFloat64(value: number) : void;
+  writeInt(value: number) : void;
+  writeNull(type: IonType) : void;
+  writeString(value: string) : void;
+  writeSymbol(value: string) : void;
+  writeTimestamp(value: Timestamp) : void;
+  stepIn(type: IonType) : void;
   stepOut() : void;
   getBytes(): Uint8Array;
+
+  /**
+   * Adds an annotation to the list of annotations to be used when
+   * writing the next value.
+   */
+  addAnnotation(annotation: string) : void;
+
+  /**
+   * Specifies the list of annotations to be used when writing
+   * the next value.
+   */
+  setAnnotations(annotations: string[]) : void;
 
   close() : void;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -53,22 +53,23 @@ export function _writeValue(reader: IonReader, writer: IonWriter, _depth = 0): v
             writer.writeFieldName(reader.fieldName());
         }
     }
+    writer.setAnnotations(reader.annotations());
     if (reader.isNull()) {
-        writer.writeNull(type, reader.annotations());
+        writer.writeNull(type);
     } else {
         switch (type) {
-            case IonTypes.BOOL:      writer.writeBoolean(reader.booleanValue(), reader.annotations()); break;
-            case IonTypes.INT:       writer.writeInt(reader.numberValue(), reader.annotations()); break;
-            case IonTypes.FLOAT:     writer.writeFloat64(reader.numberValue(), reader.annotations()); break;
-            case IonTypes.DECIMAL:   writer.writeDecimal(reader.decimalValue(), reader.annotations()); break;
-            case IonTypes.TIMESTAMP: writer.writeTimestamp(reader.timestampValue(), reader.annotations()); break;
-            case IonTypes.SYMBOL:    writer.writeSymbol(reader.stringValue(), reader.annotations()); break;
-            case IonTypes.STRING:    writer.writeString(reader.stringValue(), reader.annotations()); break;
-            case IonTypes.CLOB:      writer.writeClob(reader.byteValue(), reader.annotations()); break;
-            case IonTypes.BLOB:      writer.writeBlob(reader.byteValue(), reader.annotations()); break;
-            case IonTypes.LIST:      writer.stepIn(IonTypes.LIST, reader.annotations()); break;
-            case IonTypes.SEXP:      writer.stepIn(IonTypes.SEXP, reader.annotations()); break;
-            case IonTypes.STRUCT:    writer.stepIn(IonTypes.STRUCT, reader.annotations()); break;
+            case IonTypes.BOOL:      writer.writeBoolean(reader.booleanValue()); break;
+            case IonTypes.INT:       writer.writeInt(reader.numberValue()); break;
+            case IonTypes.FLOAT:     writer.writeFloat64(reader.numberValue()); break;
+            case IonTypes.DECIMAL:   writer.writeDecimal(reader.decimalValue()); break;
+            case IonTypes.TIMESTAMP: writer.writeTimestamp(reader.timestampValue()); break;
+            case IonTypes.SYMBOL:    writer.writeSymbol(reader.stringValue()); break;
+            case IonTypes.STRING:    writer.writeString(reader.stringValue()); break;
+            case IonTypes.CLOB:      writer.writeClob(reader.byteValue()); break;
+            case IonTypes.BLOB:      writer.writeBlob(reader.byteValue()); break;
+            case IonTypes.LIST:      writer.stepIn(IonTypes.LIST); break;
+            case IonTypes.SEXP:      writer.stepIn(IonTypes.SEXP); break;
+            case IonTypes.STRUCT:    writer.stepIn(IonTypes.STRUCT); break;
             default: throw new Error('Unrecognized type ' + (type !== null ? type.name : type));
         }
         if (type.container) {

--- a/tests/unit/IonAnnotationsTest.js
+++ b/tests/unit/IonAnnotationsTest.js
@@ -48,7 +48,8 @@ define([
         let reader = ion.makeReader(data);
         reader.next();
         let writer = ion.makeTextWriter();
-        writer.writeInt(reader.numberValue(), ['a']);
+        writer.setAnnotations(['a']);
+        writer.writeInt(reader.numberValue());
         reader.next();
         writer.writeValues(reader);
         assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::123');
@@ -59,9 +60,9 @@ define([
         let reader = ion.makeReader(data);
         reader.next();
         let writer = ion.makeTextWriter();
-        writer.writeInt(reader.numberValue(), reader.annotations().concat('c'));
-        reader.next();
-        writer.writeValues(reader);
+        writer.setAnnotations(reader.annotations());
+        writer.addAnnotation('c');
+        writer.writeInt(reader.numberValue());
         assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::b::c::123');
       };
 
@@ -69,7 +70,8 @@ define([
         let data = "{ x: 1 }";
         let reader = ion.makeReader(data);
         let writer = ion.makeTextWriter();
-        writer.stepIn(ion.IonTypes.STRUCT, ['a', 'b']);
+        writer.setAnnotations(['a', 'b']);
+        writer.stepIn(ion.IonTypes.STRUCT);
 
         reader.next();
         reader.stepIn();
@@ -81,7 +83,7 @@ define([
 
         writer.stepOut();
         assert.equal(String.fromCharCode.apply(null, writer.getBytes()), 'a::b::{x:1}');
-      }
+      };
 
       registerSuite(suite);
   }

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -58,7 +58,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.BLOB) },
         [0xaf]);
     writerTest('Writes blob with annotation',
-      (writer) => { writer.writeBlob(new Uint8Array([1]), ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeBlob(new Uint8Array([1])) },
         [
         // '$ion_symbol_table'::
         0xe7,
@@ -105,7 +105,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.BOOL) },
         [0x1f]);
     writerTest('Writes boolean with annotations',
-      (writer) => { writer.writeBoolean(true, ['a', 'b']) },
+      (writer) => { writer.setAnnotations(['a', 'b']); writer.writeBoolean(true) },
         [
         // '$ion_symbol_table'::
         0xe9,
@@ -147,7 +147,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.CLOB) },
       [0x9f]);
     writerTest('Writes clob with annotation',
-      (writer) => { writer.writeClob(new Uint8Array([1, 2, 3]), ['foo']) },
+      (writer) => { writer.setAnnotations(['foo']); writer.writeClob(new Uint8Array([1, 2, 3])) },
         [
         // Symbol table
         // // '$ion_symbol_table'
@@ -197,7 +197,7 @@ define([
       (writer) => { writer.writeDecimal(ion.Decimal.parse("-0")) },
         [0x52, 0x80, 0x80]);
     writerTest('Writes null decimal with annotation',
-      (writer) => { writer.writeNull(ion.IonTypes.DECIMAL, ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeNull(ion.IonTypes.DECIMAL) },
         [
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
         0xe3, 0x81, 0x8a, 0x5f
@@ -227,7 +227,7 @@ define([
       (writer) => { writer.writeFloat32() },
         [0x4f]);
     writerTest("Writes null 32-bit float with annotation",
-      (writer) => { writer.writeFloat32(null, ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeFloat32(null) },
         [
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
         0xe3, 0x81, 0x8a, 0x4f
@@ -248,7 +248,7 @@ define([
       (writer) => { writer.writeFloat64() },
         [0x4f]);
     writerTest("Writes null 64-bit float with annotation",
-      (writer) => { writer.writeFloat64(null, ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeFloat64(null) },
         [
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
         0xe3, 0x81, 0x8a, 0x4f
@@ -278,7 +278,7 @@ define([
       (writer) => { writer.writeInt(123456) },
         [0x23, 0x01, 0xe2, 0x40]);
     writerTest('Writes int 123456 with annotations',
-      (writer) => { writer.writeInt(123456, ['a', 'b', 'c']) },
+      (writer) => { writer.setAnnotations(['a', 'b', 'c']); writer.writeInt(123456) },
         [
         0xeb, 0x81, 0x83, 0xd8, 0x87, 0xb6, 0x81, 'a'.charCodeAt(0), 0x81, 'b'.charCodeAt(0), 0x81, 'c'.charCodeAt(0),
         0xe8, 0x83, 0x8a, 0x8b, 0x8c, 0x23, 0x01, 0xe2, 0x40
@@ -290,7 +290,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.LIST) },
         [0xbf]);
     writerTest('Writes null list with annotation',
-      (writer) => { writer.writeNull(ion.IonTypes.LIST, ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeNull(ion.IonTypes.LIST) },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -329,7 +329,7 @@ define([
       },
         [0xb8, 0xb3, 0xb0, 0xb0, 0xb0, 0xb3, 0xb0, 0xb0, 0xb0]);
     writerTest('Writes list with annotation',
-      (writer) => { writer.stepIn(ion.IonTypes.LIST, ['a']); writer.stepOut() },
+      (writer) => { writer.setAnnotations(['a']); writer.stepIn(ion.IonTypes.LIST); writer.stepOut() },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -337,7 +337,7 @@ define([
         0xe3, 0x81, 0x8a, 0xb0,
       ]);
     writerTest('Writes nested list with annotation',
-      (writer) => { writer.stepIn(ion.IonTypes.LIST); writer.stepIn(ion.IonTypes.LIST, ['a']);
+      (writer) => { writer.stepIn(ion.IonTypes.LIST); writer.setAnnotations(['a']); writer.stepIn(ion.IonTypes.LIST);
                     writer.stepOut(); writer.stepOut() },
         [
         // Symbol table
@@ -353,7 +353,8 @@ define([
           writer.stepIn(ion.IonTypes.LIST);
             writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
-            writer.stepIn(ion.IonTypes.LIST, ['a']);
+            writer.setAnnotations(['a']);
+            writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
             writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
@@ -361,7 +362,8 @@ define([
           writer.stepIn(ion.IonTypes.LIST);
             writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
-            writer.stepIn(ion.IonTypes.LIST, ['b']);
+            writer.setAnnotations(['b']);
+            writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
             writer.stepIn(ion.IonTypes.LIST);
             writer.stepOut();
@@ -393,7 +395,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.SEXP) },
         [0xcf]);
     writerTest('Writes null sexp with annotation',
-      (writer) => { writer.writeNull(ion.IonTypes.SEXP, ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeNull(ion.IonTypes.SEXP) },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -422,7 +424,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.STRING) },
         [0x8f]);
     writerTest('Writes two top-level strings one with annotation',
-      (writer) => { writer.writeString("foo"); writer.writeString("bar", ['a']) },
+      (writer) => { writer.writeString("foo"); writer.setAnnotations(['a']); writer.writeString("bar") },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),
@@ -633,7 +635,7 @@ define([
       (writer) => { writer.writeNull(ion.IonTypes.SYMBOL) },
         [0x7f]);
     writerTest('Writes symbol with identical annotation',
-      (writer) => { writer.writeSymbol('a', ['a']) },
+      (writer) => { writer.setAnnotations(['a']); writer.writeSymbol('a') },
         [
         // Symbol table
         0xe7, 0x81, 0x83, 0xd4, 0x87, 0xb2, 0x81, 'a'.charCodeAt(0),

--- a/tests/unit/IonTextWriterTest.writeSymbolToken.js
+++ b/tests/unit/IonTextWriterTest.writeSymbolToken.js
@@ -40,7 +40,8 @@ define(
 
             writer.writeSymbol(s);        // symbol
 
-            writer.writeInt(5, [s]);      // annotation
+            writer.setAnnotations([s]);
+            writer.writeInt(5);      // annotation
 
             writer.stepIn(ion.IonTypes.STRUCT);
             writer.writeFieldName(s);     // fieldname


### PR DESCRIPTION
*Description of changes:*
Moves `annotation` from `Writer.write*()` methods to `setAnnotations()` and `addAnnotation()` methods in a new `AbstractWriter` base class.

Also removes vestigial `isNull` parameter from a couple `writeContainer` methods (in TextWriter and PrettyTextWriter).

Resolves #343 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
