### PR TITLE
Mocha ion-tests, Text+Reader+Writer

### DIFF
--- a/test/IonText.ts
+++ b/test/IonText.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import {assert} from 'chai';
+import * as ion from '../src/Ion';
+import * as IonText from '../src/IonText';
+
+let stringToCharCodes = function (text: string): Uint8Array {
+    let charCodes = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i++) {
+        charCodes[i] = text.charCodeAt(i);
+    }
+    return charCodes;
+}
+
+let base64Test = function (text: string, expected: string) {
+    let msg = text + ' encoded in base64 is ' + expected;
+    it(msg, () => {
+        let charCodes = stringToCharCodes(text);
+        assert.equal(ion.toBase64(charCodes), expected);
+    });
+};
+
+let isIdentifierTest = function (text: string, expected) {
+    let name = text + ' ' + (expected ? 'is' : 'is not') + ' an identifier';
+    it(name, () => {
+        assert.equal(IonText.isIdentifier(text), expected);
+    });
+};
+
+let isOperatorTest = function (text: string, expected) {
+    let name = text + ' ' + (expected ? 'is' : 'is not') + ' an operator';
+    it(name, () => {
+        assert.equal(IonText.isOperator(text), expected);
+    });
+}
+
+let escapeTest = (ch, expected) => {
+    let value = String.fromCharCode(ch);
+    it('escape(chr(' + ch + '), ClobEscapes)', () => {
+        assert.equal(IonText.escape(value, IonText.ClobEscapes), expected);
+    });
+    it('escape(chr(' + ch + '), StringEscapes)', () => {
+        assert.equal(IonText.escape(value, IonText.StringEscapes), expected);
+    });
+    it('escape(chr(' + ch + '), SymbolEscapes)', () => {
+        assert.equal(IonText.escape(value, IonText.SymbolEscapes), expected);
+    });
+};
+
+describe('IonText', () => {
+    describe('base64 encoding', () => {
+        base64Test("M", "TQ==");
+        base64Test("Ma", "TWE=");
+        base64Test("Man", "TWFu");
+        base64Test("ManM", "TWFuTQ==");
+        base64Test("ManMa", "TWFuTWE=");
+        base64Test("ManMan", "TWFuTWFu");
+    });
+    describe('Detecting identifiers', () => {
+        isIdentifierTest('$', true);
+        isIdentifierTest('0$', false);
+        isIdentifierTest('abc123', true);
+        isIdentifierTest('_', true);
+        isIdentifierTest('{}', false);
+    });
+    describe('Detecting operators', () => {
+        isOperatorTest('!', true);
+        isOperatorTest('!!', true);
+        isOperatorTest('a', false);
+        isOperatorTest('a!', false);
+        isOperatorTest('!a', false);
+        isOperatorTest('<=>', true);
+    });
+    describe('Escaping strings', () => {
+        for (let i = 0; i < 32; i++) {
+            let expected;
+            switch (i) {
+                case  0:
+                    expected = '\\0';
+                    break;
+                case  7:
+                    expected = '\\a';
+                    break;
+                case  8:
+                    expected = '\\b';
+                    break;
+                case  9:
+                    expected = '\\t';
+                    break;
+                case 10:
+                    expected = '\\n';
+                    break;
+                case 11:
+                    expected = '\\v';
+                    break;
+                case 12:
+                    expected = '\\f';
+                    break;
+                case 13:
+                    expected = '\\r';
+                    break;
+                default:
+                    let hex = i.toString(16);
+                    expected = '\\x' + '0'.repeat(2 - hex.length) + hex;
+            }
+            escapeTest(i, expected);
+        }
+        escapeTest(0x7e, '~');     // not escaped
+        escapeTest(0x7f, '\\x7f');
+        escapeTest(0x9f, '\\x9f');
+        escapeTest(0xa0, '\xa0');  // not escaped
+    });
+});

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import {assert} from 'chai';
+import {suite, test} from "mocha-typescript";
+import * as ion from '../src/Ion';
+
+@suite('Text Reader')
+class IonTextReaderTests {
+    @test "Read string value"() {
+        let ionToRead = "\"string\"";
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ionReader.value(), "string");
+    }
+
+    @test "Read emoji with modifier"() {
+        let s: string = 'a👩🏽b👩🏽👩🏽c';
+        let r: ion.Reader = ion.makeReader("'" + s + "'" + ' ' + '"' + s + '"' + ' ' + "'''" + s + "'''");
+        r.next();
+        assert.equal(r.stringValue(), s);
+        r.next();
+        assert.equal(r.stringValue(), s);
+        r.next();
+        assert.equal(r.stringValue(), s);
+    }
+
+    @test "Read boolean value"() {
+        let ionToRead = "true";
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ionReader.value(), true);
+    }
+
+    @test "Read boolean value in struct"() {
+        let ionToRead = "{ a: false }";
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+        ionReader.stepIn();
+        ionReader.next();
+
+        assert.equal(ionReader.value(), false);
+    }
+
+    @test "resolves symbol IDs"() {
+        let ionToRead = `$ion_symbol_table::{ symbols:[ "rock", "paper", "scissors" ]}{ $5: $6, $10: $11, $12: 'taco' }`;
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+        ionReader.stepIn();
+        ionReader.next();
+        assert.equal(ionReader.fieldName(), 'version');
+        assert.equal(ionReader.value(), 'imports');
+        ionReader.next();
+        assert.equal(ionReader.fieldName(), "rock");
+        assert.equal(ionReader.value(), "paper");
+        ionReader.next();
+        assert.equal(ionReader.fieldName(), "scissors");
+        assert.equal(ionReader.value(), 'taco');
+    }
+
+    @test "Parse through struct"() {
+        var ionToRead = "{ key : \"string\" }";
+        var ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "key");
+        assert.equal(ionReader.value(), "string");
+
+        assert.isNull(ionReader.next());
+    }
+
+    @test "Parse through struct can skip over container"() {
+        var ionToRead = "{ a: { key1 : \"string1\" }, b: { key2 : \"string2\" } }";
+        var ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "a");
+
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "b");
+
+        ionReader.stepIn(); // Step into the "b" struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "key2");
+        assert.equal(ionReader.value(), "string2");
+
+        assert.isNull(ionReader.next());
+    }
+
+    @test "Parse through struct can skip over nested containers"() {
+        var ionToRead = "{ outerkey1 : { innerkey1 : {a1: \"a1\", b1: \"b1\"} }, outerkey2 : { innerkey2 : {a2: \"a2\", b2: \"b2\"} } }";
+        var ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "outerkey1");
+
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "outerkey2");
+
+        ionReader.stepIn(); // Step into the "b" struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "innerkey2");
+
+        assert.isNull(ionReader.next());
+    }
+
+    @test "Reads an array"() {
+        var ionToRead = "{ key : ['v1', 'v2'] }";
+        var ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "key");
+
+        ionReader.stepIn(); // Step into the array.
+
+        ionReader.next();
+        assert.equal(ionReader.value(), "v1");
+
+        ionReader.next();
+        assert.equal(ionReader.value(), "v2");
+
+        assert.isNull(ionReader.next());
+    }
+
+    @test "Reads a nested array"() {
+        var ionToRead = "{ key : [['v1', 'v2']] }";
+        var ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+        ionReader.next();
+
+        assert.equal(ionReader.fieldName(), "key");
+
+        ionReader.stepIn(); // Step into the outer array.
+        ionReader.next();
+        ionReader.stepIn(); // Step into the inner array.
+
+        ionReader.next();
+        assert.equal(ionReader.value(), "v1");
+
+        ionReader.next();
+        assert.equal(ionReader.value(), "v2");
+
+        assert.isNull(ionReader.next());
+    }
+
+    @test "Returns null on EOF"() {
+        var ionToRead = "";
+        var ionReader = ion.makeReader(ionToRead);
+        assert.isNull(ionReader.next());
+        assert.isNull(ionReader.next()); // EOF
+    }
+
+    @test "text IVM"() {
+        var textReader = ion.makeReader("");
+        let isNotIVM = ["$ion_schema_1_0", "$ion_1", "$ion_1_a", "$ion_", "ion_1_"];
+        let unsupportedIVM = ["$ion_2_0", "$ion_1_999", "$ion_999_0", "$ion_1_1", "$ion_1_00"];
+
+        IonTextReaderTests.ivmTest(textReader,"$ion_1_0", true, 0, []);
+        IonTextReaderTests.ivmTest(textReader,"$ion_1_0", false, 1, []);
+        IonTextReaderTests.ivmTest(textReader,"$ion_1_0", false, 0, ["taco"]);
+        for (let i = 0; i < isNotIVM.length; i++) {
+            IonTextReaderTests.ivmTest(textReader, isNotIVM[i], false, 0, []);
+        }
+        for (let i = 0; i < unsupportedIVM.length; i++) {
+            IonTextReaderTests.ivmTest(textReader, unsupportedIVM[i], "throw", 0, []);
+            IonTextReaderTests.ivmTest(textReader, unsupportedIVM[i], false, 1, []);
+            IonTextReaderTests.ivmTest(textReader, unsupportedIVM[i], false, 0, ["taco"]);
+        }
+    }
+
+    private static ivmTest(reader, value, expected, depth, annotations) {
+        if (expected === "throw") {
+            assert.throws(() => { reader.isIVM(value, depth, annotations)});
+        } else {
+            let actual = reader.isIVM(value, depth, annotations);
+            assert.equal(actual, expected);
+        }
+    }
+}

