### PR TITLE
Cleans up documentation for IonType[s].

### DIFF
--- a/src/IonType.ts
+++ b/src/IonType.ts
@@ -12,12 +12,24 @@
  * language governing permissions and limitations under the License.
  */
 
+/** Ion value type enumeration class. */
 export class IonType {
+  /** The binary type ID for this Ion Type. */
   bid: number;
+
+  /** The textual name of this type. */
   name: string;
+
+  /** Whether or not this type is a scalar value. */
   scalar: boolean;
+
+  /** Whether or not this type is a `clob` or `blob`. */
   lob: boolean;
+
+  /** Whether or not this type is an `int`, `float`, or `decimal`. */
   num: boolean;
+
+  /** Whether or not this type is a `list`, `sexp`, or `struct`. */
   container: boolean;
 
   constructor(bid: number, name: string, scalar: boolean, lob: boolean, num: boolean, container: boolean) {

--- a/src/IonTypes.ts
+++ b/src/IonTypes.ts
@@ -14,9 +14,11 @@
 
 import { IonType } from "./IonType";
 
+/** Enumeration of the Ion types. */
 export const IonTypes = {
   NULL      : new IonType(  0, "null",       true,   false, false,  false ),
   BOOL      : new IonType(  1, "bool",       true,   false, false,  false ),
+  // note that INT is actually 0x2 **and** 0x3 in the Ion binary encoding
   INT       : new IonType(  2, "int",        true,   false, true,   false ),
   FLOAT     : new IonType(  4, "float",      true,   false, true,   false ),
   DECIMAL   : new IonType(  5, "decimal",    true,   false, false,  false ),
@@ -28,6 +30,4 @@ export const IonTypes = {
   LIST      : new IonType( 11, "list",       false,  false, false,  true  ),
   SEXP      : new IonType( 12, "sexp",       false,  false, false,  true  ),
   STRUCT    : new IonType( 13, "struct",     false,  false, false,  true  ),
-  DATAGRAM  : new IonType( 20, "datagram",   false,  false, false,  true  ),
-  BOC       : new IonType( -2, "boc",        false,  false, false,  false ),
-}
+};


### PR DESCRIPTION
Also removes pseudo-types `BOC` and `DATAGRAM`.

Related to #365.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
