### PR TITLE
forces local offset to -0 for year/month/day-precision timestamps; fixes binary reader for timestamps with year < 100

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -357,7 +357,9 @@ export class ParserBinaryRaw {
             fractionalSeconds = Decimal.parse(secondInt + '.' + fractionStr);
         }
 
-        let date = new Date(Date.UTC(year, month ? month - 1 : 0, day ? day : 1, hour ? hour : 0, minute ? minute : 0, secondInt ? secondInt : 0, 0));
+        let msSinceEpoch = Date.UTC(year, month ? month - 1 : 0, day ? day : 1, hour ? hour : 0, minute ? minute : 0, secondInt ? secondInt : 0, 0);
+        msSinceEpoch = Timestamp._adjustMsSinceEpochIfNeeded(year, msSinceEpoch);
+        let date = new Date(msSinceEpoch);
         return Timestamp._valueOf(date, offset, fractionalSeconds, precision);
     }
 

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -106,6 +106,10 @@ export class Timestamp {
             this._precision = TimestampPrecision.SECONDS;
         }
 
+        if (this._precision <= TimestampPrecision.DAY) {
+            this._localOffset = -0;    // force local offset to "unknown" for YEAR/MONTH/DAY precisions
+        }
+
         if (this._precision > TimestampPrecision.MONTH) {
             // check the days per month - first the general case, basically index into the next month
             // (which doesnt need +1 because we index from 1 to 12 unlike Date) and look at the day before which is indexed with 0.
@@ -221,6 +225,7 @@ export class Timestamp {
                 this._year, (this._precision === TimestampPrecision.YEAR ? 0 : this._month - 1), this._day,
                 this._hour, this._minutes, this.getSecondsInt(), ms);
 
+        msSinceEpoch = Timestamp._adjustMsSinceEpochIfNeeded(this._year, msSinceEpoch);
         if (this._year < 100) {
             // for a year < 100, JavaScript Date's default behavior automatically adds 1900;
             // this block compensates for that behavior
@@ -231,6 +236,20 @@ export class Timestamp {
 
         let offsetShiftMs = this._localOffset * 60 * 1000;
         return new Date(msSinceEpoch - offsetShiftMs);
+    }
+
+    /**
+     * For a year < 100, JavaScript Date's default behavior automatically adds 1900;
+     * this method compensates for that behavior
+     */
+    static _adjustMsSinceEpochIfNeeded(year: number, msSinceEpoch: number) : number {
+        if (year >= 100) {
+            return msSinceEpoch;
+        }
+
+        let date = new Date(msSinceEpoch);
+        date.setUTCFullYear(year);     // yes, we really do mean some year < 100
+        return date.getTime();
     }
 
     /**

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -226,13 +226,6 @@ export class Timestamp {
                 this._hour, this._minutes, this.getSecondsInt(), ms);
 
         msSinceEpoch = Timestamp._adjustMsSinceEpochIfNeeded(this._year, msSinceEpoch);
-        if (this._year < 100) {
-            // for a year < 100, JavaScript Date's default behavior automatically adds 1900;
-            // this block compensates for that behavior
-            let date = new Date(msSinceEpoch);
-            date.setUTCFullYear(this._year);     // yes, we really do mean some year < 100
-            msSinceEpoch = date.getTime();
-        }
 
         let offsetShiftMs = this._localOffset * 60 * 1000;
         return new Date(msSinceEpoch - offsetShiftMs);

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -618,7 +618,7 @@ define([
         // 't':
         0x94,
         // Timestamp
-        0x65, 0x80, 0x0f, 0xd0, 0x81, 0x81
+        0x65, 0xc0, 0x0f, 0xd0, 0x81, 0x81
       ]);
 
     // Symbols
@@ -665,7 +665,7 @@ define([
         [
         0x63,
         // Offset
-        0x80,
+        0xc0,
         // Year
         0x0f,
         0xd0,
@@ -675,7 +675,7 @@ define([
         [
         0x64,
         // Offset
-        0x80,
+        0xc0,
         // Year
         0x0f,
         0xd0,
@@ -687,7 +687,7 @@ define([
         [
         0x65,
         // Offset
-        0x80,
+        0xc0,
         // Year
         0x0f,
         0xd0,


### PR DESCRIPTION
* forces local offset to `-0` for year/month/day-precision timestamps, and updates binary writer tests to write  `c0` (-0) for such offsets to match ion-java behavior
* adds `_adjustMsSinceEpochIfNeeded` method to compensate for timestamps with year < 100 and applies it in the binary reader

Resolves #164 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