--- a/test/IonTextWriter.ts
+++ b/test/IonTextWriter.ts
@@ -1,0 +1,562 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {assert} from 'chai';
+import * as ion from '../src/Ion';
+import * as IonUnicode from '../src/IonUnicode';
+import * as IonTests from '../src/IonTests';
+import {TextWriter} from '../src/IonTextWriter';
+
+// FIXME: While implementations happen to have an 'isTopLevel' function, the Writer interface we expose does not.
+let isTopLevel = function (writer: ion.Writer): boolean {
+    return writer['isTopLevel'];
+};
+
+let writerTest = function (name: string, instructions, expected) {
+    it(name, () => {
+        let writeable = new IonTests.Writeable();
+        let writer = new TextWriter(writeable);
+        instructions(writer);
+        while (!isTopLevel(writer)) {
+            writer.stepOut();
+        }
+        writer.close();
+        let actual = writeable.getBytes();
+        let errorMessage = String.fromCharCode.apply(null, actual) + " != " + expected;
+        let encodedExpected = IonUnicode.encodeUtf8(expected);
+        assert.deepEqual(actual, encodedExpected, errorMessage);
+    });
+};
+
+let prettyTest = function (name, instructions, expected) {
+    it(name, () => {
+        let writer = ion.makePrettyWriter(2);
+        instructions(writer);
+        while (!isTopLevel(writer)) {
+            writer.stepOut();
+        }
+        writer.close();
+        let buf = writer.getBytes();
+        let str = '';
+        for (let i = 0; i < buf.length; i++) {
+            str += String.fromCharCode(buf[i]);
+        }
+        let msg = str + " != " + expected;
+        assert.deepEqual(str, expected, msg);
+    });
+};
+
+let badWriterTest = function (name, instructions) {
+    let test = function () {
+        let writer = ion.makeTextWriter();
+        instructions(writer);
+        writer.close();
+    };
+    it(name, () => {
+        assert.throws(test, Error);
+    });
+};
+
+describe("Text Writer", () => {
+    describe("Writing blobs", () => {
+        writerTest('Writes blob',
+            writer => writer.writeBlob([1, 2, 3]),
+            '{{AQID}}');
+        writerTest('Writes null blob using null',
+            writer => writer.writeBlob(null),
+            'null.blob');
+        writerTest('Writes null blob using undefined',
+            writer => writer.writeBlob(),
+            'null.blob');
+        writerTest('Writes null blob using type',
+            writer => writer.writeNull(ion.IonTypes.BLOB),
+            'null.blob');
+        writerTest('Writes blob with identifier annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.writeBlob([1, 2, 3])
+            },
+            'foo::bar::{{AQID}}');
+        writerTest('Writes blob with non-identifier annotations',
+            writer => {
+                writer.setAnnotations(['123abc', '{}']);
+                writer.writeBlob([1, 2, 3])
+            },
+            "'123abc'::'{}'::{{AQID}}");
+    });
+
+    describe("Writing booleans", () => {
+        writerTest('Writes boolean true',
+            writer => writer.writeBoolean(true),
+            'true');
+        writerTest('Writes boolean false',
+            writer => writer.writeBoolean(false),
+            'false');
+        writerTest('Writes null boolean using null',
+            writer => writer.writeBoolean(null),
+            'null.bool');
+        writerTest('Writes null boolean using undefined',
+            writer => writer.writeBoolean(),
+            'null.bool');
+        writerTest('Writes null boolean using type',
+            writer => writer.writeNull(ion.IonTypes.BOOL),
+            'null.bool');
+        writerTest('Writes boolean with annotations',
+            writer => {
+                writer.setAnnotations(['abc', '123']);
+                writer.writeBoolean(true)
+            },
+            "abc::'123'::true");
+    });
+
+    describe("Writing clob", () => {
+        writerTest('Writes clob',
+            writer => writer.writeClob(['A'.charCodeAt(0)]),
+            '{{"A"}}');
+        writerTest('Writes null clob using null',
+            writer => writer.writeClob(null),
+            'null.clob');
+        writerTest('Writes null clob using undefined',
+            writer => writer.writeClob(),
+            'null.clob');
+        writerTest('Writes null clob using type',
+            writer => writer.writeNull(ion.IonTypes.CLOB),
+            'null.clob');
+        writerTest('Writes clob with annotations',
+            writer => {
+                writer.setAnnotations(['baz', 'qux']);
+                writer.writeClob(['A'.charCodeAt(0)])
+            },
+            'baz::qux::{{"A"}}');
+        writerTest('Writes clob escapes',
+            writer => writer.writeClob([0x00, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x22, 0x27, 0x2f, 0x3f, 0x5c]),
+            '{{"\\0\\a\\b\\t\\n\\v\\f\\r\\"\\\'\\/\\?\\\\"}}');
+    });
+
+    describe("Writing decimals", () => {
+        let decimalTest = function (name, decimalString, expected) {
+            writerTest(
+                name,
+                writer => writer.writeDecimal(ion.Decimal.parse(decimalString)),
+                expected
+            );
+        };
+        decimalTest('Writes positive decimal', '123.456', '123456d-3');
+        decimalTest('Writes negative decimal', '-123.456', '-123456d-3');
+        decimalTest('Writes integer decimal', '123456.', '123456d0');
+        decimalTest('Mantissa-only decimal has leading zero', '123456d-6', '123456d-6');
+        writerTest('Writes null decimal using null',
+            writer => writer.writeDecimal(null),
+            'null.decimal');
+        writerTest('Writes null decimal using undefined',
+            writer => writer.writeDecimal(),
+            'null.decimal');
+        writerTest('Writes null decimal using type',
+            writer => writer.writeNull(ion.IonTypes.DECIMAL),
+            'null.decimal');
+        writerTest('Writes decimal with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.writeDecimal(ion.Decimal.parse('123.456'))
+            },
+            'foo::bar::123456d-3');
+    });
+
+    describe("Writing floats", () => {
+        writerTest('Writes 32-bit float',
+            writer => writer.writeFloat32(8.125),
+            '8.125e0');
+        writerTest('Writes null 32-bit float using null',
+            writer => writer.writeFloat32(null),
+            'null.float');
+        writerTest('Writes null 32-bit float using undefined',
+            writer => writer.writeFloat32(),
+            'null.float');
+        writerTest('Writes 32-bit float with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.writeFloat32(8.125)
+            },
+            'foo::bar::8.125e0');
+        writerTest('Writes negative 32-bit float',
+            writer => writer.writeFloat32(-8.125),
+            '-8.125e0');
+        writerTest('Writes positive 0 as a 32-bit float',
+            writer => writer.writeFloat32(0),
+            '0e0');
+        writerTest('Writes negative 0 as a 32-bit float',
+            writer => writer.writeFloat32(-0),
+            '-0e0');
+        writerTest('Writes nan as a 32-bit float',
+            writer => writer.writeFloat32(NaN),
+            'nan');
+        writerTest('Writes +inf as a 32-bit float',
+            writer => writer.writeFloat32(Number.POSITIVE_INFINITY),
+            '+inf');
+        writerTest('Writes -inf as a 32-bit float',
+            writer => writer.writeFloat32(Number.NEGATIVE_INFINITY),
+            '-inf');
+
+        writerTest('Writes 64-bit float',
+            writer => writer.writeFloat64(8.125),
+            '8.125e0');
+        writerTest('Writes null 64-bit float using null',
+            writer => writer.writeFloat64(null),
+            'null.float');
+        writerTest('Writes null 64-bit float using undefined',
+            writer => writer.writeFloat64(),
+            'null.float');
+        writerTest('Writes 64-bit float with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.writeFloat64(8.125)
+            },
+            'foo::bar::8.125e0');
+        writerTest('Writes negative 64-bit float',
+            writer => writer.writeFloat64(-8.125),
+            '-8.125e0');
+        writerTest('Writes positive 0 as a 64-bit float',
+            writer => writer.writeFloat64(0),
+            '0e0');
+        writerTest('Writes negative 0 as a 64-bit float',
+            writer => writer.writeFloat64(-0),
+            '-0e0');
+        writerTest('Writes ten billion as a 64-bit float',
+            writer => writer.writeFloat64(10000000000),
+            '1e10');
+        writerTest('Writes nan as a 64-bit float',
+            writer => writer.writeFloat64(Number.NaN),
+            'nan');
+        writerTest('Writes +inf as a 64-bit float',
+            writer => writer.writeFloat64(Number.POSITIVE_INFINITY),
+            '+inf');
+        writerTest('Writes -inf as a 64-bit float',
+            writer => writer.writeFloat64(Number.NEGATIVE_INFINITY),
+            '-inf');
+    });
+
+    describe("Writing ints", () => {
+        writerTest('Writes positive int',
+            writer => writer.writeInt(123456),
+            '123456');
+        writerTest('Writes negative int',
+            writer => writer.writeInt(-123456),
+            '-123456');
+        writerTest('Writes null int using null',
+            writer => writer.writeInt(null),
+            'null.int');
+        writerTest('Writes null int using undefined',
+            writer => writer.writeInt(),
+            'null.int');
+        writerTest('Writes null using type',
+            writer => writer.writeNull(ion.IonTypes.INT),
+            'null.int');
+
+    });
+
+    describe("Writing lists", () => {
+        writerTest('Writes empty list',
+            writer => writer.stepIn(ion.IonTypes.LIST),
+            '[]');
+        writerTest('Writes empty list with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.stepIn(ion.IonTypes.LIST)
+            },
+            'foo::bar::[]');
+        writerTest('Writes nested empty lists',
+            writer => {
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.stepIn(ion.IonTypes.LIST)
+            },
+            '[[[]]]');
+        writerTest('Writes list with multiple values',
+            writer => {
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.writeSymbol('$');
+                writer.writeSymbol('%')
+            },
+            "[$,'%']");
+        writerTest('Writes nested lists with multiple values',
+            writer => {
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.writeSymbol('foo');
+                writer.writeSymbol('bar');
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.writeSymbol('baz');
+                writer.writeSymbol('qux');
+            },
+            '[foo,bar,[baz,qux]]'
+        );
+    });
+
+    describe("Writing nulls", () => {
+        writerTest('Writes null',
+            writer => writer.writeNull(ion.IonTypes.NULL),
+            'null.null');
+        writerTest('Writes null with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.writeNull(ion.IonTypes.NULL)
+            },
+            'foo::bar::null.null');
+    });
+
+    describe("Writing s-expressions", () => {
+        writerTest('Writes empty sexp',
+            writer => writer.stepIn(ion.IonTypes.SEXP),
+            '()');
+        writerTest('Writes null sexp',
+            writer => writer.writeNull(ion.IonTypes.SEXP),
+            'null.sexp');
+        writerTest('Writes empty sexp with annotations',
+            writer => {
+                writer.setAnnotations(['foo', 'bar']);
+                writer.stepIn(ion.IonTypes.SEXP)
+            },
+            'foo::bar::()');
+        writerTest('Writes sexp with adjacent operators',
+            writer => {
+                writer.stepIn(ion.IonTypes.SEXP);
+                writer.writeSymbol('+');
+                writer.writeSymbol('-');
+                writer.writeSymbol('/');
+            },
+            '(+ - /)');
+        writerTest('Writes sexp with expression',
+            writer => {
+                writer.stepIn(ion.IonTypes.SEXP);
+                writer.writeSymbol('x');
+                writer.writeSymbol('+');
+                writer.writeSymbol('y');
+            },
+            '(x + y)');
+    });
+
+    describe("Writing strings", () => {
+        writerTest('Writes string containing double quote',
+            writer => writer.writeString('"'),
+            '"\\""');
+        writerTest('Writes string containing null',
+            writer => writer.writeString(String.fromCharCode(0)),
+            '"\\0"');
+        writerTest('Writes string containing control character',
+            writer => writer.writeString(String.fromCharCode(1)),
+            '"\\x01"');
+    });
+
+    describe("Writing structs", () => {
+        writerTest('Writes empty struct',
+            writer => writer.stepIn(ion.IonTypes.STRUCT),
+            '{}');
+        writerTest('Writes nested structs',
+            writer => {
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('foo');
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.stepOut();
+                writer.writeFieldName('bar');
+                writer.stepIn(ion.IonTypes.STRUCT);
+            },
+            '{foo:{},bar:{}}');
+        writerTest('Writes struct with non-identifier field name and annotation',
+            writer => {
+                writer.setAnnotations(['1foo']);
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('123');
+                writer.setAnnotations(['2bar']);
+                writer.stepIn(ion.IonTypes.STRUCT);
+            },
+            "'1foo'::{'123':'2bar'::{}}");
+        badWriterTest('Cannot write field name at top level',
+            writer => writer.writeFieldName('foo'));
+        badWriterTest('Cannot write field name inside non-struct',
+            writer => {
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.writeFieldName('foo')
+            });
+        badWriterTest('Cannot write two adjacent field names',
+            writer => {
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('foo');
+                writer.writeFieldName('foo')
+            });
+        badWriterTest('Cannot write value without field name',
+            writer => {
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeSymbol('foo')
+            });
+        badWriterTest('Cannot end struct with missing field value',
+            writer => {
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('foo');
+                writer.stepOut()
+            });
+    });
+
+    describe("Writing symbols", () => {
+        writerTest('Writes symbol containing single quote',
+            writer => writer.writeSymbol("'"),
+            "'\\''");
+        writerTest('Writes symbol containing null',
+            writer => writer.writeSymbol(String.fromCharCode(0)),
+            "'\\0'");
+        writerTest('Writes symbol containing control character',
+            writer => writer.writeSymbol(String.fromCharCode(1)),
+            "'\\x01'");
+    });
+
+    describe("Writing timestamps", () => {
+        let timestampTest = function (name, timestamp, expected) {
+            writerTest(
+                name,
+                writer => writer.writeTimestamp(ion.Timestamp.parse(timestamp)),
+                expected
+            );
+        };
+
+        timestampTest('Writes year timestamp', '2017T', '2017T');
+        timestampTest('Writes month timestamp', '2017-02T', '2017-02T');
+        timestampTest('Writes day timestamp', '2017-02-01', '2017-02-01T');
+        timestampTest('Writes hour and minute timestamp', '2017-02-01T22:38+00:00', '2017-02-01T22:38Z');
+        timestampTest('Writes whole second timestamp', '2017-02-01T22:38:43+00:00', '2017-02-01T22:38:43Z');
+        timestampTest('Writes fractional second timestamp', '2017-02-01T22:38:43.125Z', '2017-02-01T22:38:43.125Z');
+
+        timestampTest('Writes positive offset timestamp', '2017-02-01T22:38+08:00', '2017-02-01T22:38+08:00');
+        timestampTest('Writes negative offset timestamp', '2017-02-01T22:38-08:00', '2017-02-01T22:38-08:00');
+        timestampTest('Writes zulu offset timestamp', '2017-02-01T22:38Z', '2017-02-01T22:38Z');
+    });
+
+    describe("Writing datagrams", () => {
+        writerTest('Writes two top-level symbols',
+            writer => {
+                writer.writeSymbol('a');
+                writer.writeSymbol('b')
+            },
+            'a\nb');
+        writerTest('Writes two top-level lists',
+            writer => {
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.stepOut();
+                writer.stepIn(ion.IonTypes.LIST)
+            },
+            '[]\n[]');
+        writerTest('Writes two top-level lists with annotations',
+            writer => {
+                writer.setAnnotations(['foo']);
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.stepOut();
+                writer.setAnnotations(['bar']);
+                writer.stepIn(ion.IonTypes.LIST);
+            },
+            'foo::[]\nbar::[]');
+        writerTest('Writes two top-level structs',
+            writer => {
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.stepOut();
+                writer.stepIn(ion.IonTypes.STRUCT)
+            },
+            '{}\n{}');
+    });
+
+    describe("Pretty printing", () => {
+        prettyTest('Writes composite pretty ion',
+            writer => {
+                writer.setAnnotations(['a1']);
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('int');
+                writer.setAnnotations(['a3']);
+                writer.writeInt(123);
+                writer.writeFieldName('string');
+                writer.setAnnotations(['a4']);
+                writer.writeString('string');
+                writer.writeFieldName('symbol');
+                writer.setAnnotations(['a5']);
+                writer.writeSymbol('symbol');
+                writer.writeFieldName('symbol');
+                writer.writeNull(ion.IonTypes.SYMBOL);
+                writer.writeFieldName('timestamp');
+                writer.setAnnotations(['a8']);
+                writer.writeTimestamp(ion.Timestamp.parse('2017-04-03T00:00:00.000Z'));
+                writer.writeFieldName('decimal');
+                writer.setAnnotations(['a9']);
+                writer.writeDecimal(ion.Decimal.parse('1.2'));
+                writer.writeFieldName('struct');
+                writer.setAnnotations(['a10']);
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.writeFieldName('symbol');
+                writer.setAnnotations(['a11']);
+                writer.writeSymbol('symbol');
+                writer.stepOut();
+                writer.writeFieldName('list');
+                writer.setAnnotations(['a12']);
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.setAnnotations(['a14']);
+                writer.writeInt(123);
+                writer.setAnnotations(['a15']);
+                writer.writeString('string');
+                writer.setAnnotations(['a16']);
+                writer.writeSymbol('symbol');
+                writer.setAnnotations(['a19']);
+                writer.writeTimestamp(ion.Timestamp.parse('2017-04-03T00:00:00.000Z'));
+                writer.setAnnotations(['a20']);
+                writer.writeDecimal(ion.Decimal.parse('1.2'));
+                writer.setAnnotations(['a21']);
+                writer.stepIn(ion.IonTypes.STRUCT);
+                writer.stepOut();
+                writer.setAnnotations(['a22']);
+                writer.stepIn(ion.IonTypes.LIST);
+                writer.stepOut();
+                writer.stepOut();
+                writer.writeFieldName('sexp');
+                writer.setAnnotations(['a23']);
+                writer.stepIn(ion.IonTypes.SEXP);
+                writer.setAnnotations(['a24']);
+                writer.writeNull(ion.IonTypes.SYMBOL);
+                writer.setAnnotations(['a25']);
+                writer.writeNull(ion.IonTypes.STRING);
+                writer.setAnnotations(['a26']);
+                writer.writeNull(ion.IonTypes.NULL);
+                writer.stepOut();
+            },
+            `a1::{
+  int:a3::123,
+  string:a4::"string",
+  symbol:a5::symbol,
+  symbol:null.symbol,
+  timestamp:a8::2017-04-03T00:00:00.000Z,
+  decimal:a9::12d-1,
+  struct:a10::{
+    symbol:a11::symbol
+  },
+  list:a12::[
+    a14::123,
+    a15::"string",
+    a16::symbol,
+    a19::2017-04-03T00:00:00.000Z,
+    a20::12d-1,
+    a21::{
+    },
+    a22::[
+    ]
+  ],
+  sexp:a23::(
+    a24::null.symbol 
+    a25::null.string 
+    a26::null.null
+  )
+}`);
+    });
+});

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -1,0 +1,550 @@
+/*
+ * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import {assert} from 'chai';
+import * as ion from '../src/Ion';
+import * as fs from 'fs';
+import * as path from 'path';
+import {IonEventStream} from '../src/IonEventStream';
+
+function findFiles(folder, files = []) {
+    fs.readdirSync(folder).forEach(file => {
+        let filePath = path.join(folder, file);
+        let stats = fs.lstatSync(filePath);
+        if (stats.isDirectory()) {
+            findFiles(filePath, files);
+        } else {
+            files.push(filePath);
+        }
+    });
+    return files;
+}
+
+function exhaust(reader) {
+    for (let type; type = reader.next();) {
+        if (type.isContainer && !reader.isNull()) {
+            reader.stepIn();
+            exhaust(reader);
+            reader.stepOut();
+        } else {
+            reader.value();
+        }
+    }
+}
+
+function loadValues(path, newWriter) {
+    let reader = ion.makeReader(getInput(path));
+    let values = [];
+    let containerIdx = 0;
+
+    for (let topLevelType; topLevelType = reader.next();) {
+        if (!topLevelType.isContainer) {
+            throw Error('Expected top-level value to be a container, was ' + topLevelType);
+        }
+
+        reader.stepIn();
+        values.push([]);
+
+        for (let type; type = reader.next();) {
+            let writer = newWriter();
+            writer.writeValue(reader);
+            writer.close();
+            values[containerIdx].push(writer.getBytes());
+        }
+
+        containerIdx += 1;
+        reader.stepOut();
+    }
+    return values;
+}
+
+function bytesToString(c, idx, bytes) {
+    let sb = '[' + c + '][' + idx + ']';
+    if (bytes.length >= 4 && bytes[0] === 224 && bytes[1] === 1 && bytes[2] === 0 && bytes[3] === 234) {
+        // Ion binary, convert to hex string
+        bytes.forEach(b => {
+            sb += ' ' + ('0' + (b & 0xFF).toString(16)).slice(-2);
+        });
+        return sb;
+    }
+    // otherwise, text:
+    return sb + ' ' + String.fromCharCode.apply(null, bytes);
+}
+
+function equivsTestCompare(c, i, j, bytesI, bytesJ, expectedEquivalence) {
+    let eventStreamI = new IonEventStream(ion.makeReader(bytesI));
+    let eventStreamJ = new IonEventStream(ion.makeReader(bytesJ));
+    let result = eventStreamI.equals(eventStreamJ);
+    assert(expectedEquivalence ? result : !result,
+        'Expected ' + bytesToString(c, i, bytesI)
+        + ' to' + (expectedEquivalence ? '' : ' not')
+        + ' be equivalent to ' + bytesToString(c, j, bytesJ));
+}
+
+function equivsTest(path, expectedEquivalence = true, compare = equivsTestCompare) {
+    let binaryValues = loadValues(path, () => ion.makeBinaryWriter());
+    let textValues = loadValues(path, () => ion.makeTextWriter());
+
+    for (let c = 0; c < binaryValues.length; c++) {
+        for (let i = 0; i < binaryValues[c].length; i++) {
+            for (let j = i + 1; j < binaryValues[c].length; j++) {
+                compare(c, i, j, binaryValues[c][i], binaryValues[c][j], expectedEquivalence);
+                compare(c, i, j, binaryValues[c][i], textValues[c][j], expectedEquivalence);
+                compare(c, i, j, textValues[c][i], textValues[c][j], expectedEquivalence);
+            }
+        }
+    }
+}
+
+function nonEquivsTest(path) {
+    equivsTest(path, false);
+}
+
+function equivTimelinesTest(path) {
+    function timelinesCompare(c, i, j, bytesI, bytesJ) {
+        function readTimestamp(bytes) {
+            let reader = ion.makeReader(bytes);
+            reader.next();
+            return reader.timestampValue();
+        }
+
+        let tsI = readTimestamp(bytesI);
+        let tsJ = readTimestamp(bytesJ);
+        // assert that the timestamps represent the same instant (but not necessarily data-model equivalent):
+        assert(tsI.compareTo(tsJ) === 0, 'Expected ' + tsI + ' to be instant-equivalent to ' + tsJ);
+    }
+
+    equivsTest(path, true, timelinesCompare);
+}
+
+function readerCompareTest(source) {
+    function toBytes(source, writer) {
+        let reader = ion.makeReader(source);
+        writer.writeValues(reader);
+        writer.close();
+        return writer.getBytes();
+    }
+
+    let ionBinary = toBytes(source, ion.makeBinaryWriter());
+    let ionText = toBytes(source, ion.makeTextWriter());
+
+    readerCompare(ion.makeReader(ionBinary), ion.makeReader(ionText));
+}
+
+function readerCompare(r1, r2) {
+    checkReaderValueMethods(r1, r2, null);
+
+    while (true) {
+        let t1 = r1.next();
+        let t2 = r2.next();
+
+        let v;
+        try {
+            v = r1.value();
+        } catch (e) {
+            v = 'value() threw ' + e.message;
+        }
+        assert.equal(t1, t2);
+
+        checkReaderValueMethods(r1, r2, t1);
+
+        if (t1 === null) {
+            break;
+        }
+
+        if (t1.isContainer && !r1.isNull()) {
+            r1.stepIn();
+            r2.stepIn();
+            readerCompare(r1, r2);
+            r1.stepOut();
+            r2.stepOut();
+        }
+    }
+}
+
+function checkReaderValueMethods(r1, r2, type) {
+    // This RegEx will immediately match any string that's passed to it.
+    // It's used to allow assert.throws() to accept any Error that's thrown.
+    const ANY_ERROR_MESSAGE = new RegExp('^');
+    allValueMethods.forEach(methodName => {
+        let typeName = type == null ? 'null' : type.name;
+        if (type != null && nonThrowingMethods[typeName][methodName]) {
+            let v1 = r1[methodName]();
+            let v2 = r2[methodName]();
+            assert(v1 !== undefined, "unexpected 'undefined' response");
+            assert(v2 !== undefined, "unexpected 'undefined' response");
+            assert.deepEqual(v1, v2, methodName + '():  ' + v1 + ' != ' + v2);
+        } else {
+            assert.throws(() => {
+                r1[methodName]()
+            }, ANY_ERROR_MESSAGE, 'Expected ' + methodName + '() to throw');
+            assert.throws(() => {
+                r2[methodName]()
+            }, ANY_ERROR_MESSAGE, 'Expected ' + methodName + '() to throw');
+        }
+    });
+
+    assert(r1.depth() !== undefined, 'depth() is undefined');
+    assert(r1.depth() !== null, 'depth() is null');
+    assert(r1.depth() >= 0, 'depth() is less than 0');
+    assert.equal(r1.depth(), r2.depth(), "depths don't match");
+
+    assert(r1.fieldName() !== undefined, 'fieldname() is undefined');
+    assert.equal(r1.fieldName(), r2.fieldName(), "fieldnames don't match");
+
+    assert(r1.isNull() !== undefined, 'isNull() is undefined');
+    assert(r1.isNull() !== null, 'isNull() is null');
+    assert.equal(r1.isNull(), r2.isNull(), "isNull values don't match");
+
+    assert(r1.annotations() !== undefined, 'annotations() is undefined');
+    assert(r1.annotations() !== null, 'annotations() is null');
+    assert.deepEqual(r1.annotations(), r2.annotations(), "annotations don't match");
+
+    assert(r1.type() !== undefined, 'type() is undefined');
+    assert.equal(r1.type(), type, "type() doesn't match expected type");
+    assert.equal(r1.type(), r2.type(), "types don't match");
+}
+
+function getInput(path) {
+    let options = path.endsWith(".10n") ? null : "utf8";
+    return fs.readFileSync(path, options);
+}
+
+function roundTripEventStreams(reader) {
+    let streams = [];
+    streams.push(new IonEventStream(reader));
+
+    let eventWriter = ion.makeTextWriter();
+    streams[0].writeEventStream(eventWriter);
+    eventWriter.close();
+    streams.push(new IonEventStream(ion.makeReader(eventWriter.getBytes())));
+
+    let textWriter = ion.makeTextWriter();
+    streams[0].writeIon(textWriter);
+    streams.push(new IonEventStream(ion.makeReader(textWriter.getBytes())));
+
+    let binaryWriter = ion.makeBinaryWriter();
+    streams[0].writeIon(binaryWriter);
+    streams.push(new IonEventStream(ion.makeReader(binaryWriter.getBytes())));
+
+    let eventTextWriter = ion.makeTextWriter();
+    streams[0].writeIon(eventTextWriter);
+    streams.push(new IonEventStream(ion.makeReader(eventTextWriter.getBytes())));
+
+    let eventBinaryWriter = ion.makeBinaryWriter();
+    streams[0].writeIon(eventBinaryWriter);
+    streams.push(new IonEventStream(ion.makeReader(eventBinaryWriter.getBytes())));
+
+    for (let i = 0; i < streams.length - 1; i++) {
+        for (let j = i + 1; j < streams.length; j++) {
+            if (!streams[i].equals(streams[j])) {
+                throw new Error("Streams unequal.");
+            }
+        }
+    }
+}
+
+// TBD:  add some mechanism to know when this list needs to be updated
+//       (e.g., a class that implements IonReader)
+let allValueMethods = [
+    'booleanValue',
+    'byteValue',
+    'decimalValue',
+    'numberValue',
+    'stringValue',
+    'timestampValue',
+    'value',
+];
+let nonThrowingMethods = {
+    null: {booleanValue: 1, byteValue: 1, decimalValue: 1, numberValue: 1, stringValue: 1, timestampValue: 1, value: 1},
+    bool: {booleanValue: 1, value: 1},
+    int: {numberValue: 1, value: 1},
+    float: {numberValue: 1, value: 1},
+    decimal: {decimalValue: 1, value: 1},
+    timestamp: {timestampValue: 1, value: 1},
+    symbol: {stringValue: 1, value: 1},
+    string: {stringValue: 1, value: 1},
+    clob: {byteValue: 1, value: 1},
+    blob: {byteValue: 1, value: 1},
+    list: {},
+    sexp: {},
+    struct: {},
+};
+
+function toSkipList(paths: Array<string>): Map<string, number> {
+    let skipList = new Map<string, number>();
+    paths.forEach(path => {
+        skipList[path] = 1;
+    });
+
+    // additional, known bad/slow test files:
+    skipList['ion-tests/iontestdata/good/equivs/lists.ion'] = 1;     // runs too long, causes TravisCI to fail
+    skipList['ion-tests/iontestdata/good/equivs/sexps.ion'] = 1;     // runs too long, causes TravisCI to fail
+
+    return skipList;
+}
+
+////// beginning of generated skiplists
+
+let goodSkipList = toSkipList([
+    'ion-tests/iontestdata/good/decimalsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
+    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/floatsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/intBinary.ion',
+    'ion-tests/iontestdata/good/intsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/symbolZero.ion',
+    'ion-tests/iontestdata/good/utf16.ion',
+    'ion-tests/iontestdata/good/utf32.ion',
+
+    // Support for reading LongInts was removed as part of: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
+    'ion-tests/iontestdata/good/intBigSize1201.10n',
+    'ion-tests/iontestdata/good/intBigSize13.10n',
+    'ion-tests/iontestdata/good/intBigSize14.10n',
+    'ion-tests/iontestdata/good/intBigSize16.10n',
+    'ion-tests/iontestdata/good/intBigSize256.10n',
+    'ion-tests/iontestdata/good/intLongMaxValuePlusOne.10n',
+    'ion-tests/iontestdata/good/intLongMinValue.10n',
+]);
+
+let badSkipList = toSkipList([
+    'ion-tests/iontestdata/bad/annotationLengthTooLongContainer.10n',
+    'ion-tests/iontestdata/bad/annotationLengthTooLongScalar.10n',
+    'ion-tests/iontestdata/bad/annotationLengthTooShortContainer.10n',
+    'ion-tests/iontestdata/bad/annotationLengthTooShortScalar.10n',
+    'ion-tests/iontestdata/bad/annotationNested.10n',
+    'ion-tests/iontestdata/bad/annotationWithNoValue.10n',
+    'ion-tests/iontestdata/bad/emptyAnnotatedInt.10n',
+    'ion-tests/iontestdata/bad/localSymbolTableImportNullMaxId.ion',
+    'ion-tests/iontestdata/bad/negativeIntZero.10n',
+    'ion-tests/iontestdata/bad/negativeIntZeroLn.10n',
+    'ion-tests/iontestdata/bad/nopPadWithAnnotations.10n',
+    'ion-tests/iontestdata/bad/structOrderedEmpty.10n',
+    'ion-tests/iontestdata/bad/timestamp/timestampNegativeFraction.10n',
+    'ion-tests/iontestdata/bad/timestamp/timestampSept31.10n',
+    'ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_1.10n',
+    'ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_2.10n',
+]);
+
+let eventSkipList = toSkipList([
+    'ion-tests/iontestdata/good/allNulls.ion',
+    'ion-tests/iontestdata/good/clobWithNonAsciiCharacter.10n',
+    'ion-tests/iontestdata/good/clobs.ion',
+    'ion-tests/iontestdata/good/decimalsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/bigInts.ion',
+    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
+    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/ints.ion',
+    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n',
+    'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
+    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
+    'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
+    'ion-tests/iontestdata/good/floatsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/innerVersionIdentifiers.ion',
+    'ion-tests/iontestdata/good/intBigSize1201.10n',
+    'ion-tests/iontestdata/good/intBigSize13.10n',
+    'ion-tests/iontestdata/good/intBigSize14.10n',
+    'ion-tests/iontestdata/good/intBigSize16.10n',
+    'ion-tests/iontestdata/good/intBigSize256.10n',
+    'ion-tests/iontestdata/good/intBigSize256.ion',
+    'ion-tests/iontestdata/good/intBigSize512.ion',
+    'ion-tests/iontestdata/good/intBinary.ion',
+    'ion-tests/iontestdata/good/intLongMaxValuePlusOne.10n',
+    'ion-tests/iontestdata/good/intLongMinValue.10n',
+    'ion-tests/iontestdata/good/integer_values.ion',
+    'ion-tests/iontestdata/good/intsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/lists.ion',
+    'ion-tests/iontestdata/good/non-equivs/floats.ion',
+    'ion-tests/iontestdata/good/non-equivs/ints.ion',
+    'ion-tests/iontestdata/good/non-equivs/nulls.ion',
+    'ion-tests/iontestdata/good/nopPadInsideEmptyStructZeroSymbolId.10n',
+    'ion-tests/iontestdata/good/nopPadInsideStructWithNopPadThenValueZeroSymbolId.10n',
+    'ion-tests/iontestdata/good/nopPadInsideStructWithValueThenNopPad.10n',
+    'ion-tests/iontestdata/good/notVersionMarkers.ion',
+    'ion-tests/iontestdata/good/nullList.10n',
+    'ion-tests/iontestdata/good/nullSexp.10n',
+    'ion-tests/iontestdata/good/nullStruct.10n',
+    'ion-tests/iontestdata/good/nulls.ion',
+    'ion-tests/iontestdata/good/sexpAnnotationQuotedOperator.ion',
+    'ion-tests/iontestdata/good/subfieldUInt.ion',
+    'ion-tests/iontestdata/good/subfieldVarInt.ion',
+    'ion-tests/iontestdata/good/symbolExplicitZero.10n',
+    'ion-tests/iontestdata/good/symbolImplicitZero.10n',
+    'ion-tests/iontestdata/good/symbolZero.ion',
+    'ion-tests/iontestdata/good/testfile22.ion',
+    'ion-tests/iontestdata/good/testfile23.ion',
+    'ion-tests/iontestdata/good/utf16.ion',
+    'ion-tests/iontestdata/good/utf32.ion',
+]);
+
+let readerCompareSkipList = toSkipList([]);
+
+let equivsSkipList = toSkipList([
+    'ion-tests/iontestdata/good/equivs/annotatedIvms.ion',
+    'ion-tests/iontestdata/good/equivs/bigInts.ion',
+    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
+    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/emptyStrings.ion',
+    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/ints.ion',
+    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
+    'ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion',
+    'ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion',
+    'ion-tests/iontestdata/good/equivs/localSymbolTables.ion',
+    'ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion',
+    'ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n',
+    'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
+    'ion-tests/iontestdata/good/equivs/strings.ion',
+    'ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion',
+    'ion-tests/iontestdata/good/equivs/symbols.ion',
+    'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
+    'ion-tests/iontestdata/good/equivs/systemSymbolsAsAnnotations.ion',
+    'ion-tests/iontestdata/good/equivs/textNewlines.ion',
+    'ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion',
+    'ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion',
+
+    // See: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
+]);
+
+let nonEquivsSkipList = toSkipList([
+    'ion-tests/iontestdata/good/non-equivs/clobs.ion',
+    'ion-tests/iontestdata/good/non-equivs/floats.ion',
+    'ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion',
+
+    // See: https://github.com/amzn/ion-js/issues/310
+    'ion-tests/iontestdata/good/non-equivs/ints.ion',
+
+    // See: https://github.com/amzn/ion-js/issues/444
+    'ion-tests/iontestdata/good/non-equivs/decimals.ion',
+]);
+
+////// end of generated skiplists
+
+
+/*
+  notes from the previous skipList mechanism:
+    'good/intBinary.ion', //binaryInts unsupported.
+    'good/integer_values.ion', //binary ints unsupported.
+    'good/intsWithUnderscores.ion', //binary ints unsupported.
+    'good/intBigSize256.ion', //int maxsize limitation.
+    'good/equivs/intsWithUnderscores.ion', //binary ints unsupported.
+    'good/equivs/binaryInts.ion', //binary ints unsupported.
+    'good/floatsWithUnderscores.ion', //numbers with underscores unsupported.
+    'good/equivs/floatsWithUnderscores.ion', //numbers with underscores unsupported.
+    'good/equivs/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
+    'good/decimalsWithUnderscores.ion', //numbers with underscores unsupported.
+    'good/equivs/bigInts.ion', //numbers unsupported by js's int or float are unsupported.
+    'good/intBigSize512.ion', //int maxsize limitation.
+    'good/symbolZero.ion', //no symboltoken support as of yet.
+    'good/testfile12.ion',
+    'good/non-equivs/nonNulls.ion',
+    'good/equivs/utf8/stringU0001D11E.ion',
+    'good/equivs/structComments.ion',
+    'good/equivs/sexps.ion',
+    'good/equivs/lists.ion',
+ */
+
+let goodTestsPath = path.join('ion-tests', 'iontestdata', 'good');
+let badTestsPath = path.join('ion-tests', 'iontestdata', 'bad');
+let equivTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'equivs');
+let nonEquivTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'non-equivs');
+let equivTimelineTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'timestamp', 'equivTimeline');
+
+let goodTestFiles = findFiles(goodTestsPath);
+let badTestFiles = findFiles(badTestsPath);
+let equivTestFiles = findFiles(equivTestsPath);
+let nonEquivTestFiles = findFiles(nonEquivTestsPath);
+let equivTimelineTestFiles = findFiles(equivTimelineTestsPath);
+
+function skipOrTest(paths: Array<string>, skipLists: Array<Map<string, number>>, test: (string) => void): void {
+    for (let path of paths) {
+        let skipped = false;
+        for (let skipList of skipLists) {
+            if (skipList[path]) {
+                it.skip(path, () => {});
+                skipped = true;
+                break;
+            }
+        }
+        if (!skipped) {
+            it(path, () => test(path));
+        }
+    }
+}
+
+describe('ion-tests', () => {
+    describe('Good', () => {
+        skipOrTest(
+            goodTestFiles,
+            [goodSkipList],
+            (path) => exhaust(ion.makeReader(getInput(path)))
+        );
+    });
+
+    describe('Bad', () => {
+        skipOrTest(
+            badTestFiles,
+            [badSkipList],
+            (path) => assert.throws(() => exhaust(ion.makeReader(getInput(path))))
+        );
+    });
+
+    describe('Equivs', () => {
+        skipOrTest(
+            equivTestFiles,
+            [equivsSkipList],
+            (path) => equivsTest(path)
+        );
+    });
+
+    describe('Non-equivs', () => {
+        skipOrTest(
+            nonEquivTestFiles,
+            [nonEquivsSkipList],
+            (path) => nonEquivsTest(path)
+        );
+    });
+
+    describe('Equiv timelines', () => {
+        skipOrTest(
+            equivTimelineTestFiles,
+            [],
+            (path) => equivTimelinesTest(path)
+        );
+    });
+
+    describe('EventStream', () => {
+        skipOrTest(
+            // Re-use the 'good' file set
+            goodTestFiles,
+            [eventSkipList],
+            (path) => roundTripEventStreams(ion.makeReader(getInput(path)))
+        );
+    });
+
+    describe('ReaderCompare', () => {
+        skipOrTest(
+            // Re-use the 'good' file set
+            goodTestFiles,
+            [eventSkipList, readerCompareSkipList],
+            (path) => readerCompareTest(getInput(path))
+        );
+    });
+});
+

