### PR TITLE
Added support for Mocha testing.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,17 +169,37 @@ module.exports = function(grunt) {
         }
       }
     },
-      uglify: { 
-          options: { 
-              compress: true, 
-              mangle: true, 
-              sourceMap: false
-          }, 
-          target: { 
-              src: './dist/browser/js/ion-bundle.js',
-              dest: './dist/browser/js/ion-bundle.min.js',
-          }
+    uglify: {
+        options: {
+            compress: true,
+            mangle: true,
+            sourceMap: false
+        },
+        target: {
+            src: './dist/browser/js/ion-bundle.js',
+            dest: './dist/browser/js/ion-bundle.min.js',
+        }
+    },
+    mochaTest: {
+      test: {
+        options: {
+          ui: 'mocha-typescript',
+          require: [
+              'ts-node/register',
+              'source-map-support/register',
+              'nyc'
+          ],
+          noFail: false // Run all tests even if an early test fails
+        },
+        src: ['test/**/*.ts']
       }
+    },
+    shell: {
+      // Uses the nyc configuration from package.json and the mocha settings from test/mocha.opts
+      "mochaWithCoverage": {
+        command: "npx nyc mocha --colors"
+      }
+    }
   });
 
   grunt.loadNpmTasks('grunt-babel');
@@ -188,6 +208,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-ts');
   grunt.loadNpmTasks('grunt-typedoc');
   grunt.loadNpmTasks('remap-istanbul');
@@ -205,6 +227,10 @@ module.exports = function(grunt) {
   grunt.registerTask('build', [
       'clean', 'build:es6', 'build:amd', 'build:cjs', 'copy:bigInt', 'trans:browser', 'copy:all'
   ]);
+
+  // Temporary targets that will eventually replace 'test' and 'test:coverage'
+  grunt.registerTask('mocha', ['mochaTest']);
+  grunt.registerTask('mocha:coverage', ['shell:mochaWithCoverage']);
 
   // Tests
   grunt.registerTask('test', ['build', 'intern:es6']);     // build and test

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "types": "dist/commonjs/es6/Ion.d.ts",
   "scripts": {
     "commit": "git-cz",
-    "test": "grunt test",
+    "test": "nyc mocha",
     "release": "grunt release",
-    "clean": "grunt clean",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -31,6 +30,17 @@
       "path": "node_modules/cz-conventional-changelog"
     }
   },
+  "nyc": {
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "include": [
+      "src/**.ts"
+    ],
+    "exclude": [
+      "src/.**"
+    ],
+    "check-coverage": false
+  },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
@@ -39,7 +49,12 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.5",
     "@babel/runtime": "^7.5.5",
+    "@istanbuljs/nyc-config-typescript": "^0.1.3",
+    "@types/chai": "^4.2.3",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.7.7",
     "babelify": "^10.0.0",
+    "chai": "^4.2.0",
     "commitizen": "^4.0.3",
     "cz-conventional-changelog": "^3.0.2",
     "grunt": "^1.0.4",
@@ -50,11 +65,18 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^2.1.0",
     "grunt-contrib-uglify": "^4.0.1",
+    "grunt-mocha-test": "^0.13.3",
+    "grunt-shell": "^3.0.1",
     "grunt-ts": "^6.0.0-beta.21",
     "grunt-typedoc": "^0.2.4",
     "intern": "^3.4.1",
+    "mocha": "^6.2.0",
+    "mocha-typescript": "^1.1.17",
+    "nyc": "^14.1.1",
     "remap-istanbul": "^0.13.0",
     "semantic-release": "^15.13.24",
+    "source-map-support": "^0.5.13",
+    "ts-node": "^8.4.1",
     "typedoc": "^0.15.0",
     "typescript": "^3.6.2"
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+--require ts-node/register
+--ui mocha-typescript
+--require source-map-support/register
+
+test/*.ts

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,38 @@
+import {assert} from 'chai';
+import {suite, test} from "mocha-typescript";
+import * as util from "../src/util";
+
+@suite('util')
+class UtilTests {
+    @test "_hasValue(undefined)"() {
+        assert.equal(util._hasValue(undefined), false);
+    }
+
+    @test "_hasValue(null)"() {
+        assert.equal(util._hasValue(null), false);
+    }
+
+    @test "_hasValue(0)"() {
+        assert.equal(util._hasValue(0), true);
+    }
+
+    @test "_hasValue(1)"() {
+        assert.equal(util._hasValue(1), true);
+    }
+
+    @test "_sign(-1)"() {
+        assert.equal(util._sign(-1), -1);
+    }
+
+    @test "_sign(-0)"() {
+        assert.equal(util._sign(-0), -1);
+    }
+
+    @test "_sign(0)"() {
+        assert.equal(util._sign(0), 1);
+    }
+
+    @test "_sign(1)"() {
+        assert.equal(util._sign(1), 1);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
   ],
   "compilerOptions": {
     "target": "es6",
-    "module": "es6",
+    "module": "commonjs",
     "lib": ["es6"],
     "declaration": true,
     "inlineSources": true,
@@ -17,6 +17,7 @@
     // TODO enable this to have stricter checking
     "strict": false,
     "rootDir": "src",
-    "outDir": "dist/es6/es6"
+    "outDir": "dist/es6/es6",
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
*Description of changes:*

This is the first of a three part PR series:
1. **Add support for writing Mocha tests in Typescript.**
2. Migrate all existing intern.js 3 tests to Mocha.
3. Remove intern.js and migrate all grunt build targets to the new mocha tasks.

I've converted the unit tests for the `util` module to the new format as an example.

Once this branch is merged, you'll be able to run `grunt mocha` and `grunt mocha:coverage` from the command line. `grunt:test` will still point to our intern.js tests for now.

I'll add review comments detailing what each section achieves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
