### PR TITLE
SymbolTable refactoring

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -237,7 +237,7 @@ export class BinaryReader implements Reader {
   private getSymbolString(symbolId: number) : string {
     let s: string = null;
     if (symbolId > 0) {
-      s = this._symtab.getSymbol(symbolId);
+      s = this._symtab.getSymbolText(symbolId);
       if (typeof(s) == 'undefined') {
         s = "$" + symbolId.toString();
       }

--- a/src/IonLocalSymbolTable.ts
+++ b/src/IonLocalSymbolTable.ts
@@ -47,13 +47,13 @@ export class LocalSymbolTable  {
     return symbolId;
   }
 
-    getSymbol(symbolId: number): string {
-        if(symbolId > this.maxId) throw new Error("SymbolID greater than maxID.");
-        let importedSymbol: string = this.import.getSymbol(symbolId);
-        if (importedSymbol !== undefined) return importedSymbol;
-        let index = symbolId - this.offset;
-        return this.symbols[index];
-    }
+  getSymbolText(symbolId: number): string {
+      if(symbolId > this.maxId) throw new Error("SymbolID greater than maxID.");
+      let importedSymbol: string = this.import.getSymbolText(symbolId);
+      if (importedSymbol !== undefined) return importedSymbol;
+      let index = symbolId - this.offset;
+      return this.symbols[index];
+  }
 
   get symbols() : string[] {
     return this._symbols;
@@ -65,6 +65,10 @@ export class LocalSymbolTable  {
 
   get import() : Import {
     return this._import;
+  }
+
+  numberOfSymbols(): number {
+    return this._symbols.length;
   }
 }
 

--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -17,11 +17,43 @@
  * @see https://amzn.github.io/ion-docs/docs/symbols.html#shared-symbol-tables
  */
 export class SharedSymbolTable {
+
+  protected _numberOfSymbols: number;
+  protected readonly _idsByText: Map<string, number>;
+
   constructor(
     private readonly _name: string,
     private readonly _version: number,
     private readonly _symbols: string[]
-  ) {}
+  ) {
+    this._idsByText = new Map<string, number>();
+    this._numberOfSymbols = this._symbols.length;
+    // Iterate through the symbol array in reverse order so if the same string appears more than
+    // once the smaller symbol ID is stored.
+    for (let m = _symbols.length - 1; m >= 0; m--) {
+      this._idsByText[_symbols[m]] = m;
+    }
+  }
+
+  getSymbolText(symbolId: number): string {
+    if (symbolId < 0) {
+      throw new Error(
+          `Index ${symbolId} is out of bounds for the SharedSymbolTable name=${this.name}, version=${this.version}`
+      );
+    }
+    if (symbolId >= this.numberOfSymbols) {
+      return undefined;
+    }
+    return this._symbols[symbolId];
+  }
+
+  getSymbolId(text: string): number {
+    let symbolId = this._idsByText[text];
+    if (symbolId === undefined) {
+      return null;
+    }
+    return symbolId;
+  }
 
   get name() : string {
     return this._name;
@@ -31,7 +63,7 @@ export class SharedSymbolTable {
     return this._version;
   }
 
-  get symbols() : string[] {
-    return this._symbols;
+  get numberOfSymbols(): number {
+    return this._numberOfSymbols;
   }
 }

--- a/src/IonSubstituteSymbolTable.ts
+++ b/src/IonSubstituteSymbolTable.ts
@@ -20,6 +20,25 @@ import { SharedSymbolTable } from "./IonSharedSymbolTable";
  */
 export class SubstituteSymbolTable extends SharedSymbolTable {
   constructor(length: number) {
-    super(null, undefined, new Array(length));
+    if (length < 0) {
+      throw new Error(
+        "Cannot instantiate a SubstituteSymbolTable with a negative length. (" + length + ")"
+      );
+    }
+    super("_substitute", undefined, []);
+    this._numberOfSymbols = length;
+  }
+
+  getSymbolText(symbolId: number): string {
+    if (symbolId < 0) {
+      throw new Error(
+          `Index ${symbolId} is out of bounds for the SharedSymbolTable name=${this.name}, version=${this.version}`
+      );
+    }
+    return undefined;
+  }
+
+  getSymbolId(text: string): number {
+    return undefined;
   }
 }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -203,7 +203,7 @@ export class TextReader implements Reader {
         if(raw_type === T_IDENTIFIER && (str.length > 1 && str.charAt(0) === '$'.charAt(0))) {
             let tempStr = str.substr(1, str.length);
             if (+tempStr === +tempStr) {//look up sid, +str === +str is a one line is integer hack
-                let symbol = this._symtab.getSymbol(Number(tempStr));
+                let symbol = this._symtab.getSymbolText(Number(tempStr));
                 if(symbol === undefined) throw new Error("Unresolveable symbol ID, symboltokens unsupported.");
                 return symbol;
             }
@@ -233,7 +233,7 @@ export class TextReader implements Reader {
                     if(this._raw_type === T_IDENTIFIER && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))){
                         let tempStr = this._raw.substr(1, this._raw.length);
                         if (+tempStr === +tempStr) {//look up sid, +str === +str is a one line is integer hack
-                            let symbol = this._symtab.getSymbol(Number(tempStr));
+                            let symbol = this._symtab.getSymbolText(Number(tempStr));
                             if(symbol === undefined) throw new Error("Unresolvable symbol ID, symboltokens unsupported.");
                             return symbol;
                         }
@@ -306,7 +306,8 @@ export class TextReader implements Reader {
                 if(this._raw_type === T_IDENTIFIER && (this._raw.length > 1 && this._raw.charAt(0) === '$'.charAt(0))){
                     let tempStr = this._raw.substr(1, this._raw.length);
                     if (+tempStr === +tempStr) {//look up sid, +str === +str is a one line is integer hack
-                        let symbol = this._symtab.getSymbol(Number(tempStr));
+                        let symbolId = Number(tempStr);
+                        let symbol = this._symtab.getSymbolText(symbolId);
                         if(symbol === undefined) throw new Error("Unresolvable symbol ID, symboltokens unsupported.");
                         return symbol;
                     }

--- a/tests/unit/IonImportTest.js
+++ b/tests/unit/IonImportTest.js
@@ -60,9 +60,9 @@ define([
       assert.equal(child.getSymbolId('c'), 3);
 
       // Verify that duplicate symbols are accessible
-      assert.equal(child.getSymbol(4), 'a');
-      assert.equal(child.getSymbol(5), 'b');
-      assert.equal(child.getSymbol(6), 'c');
+      assert.equal(child.getSymbolText(4), 'a');
+      assert.equal(child.getSymbolText(5), 'b');
+      assert.equal(child.getSymbolText(6), 'c');
     };
 
     suite['Short length omits symbols'] = function() {
@@ -70,10 +70,10 @@ define([
       var parent = new ion.Import(null, symbolTable, 1);
       var child = new ion.Import(parent, symbolTable);
 
-      assert.equal(child.getSymbol(1), 'a');
-      assert.equal(child.getSymbol(2), 'a');
-      assert.equal(child.getSymbol(3), 'b');
-      assert.equal(child.getSymbol(4), 'c');
+      assert.equal(child.getSymbolText(1), 'a');
+      assert.equal(child.getSymbolText(2), 'a');
+      assert.equal(child.getSymbolText(3), 'b');
+      assert.equal(child.getSymbolText(4), 'c');
     }
 
     suite['Long length pads symbols'] = function() {
@@ -81,13 +81,13 @@ define([
       var parent = new ion.Import(null, symbolTable, 4);
       var child = new ion.Import(parent, symbolTable);
 
-      assert.equal(child.getSymbol(1), 'a');
-      assert.equal(child.getSymbol(2), 'b');
-      assert.equal(child.getSymbol(3), 'c');
-      assert.isUndefined(child.getSymbol(4));
-      assert.equal(child.getSymbol(5), 'a');
-      assert.equal(child.getSymbol(6), 'b');
-      assert.equal(child.getSymbol(7), 'c');
+      assert.equal(child.getSymbolText(1), 'a');
+      assert.equal(child.getSymbolText(2), 'b');
+      assert.equal(child.getSymbolText(3), 'c');
+      assert.isUndefined(child.getSymbolText(4));
+      assert.equal(child.getSymbolText(5), 'a');
+      assert.equal(child.getSymbolText(6), 'b');
+      assert.equal(child.getSymbolText(7), 'c');
     }
 
     registerSuite(suite);

--- a/tests/unit/IonLocalSymbolTableTest.js
+++ b/tests/unit/IonLocalSymbolTableTest.js
@@ -46,7 +46,7 @@ define([
       var symbolTable = ion.defaultLocalSymbolTable();
       assertSystemSymbols(symbolTable);
       try {
-        symbolTable.getSymbol(10);
+        symbolTable.getSymbolText(10);
         throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
@@ -61,9 +61,9 @@ define([
 
       var symbolTable = new ion.LocalSymbolTable(import2);
 
-      assert.isDefined(symbolTable.getSymbol(13));
+      assert.isDefined(symbolTable.getSymbolText(13));
       try{
-          symbolTable.getSymbol(14);
+          symbolTable.getSymbolText(14);
           throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
@@ -93,7 +93,7 @@ define([
       assert.equal(symbolTable.getSymbolId('e'), 14);
       assert.equal(symbolTable.getSymbolId('f'), 15);
       try{
-          symbolTable.getSymbol(16);
+          symbolTable.getSymbolText(16);
           throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
@@ -108,9 +108,9 @@ define([
 
       var symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
-      assert.isDefined(symbolTable.getSymbol(13));
+      assert.isDefined(symbolTable.getSymbolText(13));
       try{
-          symbolTable.getSymbol(14);
+          symbolTable.getSymbolText(14);
           throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
@@ -133,9 +133,9 @@ define([
 
       var symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
-      assert.isDefined(symbolTable.getSymbol(17));
+      assert.isDefined(symbolTable.getSymbolText(17));
       try {
-          symbolTable.getSymbol(18);
+          symbolTable.getSymbolText(18);
           throw new Error("Expected Error.")
       } catch(e) {
           if(e.message === "Expected Error.") throw new Error("Failed to cause index Error")
@@ -145,10 +145,10 @@ define([
       assertSystemSymbols(symbolTable);
       assert.equal(symbolTable.getSymbolId('a'), 10);
       assert.equal(symbolTable.getSymbolId('b'), 11);
-      assert.isUndefined(symbolTable.getSymbol(12));
+      assert.isUndefined(symbolTable.getSymbolText(12));
       assert.equal(symbolTable.getSymbolId('c'), 13);
       assert.equal(symbolTable.getSymbolId('d'), 14);
-      assert.isUndefined(symbolTable.getSymbol(15));
+      assert.isUndefined(symbolTable.getSymbolText(15));
       assert.equal(symbolTable.getSymbolId('e'), 16);
       assert.equal(symbolTable.getSymbolId('f'), 17);
     }
@@ -163,7 +163,7 @@ define([
       assert.isDefined(id, "Unable to add symbol to symbol table");
       assert.equal(id, 10);
 
-      var actualSymbol_ = symbolTable.getSymbol(id);
+      var actualSymbol_ = symbolTable.getSymbolText(id);
       assert.equal(symbol_, actualSymbol_, "Symbol names did not match");
     };
 


### PR DESCRIPTION
*Issue #, if available:* #404, #405

### Overview

This PR refactors the `SharedSymbolTable`, `SubstituteSymbolTable`, and `Import` classes for better encapsulation. 

These changes allowed `SubstituteSymbolTable` to [avoid allocating](https://github.com/amzn/ion-js/issues/404), which reduced the time required to run `grunt test` on my laptop from `2m14.116s` to `0m30.987s`. 🎉 🍾 

### Low-level changes
- The `SharedSymbolTable#symbols()` method has been removed, as it required subclasses (like `SubstituteSymbolTable`) to maintain an array even if it wasn't called for.
- Added `numberOfSymbols()` accessor that can be used instead of `symbols().length`.
- `SubstituteSymbolTable` simply returns `undefined` when asked to resolve a symbol instead of allocating an array filled with `undefined` values and consulting it.
- `SharedSymbolTable` manages its own index from symbol text -> symbol ID rather than requiring outside assistance from `Import`.
- Renamed `getSymbol()` to `getSymbolText()` both to be more explicit and to preserve the `getSymbol` name for a possible later version of the API that returns a `SymbolToken`.

### Out of scope
There is still plenty of room for improvement in this portion of the code base. The following list contains changes which we can/should pursue, but which fell outside the scope of this PR:
* Introducing a `SymbolTable` interface that all of the symbol-table-like classes adhere to.
* Replacing all uses of `undefined` as a possible return value with a well-defined `UNKNOWN_SYMBOL`. (See #425.)
* Having the API center around a proper `SymbolToken` class instead of offering separate methods for `getSymbolText` and `getSymbolId`. (See #121.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
