### PR TITLE
removes extraneous index++ in IonParserTextRaw that was causing false 'illegal low surrogate' errors, and collapses redundant code

### DIFF
--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -30,6 +30,12 @@ define(
             assert.equal(ionReader.value(), "string");
         };
 
+        suite['Read emoji with modifier'] = function() {
+            let r = ion.makeReader('"👩🏽"');
+            r.next();
+            r.stringValue();
+        };
+
         suite['Read boolean value'] = function() {
             var ionToRead = "true";
             var ionReader = ion.makeReader(ionToRead);


### PR DESCRIPTION
The `index` variable was being incorrectly incremented after an `isLowSurrogate` test.  The block of code for T_STRING1, T_STRING2, and T_STRING3 were nearly identical, so I've collapsed those as well.

Resolves #427 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
