### PR TITLE
Adds TypeDoc Configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,12 +40,6 @@ module.exports = function(grunt) {
        */
     typedoc: {
       build: {
-        options: {
-          module: 'amd',
-          target: 'es6',
-          out: 'docs/api/',
-          name: 'Ion Library',
-        },
         src: 'src/**/*'
       }
     },

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ion-JS Library",
+
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+
+  "exclude": [
+    "src/IonConstants.ts",
+    "src/IonImport.ts",
+    "src/IonLongInt.ts",
+    "src/IonSubstituteSymbolTable.ts",
+    "src/IonSpan.ts",
+    "src/IonSymbol.ts",
+    "src/IonSymbolIndex.ts",
+    "src/IonUnicode.ts",
+    "src/IonValue.ts",
+    "src/IonWriteable.ts",
+    "src/util.ts",
+
+    "src/IonBinary*.ts",
+    "src/Ion+(Pretty|)Text*.ts",
+    "src/*Raw.ts",
+    "src/IonLowLevel*.ts",
+
+    "src/IonTest*.ts",
+    "src/IonEvent*.ts"
+  ],
+
+  "out": "docs/api/"
+}


### PR DESCRIPTION
* Moves most of the doc configuration to `typedoc.json`.
* Adds various options to only publish exported/public APIs.
* Adds an exclude list for internal modules based on cursory examination
  of what can be reached from `Ion` module.

Resolves #369.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
