### PR TITLE
Eliminates Catalog and LocalSymbolTable from Public API.

### DIFF
--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -52,10 +52,10 @@ export type ReaderBuffer = ReaderOctetBuffer | string;
  *
  * @param buf       The Ion data to be used by the reader. Typically a string, UTF-8 encoded buffer (text), or raw
  *                  binary buffer.
- * @param catalog   An optional {Catalog} to be used for resolving symbol table references.
- * @returns {Reader}
  */
-export function makeReader(buf: ReaderBuffer, catalog? : Catalog) : Reader {
+export function makeReader(buf: ReaderBuffer) : Reader {
+    // TODO #387 make the catalog an optional parameter
+    const catalog = null;
     if((typeof buf) === "string"){
         return new TextReader(new StringSpan(<string>buf), catalog);
     }
@@ -69,23 +69,21 @@ export function makeReader(buf: ReaderBuffer, catalog? : Catalog) : Reader {
 
 /** Creates a new Ion Text Writer. */
 export function makeTextWriter() : Writer {
-  return new TextWriter(new Writeable());
+    // TODO #384 make LST an optional parameter
+    return new TextWriter(new Writeable());
 }
 
 /** Creates a new Ion Text Writer with pretty printing of the text. */
 export function makePrettyWriter(indentSize?: number) : Writer {
+    // TODO #384 make LST an optional parameter
     return new PrettyTextWriter(new Writeable(), indentSize);
 }
 
-
-/**
- * Creates a new Ion Binary Writer. You can optionally provide a local symbol table else
- * the default local symbol table will be used.
- *
- * @param localSymbolTable to use for the new writer
- */
-export function makeBinaryWriter(localSymbolTable : LocalSymbolTable = defaultLocalSymbolTable()) : Writer {
-  return new BinaryWriter(localSymbolTable, new Writeable());
+/** Creates a new Ion Binary Writer. */
+export function makeBinaryWriter() : Writer {
+    // TODO #384 make LST an optional parameter
+    const localSymbolTable = defaultLocalSymbolTable();
+    return new BinaryWriter(localSymbolTable, new Writeable());
 }
 
 export { Reader } from "./IonReader";

--- a/src/IonCatalog.ts
+++ b/src/IonCatalog.ts
@@ -14,54 +14,54 @@
 import { getSystemSymbolTable } from "./IonSystemSymbolTable";
 import { SharedSymbolTable } from "./IonSharedSymbolTable";
 
-    interface SymbolTableIndex { [name: string]: SharedSymbolTable[] }
+interface SymbolTableIndex { [name: string]: SharedSymbolTable[] }
 
-    function byVersion(x: SharedSymbolTable, y: SharedSymbolTable) : number {
-        return x.version - y.version;
+function byVersion(x: SharedSymbolTable, y: SharedSymbolTable) : number {
+    return x.version - y.version;
+}
+
+/**
+ * A catalog holds available shared symbol tables and always includes the system symbol table.
+ * @see https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog
+ */
+export class Catalog {
+    private symbolTables: SymbolTableIndex;
+
+    /** Creates a catalog containing only the system symbol table. */
+    constructor() {
+        this.symbolTables = {};
+        this.add(getSystemSymbolTable());
+    }
+
+    /** Adds a new shared symbol table to this catalog. */
+    add(symbolTable: SharedSymbolTable) : void {
+        if(symbolTable.name === undefined || symbolTable.name === null) throw new Error("SymbolTable name must be defined.");
+        let versions = this.symbolTables[symbolTable.name];
+        if (versions === undefined) this.symbolTables[symbolTable.name] = [];
+        this.symbolTables[symbolTable.name][symbolTable.version] = symbolTable;
     }
 
     /**
-     * A catalog holds available shared symbol tables and always includes the system symbol table.
-     * @see https://amzn.github.io/ion-docs/docs/symbols.html#the-catalog
+     * Returns a symbol table by name and version.
+     *
+     * @return The symbol table or `null` if it does not exist in the {Catalog}.
      */
-    export class Catalog {
-        private symbolTables: SymbolTableIndex;
-
-        /** Creates a catalog containing only the system symbol table. */
-        constructor() {
-            this.symbolTables = {};
-            this.add(getSystemSymbolTable());
-        }
-
-        /** Adds a new shared symbol table to this catalog. */
-        add(symbolTable: SharedSymbolTable) : void {
-            if(symbolTable.name === undefined || symbolTable.name === null) throw new Error("SymbolTable name must be defined.");
-            let versions = this.symbolTables[symbolTable.name];
-            if (versions === undefined) this.symbolTables[symbolTable.name] = [];
-            this.symbolTables[symbolTable.name][symbolTable.version] = symbolTable;
-        }
-
-        /**
-         * Returns a symbol table by name and version.
-         *
-         * @return The symbol table or `null` if it does not exist in the {Catalog}.
-         */
-        getVersion(name: string, version: number) : SharedSymbolTable | null {
-            let tables : SharedSymbolTable[] = this.symbolTables[name];
-            if(!tables) return null;
-            let table = tables[version];
-            if(!table) table = tables[tables.length];
-            return table? table : null;
-        }
-
-        /**
-         * Retrieves the latest version of a symbol table by name.
-         *
-         * @return The symbol table or `null` if it does not exist in the {Catalog}.
-         */
-        getTable(name: string) : SharedSymbolTable | null {
-            let versions = this.symbolTables[name], table;
-            if(versions === undefined) return null;
-            return versions[versions.length - 1];
-        }
+    getVersion(name: string, version: number) : SharedSymbolTable | null {
+        let tables : SharedSymbolTable[] = this.symbolTables[name];
+        if(!tables) return null;
+        let table = tables[version];
+        if(!table) table = tables[tables.length];
+        return table? table : null;
     }
+
+    /**
+     * Retrieves the latest version of a symbol table by name.
+     *
+     * @return The symbol table or `null` if it does not exist in the {Catalog}.
+     */
+    getTable(name: string) : SharedSymbolTable | null {
+        let versions = this.symbolTables[name], table;
+        if(versions === undefined) return null;
+        return versions[versions.length - 1];
+    }
+}

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -245,7 +245,7 @@ export class IonEventStream {
                 case 'value_text' : {
                     let tempString : string = this.reader.stringValue();
                     if(tempString.substr(0,5) === '$ion_') tempString = "$ion_user_value::" + tempString
-                    let tempReader : Reader = makeReader(tempString, undefined);
+                    let tempReader : Reader = makeReader(tempString);
                     tempReader.next();
                     let tempValue = tempReader.value();
                     currentEvent['isNull'] =  tempReader.isNull();
@@ -378,7 +378,7 @@ export class IonEventStream {
             tid = this.reader.next();
         }
         this.reader.stepOut();
-        let tempReader : Reader = makeReader(numBuffer, undefined);
+        let tempReader : Reader = makeReader(numBuffer);
         tempReader.next();
         return tempReader.value();
     }

--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -11,9 +11,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
+
 /**
  * A shared symbol table.
- * @see http://amzn.github.io/ion-docs/symbols.html#shared-symbol-tables
+ * @see https://amzn.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
  */
 export class SharedSymbolTable {
   constructor(

--- a/src/IonSymbols.ts
+++ b/src/IonSymbols.ts
@@ -88,29 +88,35 @@ function load_symbols(reader: Reader) : string[] {
   return symbols;
 }
 
-    export function makeSymbolTable(catalog: Catalog, reader: Reader) : LocalSymbolTable {
-        let import_: Import;
-        let symbols: string[];
-        let maxId: number;
-        let foundSymbols : boolean = false;
-        let foundImports : boolean = false;
+/**
+ * Constructs a {LocalSymbolTable} from the given Ion {Reader}.
+ *
+ * @param catalog The catalog to resolve imported shared symbol tables from.
+ * @param reader The Ion {Reader} over the local symbol table in its serialized form.
+ */
+export function makeSymbolTable(catalog: Catalog, reader: Reader) : LocalSymbolTable {
+    let import_: Import;
+    let symbols: string[];
+    let maxId: number;
+    let foundSymbols : boolean = false;
+    let foundImports : boolean = false;
 
-        reader.stepIn();
-        while (reader.next()) {
-            switch(reader.fieldName()) {
-            case "imports":
-                if(foundImports) throw new Error("Multiple import fields found.");
-                import_ = load_imports(reader, catalog);
-                foundImports = true;
-                break;
-            case "symbols":
-                if(foundSymbols) throw new Error("Multiple symbol fields found.");
-                symbols = load_symbols(reader);
-                foundSymbols = true;
-                break;
-            }
+    reader.stepIn();
+    while (reader.next()) {
+        switch(reader.fieldName()) {
+        case "imports":
+            if(foundImports) throw new Error("Multiple import fields found.");
+            import_ = load_imports(reader, catalog);
+            foundImports = true;
+            break;
+        case "symbols":
+            if(foundSymbols) throw new Error("Multiple symbol fields found.");
+            symbols = load_symbols(reader);
+            foundSymbols = true;
+            break;
         }
-        reader.stepOut();
-
-        return new LocalSymbolTable(import_, symbols);
     }
+    reader.stepOut();
+
+    return new LocalSymbolTable(import_, symbols);
+}

--- a/src/IonSystemSymbolTable.ts
+++ b/src/IonSystemSymbolTable.ts
@@ -11,9 +11,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
+
 /**
  * @file Helper methods for obtaining the system symbol table or its Import.
- * @see http://amzn.github.io/ion-docs/symbols.html#system-symbols
+ * @see https://amzn.github.io/ion-docs/docs/symbols.html#system-symbols
  */
 import { Import } from "./IonImport";
 import { SharedSymbolTable } from "./IonSharedSymbolTable";

--- a/typedoc.json
+++ b/typedoc.json
@@ -19,6 +19,10 @@
     "src/IonWriteable.ts",
     "src/util.ts",
 
+    "src/IonCatalog.ts",
+    "src/IonSymbols.ts",
+    "src/Ion*SymbolTable.ts",
+
     "src/IonBinary*.ts",
     "src/Ion+(Pretty|)Text*.ts",
     "src/*Raw.ts",


### PR DESCRIPTION
* Removes `Catalog` parameter from `makeReader()`.
* Removes `LocalSymbolTable` parameter from `makeBinaryWriter()`.
* Fixes extraneous indentation in IonCatalog/IonSymbols.
* Minor doc cleanup for IonSystemSymbolTable/IonSharedSymbolTable/IonSymbols.
* Adds IonCatalog/IonSymbols/Ion*SymbolTable to exludes in `typedoc.json`.

Resolves #382 by reducing public API surface area.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
