### PR TITLE
throws when annotations are not an array full of strings.

### DIFF
--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -15,6 +15,7 @@ import {Writer} from "./IonWriter";
 import {IonType} from "./IonType";
 import {Reader} from "./IonReader";
 import {IonTypes} from "./IonTypes";
+import {_validateAnnotations, _isString} from "./util"
 
 // TS workaround that avoids the need to copy all Writer method signatures into AbstractWriter
 export interface AbstractWriter extends Writer {}
@@ -23,14 +24,17 @@ export abstract class AbstractWriter implements Writer {
     protected _annotations = [];
 
     addAnnotation(annotation: string): void {
+        if(!_isString(annotation)) {
+            throw new Error('Annotation must be of type string.');
+        }
         this._annotations.push(annotation);
     }
 
     setAnnotations(annotations: string[]): void {
-        if (annotations === undefined || annotations === null) {
+        if(annotations === undefined || annotations === null){
             this._annotations = [];
-        } else if(!Array.isArray(annotations)){
-            throw new Error("Annotations must be an array of strings.")
+        } else if (!_validateAnnotations(annotations)) {
+            throw new Error('Annotations must be of type string[].');
         } else {
             this._annotations = annotations;
         }

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -30,10 +30,8 @@ export abstract class AbstractWriter implements Writer {
     }
 
     setAnnotations(annotations: string[]): void {
-        if (annotations === undefined) {
-            throw new Error('Annotations were undefined.');
-        } else if (annotations === null) {
-            this._annotations = [];
+        if (annotations === undefined || annotations === null) {
+            throw new Error('Annotations were undefined or null.');
         } else if (!this._validateAnnotations(annotations)) {
             throw new Error('Annotations must be of type string[].');
         } else {

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -15,7 +15,6 @@ import {Writer} from "./IonWriter";
 import {IonType} from "./IonType";
 import {Reader} from "./IonReader";
 import {IonTypes} from "./IonTypes";
-import {_validateAnnotations, _isString} from "./util"
 
 // TS workaround that avoids the need to copy all Writer method signatures into AbstractWriter
 export interface AbstractWriter extends Writer {}
@@ -24,7 +23,7 @@ export abstract class AbstractWriter implements Writer {
     protected _annotations = [];
 
     addAnnotation(annotation: string): void {
-        if(!_isString(annotation)) {
+        if(!this._isString(annotation)) {
             throw new Error('Annotation must be of type string.');
         }
         this._annotations.push(annotation);
@@ -33,7 +32,7 @@ export abstract class AbstractWriter implements Writer {
     setAnnotations(annotations: string[]): void {
         if(annotations === undefined || annotations === null){
             this._annotations = [];
-        } else if (!_validateAnnotations(annotations)) {
+        } else if (!this._validateAnnotations(annotations)) {
             throw new Error('Annotations must be of type string[].');
         } else {
             this._annotations = annotations;
@@ -99,6 +98,22 @@ export abstract class AbstractWriter implements Writer {
                 reader.stepOut();
             }
         }
+    }
+
+    private _validateAnnotations(input : string[]) : boolean {
+        if (!Array.isArray(input)) {
+            return false;
+        }
+        for (let ann in input) {
+            if (!this._isString(ann)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private _isString(input : string) : boolean {
+        return typeof input === 'string';
     }
 }
 

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -104,8 +104,8 @@ export abstract class AbstractWriter implements Writer {
         if (!Array.isArray(input)) {
             return false;
         }
-        for (let ann in input) {
-            if (!this._isString(ann)) {
+        for (let i = 0; i < input.length; i++) {
+            if (!this._isString(input[i])) {
                 return false;
             }
         }

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -30,7 +30,9 @@ export abstract class AbstractWriter implements Writer {
     }
 
     setAnnotations(annotations: string[]): void {
-        if(annotations === undefined || annotations === null){
+        if (annotations === undefined) {
+            throw new Error('Annotations were undefined.');
+        } else if (annotations === null) {
             this._annotations = [];
         } else if (!this._validateAnnotations(annotations)) {
             throw new Error('Annotations must be of type string[].');

--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -27,7 +27,13 @@ export abstract class AbstractWriter implements Writer {
     }
 
     setAnnotations(annotations: string[]): void {
-        this._annotations = annotations;
+        if (annotations === undefined || annotations === null) {
+            this._annotations = [];
+        } else if(!Array.isArray(annotations)){
+            throw new Error("Annotations must be an array of strings.")
+        } else {
+            this._annotations = annotations;
+        }
     }
 
     protected _clearAnnotations(): void {

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -22,7 +22,7 @@ import {LongInt} from "./IonLongInt";
 import {LowLevelBinaryWriter} from "./IonLowLevelBinaryWriter";
 import {TimestampPrecision,Timestamp} from "./IonTimestamp";
 import {Writeable} from "./IonWriteable";
-import {_sign} from "./util";
+import {_sign, _validateAnnotations} from "./util";
 
 const MAJOR_VERSION: number = 1;
 const MINOR_VERSION: number = 0;
@@ -317,19 +317,12 @@ export class BinaryWriter extends AbstractWriter {
   }
 
   private encodeAnnotations(annotations: string[]) : Uint8Array {
-    if (!annotations || annotations.length === 0) {
+    if (annotations.length === 0) {
       return new Uint8Array(0);
     }
-    if (!Array.isArray(annotations)) {
-      throw new Error('Annotations must be an array of strings.');
-    }
-
     let writeable: Writeable = new Writeable();
     let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(writeable);
     for (let annotation of annotations) {
-      if(typeof annotation !== 'string') {
-        throw new Error('Annotation must be of type string.');
-      }
       let symbolId: number = this.symbolTable.addSymbol(annotation);
       writer.writeVariableLengthUnsignedInt(symbolId);
     }

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -22,7 +22,7 @@ import {LongInt} from "./IonLongInt";
 import {LowLevelBinaryWriter} from "./IonLowLevelBinaryWriter";
 import {TimestampPrecision,Timestamp} from "./IonTimestamp";
 import {Writeable} from "./IonWriteable";
-import {_sign, _validateAnnotations} from "./util";
+import {_sign} from "./util";
 
 const MAJOR_VERSION: number = 1;
 const MINOR_VERSION: number = 0;

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -320,10 +320,16 @@ export class BinaryWriter extends AbstractWriter {
     if (!annotations || annotations.length === 0) {
       return new Uint8Array(0);
     }
+    if (!Array.isArray(annotations)) {
+      throw new Error('Annotations must be an array of strings.');
+    }
 
     let writeable: Writeable = new Writeable();
     let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(writeable);
     for (let annotation of annotations) {
+      if(typeof annotation !== 'string') {
+        throw new Error('Annotation must be of type string.');
+      }
       let symbolId: number = this.symbolTable.addSymbol(annotation);
       writer.writeVariableLengthUnsignedInt(symbolId);
     }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -231,7 +231,7 @@ export class IonEventFactory {
                 throw new Error("symbol tables unsupported.");
             case IonEventType.CONTAINER_END :
             case IonEventType.STREAM_END :
-                return new IonEndEvent(eventType, null, null, null, depth);
+                return new IonEndEvent(eventType, null, null, [], depth);
         }
     }
 }

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -169,7 +169,7 @@ export class IonEventStream {
                     }
                     case null : {
                         if (this.reader.depth() === 0) {
-                            this.eventStream.push(this.eventFactory.makeEvent(IonEventType.STREAM_END, IonTypes.NULL, null, this.reader.depth(), undefined, false,undefined));
+                            this.eventStream.push(this.eventFactory.makeEvent(IonEventType.STREAM_END, IonTypes.NULL, null, this.reader.depth(), [], false,undefined));
                             return;
                         } else {
                             this.reader.stepOut();
@@ -188,7 +188,7 @@ export class IonEventStream {
     }
 
     private endContainer(thisContainer : IonEvent, thisContainerIndex : number) {
-        this.eventStream.push(this.eventFactory.makeEvent(IonEventType.CONTAINER_END, thisContainer.ionType, null, thisContainer.depth, null,false, null));
+        this.eventStream.push(this.eventFactory.makeEvent(IonEventType.CONTAINER_END, thisContainer.ionType, null, thisContainer.depth, [],false, null));
         thisContainer.ionValue = this.eventStream.slice(thisContainerIndex, this.eventStream.length);
     }
 
@@ -289,6 +289,7 @@ export class IonEventStream {
                 throw new Error('Symbol tables unsupported');
         }
         let fieldname = (currentEvent['field_name'] !== undefined ? currentEvent['field_name'] : null);
+        if(!currentEvent['annotations']) currentEvent['annotations'] = [];
 
         let textEvent = this.eventFactory.makeEvent(
             eventType,

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -356,6 +356,9 @@ export class TextWriter extends AbstractWriter {
     protected writeAnnotations() : void {
         if (this._annotations === null || this._annotations === undefined) return;
         for (let annotation of this._annotations) {
+            if (typeof annotation !== 'string') {
+                throw new Error('Annotations must be of type string.');
+            }
             this.writeSymbolToken(annotation);
             this.writeUtf8('::');
         }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -354,11 +354,7 @@ export class TextWriter extends AbstractWriter {
     }
 
     protected writeAnnotations() : void {
-        if (this._annotations === null || this._annotations === undefined) return;
         for (let annotation of this._annotations) {
-            if (typeof annotation !== 'string') {
-                throw new Error('Annotations must be of type string.');
-            }
             this.writeSymbolToken(annotation);
             this.writeUtf8('::');
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,18 +26,3 @@ export function _sign(x: number): number {
 export function _hasValue(v: any): boolean {
     return v !== undefined && v !== null;
 }
-
-export function _validateAnnotations(input : string[]) : boolean {
-    if (!Array.isArray(input)) {
-        return false;
-    }
-    for (let ann in input) {
-        if (!_isString(ann)) {
-            return false;
-        }
-    }
-    return true;
-}
-export function _isString(input : string) : boolean {
-    return typeof input === 'string';
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,3 +27,17 @@ export function _hasValue(v: any): boolean {
     return v !== undefined && v !== null;
 }
 
+export function _validateAnnotations(input : string[]) : boolean {
+    if (!Array.isArray(input)) {
+        return false;
+    }
+    for (let ann in input) {
+        if (!_isString(ann)) {
+            return false;
+        }
+    }
+    return true;
+}
+export function _isString(input : string) : boolean {
+    return typeof input === 'string';
+}

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -846,6 +846,12 @@ define([
       }
     }
 
+    errorTest('Cannot pass single string as an annotation.',
+        (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
+    errorTest('Cannot pass annotations array without a string.',
+        (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
+    errorTest('Cannot pass annotations array containing a non string value.',
+        (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
     errorTest('Cannot write top-level field name',
       (writer) => { writer.writeFieldName('foo') });
     errorTest('Cannot exit container at top level',

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -655,9 +655,6 @@ define([
     writerTest('Writes null symbol by detecting null',
       (writer) => { writer.writeSymbol(null) },
         [0x7f]);
-    writerTest('Writes null symbol by detecting null and allows user to pass null into set annotations',
-          (writer) => { writer.setAnnotations(null); writer.writeSymbol(null) },
-          [0x7f]);
     skippedWriterTest('Writes null symbol by detecting undefined',
       (writer) => { writer.writeSymbol() },
         [0x7f]);
@@ -848,31 +845,33 @@ define([
       }
     }
 
-    errorTest('Cannot pass single string as an annotation.',
+    errorTest('Should throw when passing a single string as an annotation.',
         (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
-    errorTest('Cannot pass annotations array without a string.',
+    errorTest('Should throw when setting annotations to null',
+          (writer) => { writer.setAnnotations(null), writer.writeInt(5) });
+    errorTest('Should throw when passing annotations array without a string.',
         (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
-    errorTest('Cannot add int as annotation.',
+    errorTest('Should throw when adding an int as annotation.',
           (writer) => { writer.addAnnotation(5), writer.writeInt(5) });
-    errorTest('Cannot add array of chars.',
+    errorTest('Should throw when adding array of chars.',
           (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
-    errorTest('Cannot pass annotations array containing a non string value.',
+    errorTest('Should throw when passing annotations array containing a non string value.',
         (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
-    errorTest('Cannot add a non string annotation.',
+    errorTest('Should throw when adding a non string annotation.',
           (writer) => { writer.addAnnotation(null), writer.writeInt(5) });
-    errorTest('Cannot add a non string annotation.',
+    errorTest('Should throw when adding a non string annotation.',
           (writer) => { writer.addAnnotation(undefined), writer.writeInt(5) });
-    errorTest('Cannot pass annotations array containing undefined.',
+    errorTest('Should throw when passing annotations array containing undefined.',
         (writer) => { writer.setAnnotations([undefined]), writer.writeInt(5) });
-    errorTest('Cannot pass annotations array containing null',
+    errorTest('Should throw when passing annotations array containing null',
         (writer) => { writer.setAnnotations([null]), writer.writeInt(5) });
-    errorTest('Cannot pass undefined as annotations.',
+    errorTest('Should throw when passing undefined as annotations.',
         (writer) => { writer.setAnnotations(undefined), writer.writeInt(5) });
-    errorTest('Cannot write top-level field name',
+    errorTest('Should throw when writing top-level field name',
       (writer) => { writer.writeFieldName('foo') });
-    errorTest('Cannot exit container at top level',
+    errorTest('Should throw when exiting containers at top level',
       (writer) => { writer.stepOut() });
-    errorTest('Cannot double-exit container',
+    errorTest('Should throw when double-exiting a container',
       (writer) => {
         writer.stepIn(ion.IonTypes.LIST);
         writer.stepOut();

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -850,6 +850,10 @@ define([
         (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
     errorTest('Cannot pass annotations array without a string.',
         (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
+    errorTest('Cannot add int as annotation.',
+          (writer) => { writer.addAnnotation(5), writer.writeInt(5) });
+    errorTest('Cannot add array of chars.',
+          (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing a non string value.',
         (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing undefined.',

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -640,7 +640,7 @@ define([
         // 's':
         0x92,
         // Struct
-        0xd0, // 96
+        0xd0, // 9
         // 's':
         0x92,
         // 'qux'
@@ -652,10 +652,12 @@ define([
       ]);
 
     // Symbols
-
     writerTest('Writes null symbol by detecting null',
       (writer) => { writer.writeSymbol(null) },
         [0x7f]);
+    writerTest('Writes null symbol by detecting null and allows user to pass null into set annotations',
+          (writer) => { writer.setAnnotations(null); writer.writeSymbol(null) },
+          [0x7f]);
     skippedWriterTest('Writes null symbol by detecting undefined',
       (writer) => { writer.writeSymbol() },
         [0x7f]);

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -856,6 +856,10 @@ define([
           (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing a non string value.',
         (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
+    errorTest('Cannot add a non string annotation.',
+          (writer) => { writer.addAnnotation(null), writer.writeInt(5) });
+    errorTest('Cannot add a non string annotation.',
+          (writer) => { writer.addAnnotation(undefined), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing undefined.',
         (writer) => { writer.setAnnotations([undefined]), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing null',

--- a/tests/unit/IonBinaryWriterTest.js
+++ b/tests/unit/IonBinaryWriterTest.js
@@ -852,6 +852,12 @@ define([
         (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
     errorTest('Cannot pass annotations array containing a non string value.',
         (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
+    errorTest('Cannot pass annotations array containing undefined.',
+        (writer) => { writer.setAnnotations([undefined]), writer.writeInt(5) });
+    errorTest('Cannot pass annotations array containing null',
+        (writer) => { writer.setAnnotations([null]), writer.writeInt(5) });
+    errorTest('Cannot pass undefined as annotations.',
+        (writer) => { writer.setAnnotations(undefined), writer.writeInt(5) });
     errorTest('Cannot write top-level field name',
       (writer) => { writer.writeFieldName('foo') });
     errorTest('Cannot exit container at top level',

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -371,6 +371,10 @@
 
       badWriterTest('Cannot pass single string as an annotation.',
           (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
+      badWriterTest('Cannot add int as annotation.',
+          (writer) => { writer.addAnnotation(5), writer.writeInt(5) });
+      badWriterTest('Cannot add array of chars.',
+          (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
       badWriterTest('Cannot pass annotations array without a string.',
           (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
       badWriterTest('Cannot pass annotations array containing a non string value.',

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -402,7 +402,9 @@
 
 
     // Symbols
-
+    writerTest('Writes null symbol by detecting null and allows user to pass null into set annotations',
+          (writer) => { writer.setAnnotations(null); writer.writeSymbol(null) },
+          "null.symbol");
     writerTest('Writes symbol containing single quote',
       writer => writer.writeSymbol("'"),
       "'\\''");

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -375,6 +375,10 @@
           (writer) => { writer.addAnnotation(5), writer.writeInt(5) });
       badWriterTest('Cannot add array of chars.',
           (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
+      badWriterTest('Cannot add a non string annotation.',
+          (writer) => { writer.addAnnotation(null), writer.writeInt(5) });
+      badWriterTest('Cannot add a non string annotation.',
+          (writer) => { writer.addAnnotation(undefined), writer.writeInt(5) });
       badWriterTest('Cannot pass annotations array without a string.',
           (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
       badWriterTest('Cannot pass annotations array containing a non string value.',

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -368,32 +368,33 @@
           writer => { writer.stepIn(ion.IonTypes.STRUCT); writer.stepIn(ion.IonTypes.LIST);});
 
       //  annotations
-
-      badWriterTest('Cannot pass single string as an annotation.',
+      badWriterTest('Should throw when setting annotations to null',
+          (writer) => { writer.setAnnotations(null); writer.writeInt(5) });
+      badWriterTest('Should throw when passing single string as an annotation.',
           (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
-      badWriterTest('Cannot add int as annotation.',
+      badWriterTest('Should throw when adding int as annotation.',
           (writer) => { writer.addAnnotation(5), writer.writeInt(5) });
-      badWriterTest('Cannot add array of chars.',
+      badWriterTest('Should throw when adding array of chars.',
           (writer) => { writer.addAnnotation(['t', 'a', 'c', 'o']), writer.writeInt(5) });
-      badWriterTest('Cannot add a non string annotation.',
+      badWriterTest('Should throw when adding a non string annotation.',
           (writer) => { writer.addAnnotation(null), writer.writeInt(5) });
-      badWriterTest('Cannot add a non string annotation.',
+      badWriterTest('Should throw when adding a non string annotation.',
           (writer) => { writer.addAnnotation(undefined), writer.writeInt(5) });
-      badWriterTest('Cannot pass annotations array without a string.',
+      badWriterTest('Should throw when passing annotations array without a string.',
           (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
-      badWriterTest('Cannot pass annotations array containing a non string value.',
+      badWriterTest('Should throw when passing annotations array containing a non string value.',
           (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
-      badWriterTest('Cannot pass annotations array containing undefined.',
+      badWriterTest('Should throw when passing annotations array containing undefined.',
           (writer) => { writer.setAnnotations([undefined]), writer.writeInt(5) });
-      badWriterTest('Cannot pass annotations array containing null',
+      badWriterTest('Should throw when passing annotations array containing null',
           (writer) => { writer.setAnnotations([null]), writer.writeInt(5) });
-      badWriterTest('Cannot pass undefined as annotations.',
+      badWriterTest('Should throw when passing undefined as annotations.',
           (writer) => { writer.setAnnotations(undefined), writer.writeInt(5) });
-      badWriterTest('Cannot write top-level field name',
+      badWriterTest('Should throw when writing top-level field name',
           (writer) => { writer.writeFieldName('foo') });
-      badWriterTest('Cannot exit container at top level',
+      badWriterTest('Should throw when exiting a container at top level',
           (writer) => { writer.stepOut() });
-      badWriterTest('Cannot double-exit container',
+      badWriterTest('Should throw when double-exiting a container',
           (writer) => {
               writer.stepIn(ion.IonTypes.LIST);
               writer.stepOut();
@@ -402,9 +403,6 @@
 
 
     // Symbols
-    writerTest('Writes null symbol by detecting null and allows user to pass null into set annotations',
-          (writer) => { writer.setAnnotations(null); writer.writeSymbol(null) },
-          "null.symbol");
     writerTest('Writes symbol containing single quote',
       writer => writer.writeSymbol("'"),
       "'\\''");

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -367,6 +367,32 @@
       badWriterTest('Cannot step into list with missing field value',
           writer => { writer.stepIn(ion.IonTypes.STRUCT); writer.stepIn(ion.IonTypes.LIST);});
 
+      //  annotations
+
+      badWriterTest('Cannot pass single string as an annotation.',
+          (writer) => { writer.setAnnotations('taco'), writer.writeInt(5) });
+      badWriterTest('Cannot pass annotations array without a string.',
+          (writer) => { writer.setAnnotations([5]), writer.writeInt(5) });
+      badWriterTest('Cannot pass annotations array containing a non string value.',
+          (writer) => { writer.setAnnotations(['a', 5,'t']), writer.writeInt(5) });
+      badWriterTest('Cannot pass annotations array containing undefined.',
+          (writer) => { writer.setAnnotations([undefined]), writer.writeInt(5) });
+      badWriterTest('Cannot pass annotations array containing null',
+          (writer) => { writer.setAnnotations([null]), writer.writeInt(5) });
+      badWriterTest('Cannot pass undefined as annotations.',
+          (writer) => { writer.setAnnotations(undefined), writer.writeInt(5) });
+      badWriterTest('Cannot write top-level field name',
+          (writer) => { writer.writeFieldName('foo') });
+      badWriterTest('Cannot exit container at top level',
+          (writer) => { writer.stepOut() });
+      badWriterTest('Cannot double-exit container',
+          (writer) => {
+              writer.stepIn(ion.IonTypes.LIST);
+              writer.stepOut();
+              writer.stepOut();
+          });
+
+
     // Symbols
 
     writerTest('Writes symbol containing single quote',


### PR DESCRIPTION
*Issue #, if available:*
#340

*Description of changes:*
Checks that inputs for the function setAnnotations() is an array, and that each annotation within is a string while being written.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
