### PR TITLE
improves escaping of non-printable ASCII characters

### DIFF
--- a/src/IonText.ts
+++ b/src/IonText.ts
@@ -267,16 +267,16 @@ function toCharCodes(s: string) {
   return charCodes;
 }
 
+const _HEX_ESCAPE_PREFIX = [CharCodes.BACKSLASH, CharCodes.LOWERCASE_X];
 function hexEscape(codePoint: number) : number[] {
-    let prefix: number[] = [CharCodes.BACKSLASH, CharCodes.LOWERCASE_X];
     let hexEscape: string = codePoint.toString(16);
     while (hexEscape.length < 2) {
         hexEscape = "0" + hexEscape;
     }
-    return prefix.concat(toCharCodes(hexEscape));
+    return _HEX_ESCAPE_PREFIX.concat(toCharCodes(hexEscape));
 }
 
-function hexEscapes(escapes: EscapeIndex, start: number, end?: number) {
+function populateWithHexEscapes(escapes: EscapeIndex, start: number, end?: number) {
     if (end === undefined) {
         escapes[start] = hexEscape(start);
     } else {
@@ -288,7 +288,7 @@ function hexEscapes(escapes: EscapeIndex, start: number, end?: number) {
 
 let CommonEscapes : EscapeIndex = {};
 CommonEscapes[CharCodes.NULL] = backslashEscape('0');
-hexEscapes(CommonEscapes, 1, 7);
+populateWithHexEscapes(CommonEscapes, 1, 7);
 CommonEscapes[CharCodes.BELL] = backslashEscape('a');
 CommonEscapes[CharCodes.BACKSPACE] = backslashEscape('b');
 CommonEscapes[CharCodes.HORIZONTAL_TAB] = backslashEscape('t');
@@ -296,9 +296,9 @@ CommonEscapes[CharCodes.LINE_FEED] = backslashEscape('n');
 CommonEscapes[CharCodes.VERTICAL_TAB] = backslashEscape('v');
 CommonEscapes[CharCodes.FORM_FEED] = backslashEscape('f');
 CommonEscapes[CharCodes.CARRIAGE_RETURN] = backslashEscape('r');
-hexEscapes(CommonEscapes, 14, 32);
+populateWithHexEscapes(CommonEscapes, 14, 32);
 CommonEscapes[CharCodes.BACKSLASH] = backslashEscape('\\');
-hexEscapes(CommonEscapes, 0x7f, 0xa0);
+populateWithHexEscapes(CommonEscapes, 0x7f, 0xa0);
 
 export let ClobEscapes : EscapeIndex = Object['assign']({}, CommonEscapes);
 ClobEscapes[CharCodes.DOUBLE_QUOTE] = backslashEscape('"');

--- a/src/IonText.ts
+++ b/src/IonText.ts
@@ -247,7 +247,7 @@ export enum CharCodes {
   RIGHT_BRACKET = 0x5d,
   COMMA = 0x2c,
   SPACE = 0x20,
-  LOWERCASE_U = 0x75,
+  LOWERCASE_X = 0x78,
   COLON = 0x3a,
 }
 
@@ -267,43 +267,28 @@ function toCharCodes(s: string) {
   return charCodes;
 }
 
-function unicodeEscape(codePoint: number) : number[] {
-  let prefix: number[] = [CharCodes.BACKSLASH, CharCodes.LOWERCASE_U];
-  let hexEscape: string = codePoint.toString(16);
-  while (hexEscape.length < 4) {
-    hexEscape = "0" + hexEscape;
-  }
-  return prefix.concat(toCharCodes(hexEscape));
+function hexEscape(codePoint: number) : number[] {
+    let prefix: number[] = [CharCodes.BACKSLASH, CharCodes.LOWERCASE_X];
+    let hexEscape: string = codePoint.toString(16);
+    while (hexEscape.length < 2) {
+        hexEscape = "0" + hexEscape;
+    }
+    return prefix.concat(toCharCodes(hexEscape));
 }
 
-export let ClobEscapes : EscapeIndex = {};
-ClobEscapes[CharCodes.NULL] = backslashEscape("0");
-ClobEscapes[CharCodes.BELL] = backslashEscape("a");
-ClobEscapes[CharCodes.BACKSPACE] = backslashEscape("b");
-ClobEscapes[CharCodes.HORIZONTAL_TAB] = backslashEscape("t");
-ClobEscapes[CharCodes.LINE_FEED] = backslashEscape("n");
-ClobEscapes[CharCodes.VERTICAL_TAB] = backslashEscape("v");
-ClobEscapes[CharCodes.FORM_FEED] = backslashEscape("f");
-ClobEscapes[CharCodes.CARRIAGE_RETURN] = backslashEscape("r");
-ClobEscapes[CharCodes.DOUBLE_QUOTE] = backslashEscape('"');
-ClobEscapes[CharCodes.SINGLE_QUOTE] = backslashEscape("'");
-ClobEscapes[CharCodes.FORWARD_SLASH] = backslashEscape("/");
-ClobEscapes[CharCodes.QUESTION_MARK] = backslashEscape("?");
-ClobEscapes[CharCodes.BACKSLASH] = backslashEscape("\\");
-
-    function unicodeEscapes(escapes: EscapeIndex, start: number, end?: number) {
-        if (end === undefined) {
-            escapes[start] = unicodeEscape(start);
-        } else {
-            for (let i: number = start; i < end; i++) {
-                escapes[i] = unicodeEscape(i);
-            }
+function hexEscapes(escapes: EscapeIndex, start: number, end?: number) {
+    if (end === undefined) {
+        escapes[start] = hexEscape(start);
+    } else {
+        for (let i: number = start; i < end; i++) {
+            escapes[i] = hexEscape(i);
         }
     }
+}
 
 let CommonEscapes : EscapeIndex = {};
 CommonEscapes[CharCodes.NULL] = backslashEscape('0');
-unicodeEscapes(CommonEscapes, 1, 6);
+hexEscapes(CommonEscapes, 1, 7);
 CommonEscapes[CharCodes.BELL] = backslashEscape('a');
 CommonEscapes[CharCodes.BACKSPACE] = backslashEscape('b');
 CommonEscapes[CharCodes.HORIZONTAL_TAB] = backslashEscape('t');
@@ -311,7 +296,15 @@ CommonEscapes[CharCodes.LINE_FEED] = backslashEscape('n');
 CommonEscapes[CharCodes.VERTICAL_TAB] = backslashEscape('v');
 CommonEscapes[CharCodes.FORM_FEED] = backslashEscape('f');
 CommonEscapes[CharCodes.CARRIAGE_RETURN] = backslashEscape('r');
+hexEscapes(CommonEscapes, 14, 32);
 CommonEscapes[CharCodes.BACKSLASH] = backslashEscape('\\');
+hexEscapes(CommonEscapes, 0x7f, 0xa0);
+
+export let ClobEscapes : EscapeIndex = Object['assign']({}, CommonEscapes);
+ClobEscapes[CharCodes.DOUBLE_QUOTE] = backslashEscape('"');
+ClobEscapes[CharCodes.SINGLE_QUOTE] = backslashEscape("'");
+ClobEscapes[CharCodes.FORWARD_SLASH] = backslashEscape("/");
+ClobEscapes[CharCodes.QUESTION_MARK] = backslashEscape("?");
 
 export let StringEscapes : EscapeIndex = Object['assign']({}, CommonEscapes);
 StringEscapes[CharCodes.DOUBLE_QUOTE] = backslashEscape('"');

--- a/tests/unit/IonTextTest.js
+++ b/tests/unit/IonTextTest.js
@@ -72,6 +72,37 @@
     isOperatorTest('!a', false);
     isOperatorTest('<=>', true);
 
+    let escapeTest = (ch, expected) => {
+        let value = String.fromCharCode(ch);
+        suite['escape(chr(' + ch + '), ClobEscapes)'] = () => assert.equal(
+            ionText.escape(value, ionText.ClobEscapes), expected);
+        suite['escape(chr(' + ch + '), StringEscapes)'] = () => assert.equal(
+            ionText.escape(value, ionText.StringEscapes), expected);
+        suite['escape(chr(' + ch + '), SymbolEscapes)'] = () => assert.equal(
+            ionText.escape(value, ionText.SymbolEscapes), expected);
+    };
+    for (let i = 0; i < 32; i++) {
+        let expected;
+        switch (i) {
+            case  0: expected = '\\0'; break;
+            case  7: expected = '\\a'; break;
+            case  8: expected = '\\b'; break;
+            case  9: expected = '\\t'; break;
+            case 10: expected = '\\n'; break;
+            case 11: expected = '\\v'; break;
+            case 12: expected = '\\f'; break;
+            case 13: expected = '\\r'; break;
+            default:
+                let hex = i.toString(16);
+                expected = '\\x' + '0'.repeat(2 - hex.length) + hex;
+        }
+        escapeTest(i, expected);
+    }
+    escapeTest(0x7e, '~');     // not escaped
+    escapeTest(0x7f, '\\x7f');
+    escapeTest(0x9f, '\\x9f');
+    escapeTest(0xa0, '\xa0');  // not escaped
+
     registerSuite(suite);
   }
 );

--- a/tests/unit/IonTextWriterTest.js
+++ b/tests/unit/IonTextWriterTest.js
@@ -324,7 +324,7 @@
       '"\\0"');
     writerTest('Writes string containing control character',
       writer => writer.writeString(String.fromCharCode(1)),
-      '"\\u0001"');
+      '"\\x01"');
 
     // Structs
 
@@ -371,7 +371,7 @@
       "'\\0'");
     writerTest('Writes symbol containing control character',
       writer => writer.writeSymbol(String.fromCharCode(1)),
-      "'\\u0001'");
+      "'\\x01'");
 
     // Timestamps
 


### PR DESCRIPTION
Fills out the text escape tables a bit, and changes from `\u` to `\x` escapes so the a number of table entries can be shared with clobs (whereas `\u` is not a valid clob escape).

Resolves #431 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
