### PR TITLE
Bug? Single quote cobbled.

### DIFF
--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -322,6 +322,9 @@
     writerTest('Writes string containing single quote',
       writer => writer.writeString('’'),
       '’');
+    writerTest('Writes string containing Russian',
+      writer => writer.writeString('русский'),
+      'русский');
     writerTest('Writes string containing null',
       writer => writer.writeString(String.fromCharCode(0)),
       '"\\0"');

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -319,6 +319,9 @@
     writerTest('Writes string containing double quote',
       writer => writer.writeString('"'),
       '"\\""');
+    writerTest('Writes string containing single quote',
+      writer => writer.writeString('’'),
+      '’');
     writerTest('Writes string containing null',
       writer => writer.writeString(String.fromCharCode(0)),
       '"\\0"');


### PR DESCRIPTION
Looks like `writeText` is garbling `’` as "â or `русский`. Something with encoding?

A more complete example where this appears in a value string:

```
"{Description:\"world’s most popular and authoritative source\"}"
```