--- a/test/writeSymbolTokens.ts
+++ b/test/writeSymbolTokens.ts
@@ -1,0 +1,85 @@
+import {assert} from 'chai';
+import * as ion from '../src/Ion';
+import * as IonText from '../src/IonText';
+
+function verifyQuoteBehavior(symbolText: string, shouldQuote: boolean, shouldQuoteInSexp = true) {
+    let writer = ion.makeTextWriter();
+
+    writer.writeSymbol(symbolText);        // symbol
+
+    writer.setAnnotations([symbolText]);
+    writer.writeInt(5);      // annotation
+
+    writer.stepIn(ion.IonTypes.STRUCT);
+    writer.writeFieldName(symbolText);     // fieldname
+    writer.writeInt(5);
+    writer.stepOut();
+
+    writer.stepIn(ion.IonTypes.SEXP);
+    writer.writeSymbol(symbolText);        // symbol in sexp (operators should not be quoted)
+    writer.stepOut();
+
+    writer.close();
+    let actual = String.fromCharCode.apply(null, writer.getBytes());
+
+    symbolText = IonText.escape(symbolText, IonText.SymbolEscapes);
+
+    let expected = `${symbolText}\n${symbolText}::5\n{${symbolText}:5}\n(${symbolText})`;
+    if (shouldQuote) {
+        expected = `'${symbolText}'\n'${symbolText}'::5\n{'${symbolText}':5}\n`;
+        if (shouldQuoteInSexp) {
+            expected += `('${symbolText}')`;
+        } else {
+            expected += `(${symbolText})`;
+        }
+    }
+    assert.equal(actual, expected);
+}
+
+function verifyQuotesAdded(symbolText: string) {
+    verifyQuoteBehavior(symbolText, true)
+}
+
+function verifyNoQuotes(symbolText: string) {
+    verifyQuoteBehavior(symbolText, false)
+}
+
+let symbolsThatNeedQuotes = [
+    'false',
+    'nan',
+    'null',
+    'true',
+    '+inf',
+    '-inf',
+    '',
+    ' ',
+    '1',
+    '1-2',
+    '1.2',
+    '-1.2',
+    '{}',
+    '[]',
+    '"',
+    "'",
+    '$1',
+];
+
+let symbolsThatDoNotNeedQuotes = [
+    'a',
+    'a_b',
+    '$a',
+];
+
+describe('Writing text symbol tokens', () => {
+    describe('Symbols that need quotes', () => {
+        for (let symbol of symbolsThatNeedQuotes) {
+            it(symbol, () => verifyQuotesAdded(symbol));
+        }
+    });
+    describe("Symbols that don't need quotes", () => {
+        for (let symbol of symbolsThatDoNotNeedQuotes) {
+            it(symbol, () => verifyNoQuotes(symbol));
+        }
+    });
+    it('Symbols that need quotes outside of an S-Expression', () => verifyQuoteBehavior('+', true, false))
+});


### PR DESCRIPTION
*Description of changes:*

Follow-on work from #440. This PR migrates our `ion-tests` suites, `IonText`, `IonTextReader`, and `IonTextWriter` to Mocha.

The latest `BigInteger.js` from npm's handling of `-0` diverges from the local copy we've been using, so our non-equiv test for `decimals` fails in the Mocha test suite. It still passes in the intern.js suite, which still points to the local copy. I'm tracking this in #444 and will close the issue after the migration away from `BigInteger.js` is complete. This will block our removal of intern.js.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
