### PR TITLE
Added Reader#deepValue.

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -21,8 +21,6 @@
 import { Catalog } from "./IonCatalog";
 import { Decimal } from "./IonDecimal";
 import { defaultLocalSymbolTable } from "./IonLocalSymbolTable";
-import { getSystemSymbolTable } from "./IonSystemSymbolTable";
-import { Import } from "./IonImport";
 import { ion_symbol_table_sid } from "./IonSymbols";
 import { IonType } from "./IonType";
 import { IonTypes } from "./IonTypes";
@@ -31,9 +29,9 @@ import { LocalSymbolTable } from "./IonLocalSymbolTable";
 import { makeSymbolTable } from "./IonSymbols";
 import { ParserBinaryRaw } from "./IonParserBinaryRaw";
 import { Reader } from "./IonReader";
-import { SharedSymbolTable } from "./IonSharedSymbolTable";
 import { BinarySpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
+import { makeBinaryWriter } from "./Ion";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
 
@@ -243,6 +241,13 @@ export class BinaryReader implements Reader {
       }
     }
     return s;
+  }
+
+  deepValue(): Uint8Array {
+    let writer = makeBinaryWriter();
+    writer.writeValues(this);
+    writer.close();
+    return writer.getBytes();
   }
 }
 

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -152,4 +152,14 @@ export interface Reader {
      * @throw Error when the reader is not positioned on a scalar value.
      */
     value(): ReaderScalarValue;
+
+    /**
+     * Returns a representation of the ion document.
+     * 
+     * @return `string` String value when text.
+     * @returns `Uint8Array` Binary array when binary.
+     * 
+     * @throws
+     */
+    deepValue: () => string | Uint8Array;
 }

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -22,11 +22,9 @@ import { Catalog } from "./IonCatalog";
 import { Decimal } from "./IonDecimal";
 import { defaultLocalSymbolTable } from "./IonLocalSymbolTable";
 import { get_ion_type } from "./IonParserTextRaw";
-import { getSystemSymbolTable } from "./IonSystemSymbolTable";
 import { ion_symbol_table } from "./IonSymbols";
 import { IonType } from "./IonType";
 import { IonTypes } from "./IonTypes";
-import { IVM } from "./IonConstants";
 import { LocalSymbolTable } from "./IonLocalSymbolTable";
 import { makeSymbolTable } from "./IonSymbols";
 import { ParserTextRaw } from "./IonParserTextRaw";
@@ -34,8 +32,9 @@ import { Reader } from "./IonReader";
 import { StringSpan } from "./IonSpan";
 import { Timestamp } from "./IonTimestamp";
 import { fromBase64 } from "./IonText";
-import { is_digit } from "./IonText";
 import { encodeUtf8 } from "./IonUnicode";
+import { makeTextWriter } from "./Ion";
+import { decodeUtf8 } from "./IonUnicode";
 
 const RAW_STRING = new IonType( -1, "raw_input", true,  false, false, false );
 
@@ -354,5 +353,12 @@ export class TextReader implements Reader {
             default:
                 throw new Error('There is no current value.');
         }
+    }
+
+    deepValue(): string {
+        let writer = makeTextWriter();
+        writer.writeValues(this);
+        writer.close();
+        return decodeUtf8(writer.getBytes());
     }
 };

--- a/tests/unit/IonBinaryReaderTest.js
+++ b/tests/unit/IonBinaryReaderTest.js
@@ -30,6 +30,12 @@ define([
                 reader.next();
                 assert.deepEqual(reader.timestampValue(), timestamp);
             },
+
+            'deepValue': () => {
+              var ivm = [0xe0, 0x01, 0x00, 0xea];
+              var ionReader = ion.makeReader(ivm);
+              assert.deepEqual(ionReader.deepValue(), new Uint8Array(ivm));
+            }
         });
     }
 );

--- a/tests/unit/IonTextReaderTest.js
+++ b/tests/unit/IonTextReaderTest.js
@@ -226,6 +226,19 @@ define(
 
 
         }
+
+        function testDeepValue(ionToRead, expectedOutput = ionToRead) {
+            var ionReader = ion.makeReader(ionToRead);
+            assert.equal(ionReader.deepValue(), expectedOutput);
+        }
+
+        suite['data'] = function() {
+            testDeepValue("123");
+            testDeepValue("{x : 123}", "{x:123}");
+            testDeepValue("{x:{y:[\"z\"]}}");
+            testDeepValue("a::123");
+        }
+
         registerSuite(suite);
     }
 );


### PR DESCRIPTION
*Issue #, if available:*

#338, reopening #339 after rebasing and renaming `raw` to `deepValue`.

*Description of changes:*

Proposing an implementation to get deep data from an Ion reader. In my scenario we get an ion document then locate a path within the document, and extract a subdocument from it. This gives a text/binary representation of the sub document. 

Maybe there should be a way to get an ion document from any location as well?

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
