### PR TITLE
Mocha tests for IonParserBinaryRaw.

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -136,7 +136,7 @@ export class ParserBinaryRaw {
         this._in = source;
     }
 
-    private static readFloatFrom(input: BinarySpan, numberOfBytes) : number {
+    static _readFloatFrom(input: BinarySpan, numberOfBytes) : number {
         let tempBuf : DataView;
         switch(numberOfBytes) {
             case 0:
@@ -155,10 +155,10 @@ export class ParserBinaryRaw {
     }
 
     private read_binary_float() : number {
-        return ParserBinaryRaw.readFloatFrom(this._in, this._len);
+        return ParserBinaryRaw._readFloatFrom(this._in, this._len);
     }
 
-    private static readVarUnsignedIntFrom(input: BinarySpan) : number {
+    static _readVarUnsignedIntFrom(input: BinarySpan) : number {
         let numberOfBits = 0;
         let byte;
         let magnitude = 0;
@@ -180,10 +180,10 @@ export class ParserBinaryRaw {
     }
 
     private readVarUnsignedInt() : number {
-        return ParserBinaryRaw.readVarUnsignedIntFrom(this._in);
+        return ParserBinaryRaw._readVarUnsignedIntFrom(this._in);
     }
 
-    private static readVarSignedIntFrom(input: BinarySpan) : number {
+    static _readVarSignedIntFrom(input: BinarySpan) : number {
         let v = input.next(), byte;
         let isNegative = v & 0x40;
         let stopBit = v & 0x80;
@@ -205,7 +205,7 @@ export class ParserBinaryRaw {
     }
 
     private readVarSignedInt() : number {
-        return ParserBinaryRaw.readVarSignedIntFrom(this._in);
+        return ParserBinaryRaw._readVarSignedIntFrom(this._in);
     }
 
     private readVarLongInt() : LongInt {
@@ -223,7 +223,7 @@ export class ParserBinaryRaw {
         return LongInt.fromVarIntBytes(bytes, isNegative);
     }
 
-    private static readSignedIntFrom(input: BinarySpan, numberOfBytes: number) : LongInt {
+    static _readSignedIntFrom(input: BinarySpan, numberOfBytes: number) : LongInt {
         if (numberOfBytes == 0) {
             return new LongInt(0);
         }
@@ -235,10 +235,10 @@ export class ParserBinaryRaw {
     }
 
     private readSignedInt() : LongInt {
-        return ParserBinaryRaw.readSignedIntFrom(this._in, this._len);
+        return ParserBinaryRaw._readSignedIntFrom(this._in, this._len);
     }
 
-    private static readUnsignedIntFrom(input: BinarySpan, numberOfBytes: number) : number {
+    static _readUnsignedIntFrom(input: BinarySpan, numberOfBytes: number) : number {
         let value = 0, bytesRead = 0, byte;
         if (numberOfBytes < 1)
             return 0;
@@ -265,15 +265,15 @@ export class ParserBinaryRaw {
     }
 
     private readUnsignedInt() : number {
-        return ParserBinaryRaw.readUnsignedIntFrom(this._in, this._len);
+        return ParserBinaryRaw._readUnsignedIntFrom(this._in, this._len);
     }
 
-    private static readUnsignedLongIntFrom(input: BinarySpan, numberOfBytes: number) : LongInt {
+    static _readUnsignedLongIntFrom(input: BinarySpan, numberOfBytes: number) : LongInt {
         return LongInt.fromUIntBytes(Array.prototype.slice.call(input.view(numberOfBytes)));
     }
 
     private readUnsignedLongInt() : LongInt {
-        return ParserBinaryRaw.readUnsignedLongIntFrom(this._in, this._len);
+        return ParserBinaryRaw._readUnsignedLongIntFrom(this._in, this._len);
     }
 
     /**
@@ -289,11 +289,11 @@ export class ParserBinaryRaw {
         let coefficient, exponent, d;
 
         let initialPosition = input.position();
-        exponent = ParserBinaryRaw.readVarSignedIntFrom(input);
+        exponent = ParserBinaryRaw._readVarSignedIntFrom(input);
         let numberOfExponentBytes = input.position() - initialPosition;
         let numberOfCoefficientBytes = numberOfBytes - numberOfExponentBytes;
 
-        coefficient = ParserBinaryRaw.readSignedIntFrom(input,  numberOfCoefficientBytes);
+        coefficient = ParserBinaryRaw._readSignedIntFrom(input,  numberOfCoefficientBytes);
         d = Decimal._fromLongIntCoefficient(coefficient, exponent);
 
         return d;
@@ -350,7 +350,7 @@ export class ParserBinaryRaw {
             let exponent = this.readVarSignedInt();
             let coefficient = LongInt._ZERO;
             if (this._in.position() < end) {
-                coefficient = ParserBinaryRaw.readSignedIntFrom(this._in, end - this._in.position());
+                coefficient = ParserBinaryRaw._readSignedIntFrom(this._in, end - this._in.position());
             }
             let dec = Decimal._fromLongIntCoefficient(coefficient, exponent);
             let [_, fractionStr] = Timestamp._splitSecondsDecimal(dec);

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -15,14 +15,6 @@
 import {assert} from 'chai';
 import * as ion from '../src/IonTests';
 
-// Registers the provided test with the test suite.
-let registerTest = function(testName, test, throwsException = false) {
-  test = throwsException
-      ? function() { assert.throws(test, Error); }
-      : test;
-  it(testName, test);
-};
-
 /**
  * UInt
  *
@@ -179,32 +171,6 @@ let varUnsignedIntBytesMatchValue = function(bytes, expected) {
   assert.equal(actual, expected);
 };
 
-// The base test function called by the more specific flavors below.
-// Creates a test which will attempt to read the `expected` VarUInt from the provided input bytes, handling
-// any anticipated exceptions.
-let readVarUnsignedIntTest = function(testName, bytes, expected, throwsException) {
-  let test = function() {
-    varUnsignedIntBytesMatchValue(bytes, expected);
-  };
-  registerTest(testName, test, throwsException);
-};
-
-// Should read the `expected` VarUInt value from the provided input bytes.
-// Will fail if an exception is thrown or if the value that's read from the bytes is not equal to `expected`.
-let readVarUnsignedInt = function(bytes, expected) {
-  let testName = 'Read var unsigned int ' + expected + ' from bytes: ' + bytes;
-  let testThrows = false;
-  readVarUnsignedIntTest(testName, bytes, expected, testThrows);
-};
-
-// Should detect that overflow has occurred while reading and throw an exception.
-// Will fail if no exception is thrown.
-let overflowWhileReadingVarUnsignedInt = function(bytes, expected) {
-  let testName = 'Overflow while attempting to read var unsigned int ' + expected + ' from the bytes: ' + bytes;
-  let testThrows = true;
-  readVarUnsignedIntTest(testName, bytes, expected, testThrows);
-};
-
 let varUnsignedIntReadingTests = [
   {bytes: [0x80], expected: 0},
   {bytes: [0x00, 0x81], expected: 1},
@@ -221,11 +187,11 @@ let varUnsignedIntOverflowTests = [
 
 describe('Reading variable unsigned ints', () => {
   // Test all values that can be encoded in a single byte
-  registerTest('All single-byte encodings', function() {
+  it('All single-byte encodings', function() {
     for (let byte = 0; byte <= 0x7F; byte++) {
       varUnsignedIntBytesMatchValue([byte | 0x80], byte);
     }
-  }, false);
+  });
 
   describe('Ok', () => {
     varUnsignedIntReadingTests.forEach(({bytes, expected}) => {

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {assert} from 'chai';
+import * as ion from '../src/IonTests';
+
+// Registers the provided test with the test suite.
+let registerTest = function(testName, test, throwsException = false) {
+  test = throwsException
+      ? function() { assert.throws(test, Error); }
+      : test;
+  it(testName, test);
+};
+
+/**
+ * UInt
+ *
+ * Spec: http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+ */
+
+// Returns the largest unsigned integer value that can be stored in `numberOfBits` bits.
+let maxValueForBits = function(numberOfBits) {
+  return Math.pow(2, numberOfBits) - 1;
+};
+
+// Returns the largest unsigned integer value that can be stored in `numberOfBytes` bytes.
+let maxValueForBytes = function(numberOfBytes) {
+  return maxValueForBits(numberOfBytes * 8);
+};
+
+// Returns an array containing `numberOfBytes` bytes with value of 0xFF.
+let maxValueByteArray = function(numberOfBytes) {
+  let data = [];
+  for(let m = 0; m < numberOfBytes; m++) {
+    data.push(0xFF);
+  }
+  return data;
+};
+
+let unsignedIntBytesMatchValue = function(bytes, expected) {
+  let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+  let actual = ion.ParserBinaryRaw._readUnsignedIntFrom(binarySpan, bytes.length);
+  assert.equal(actual, expected)
+};
+
+let unsignedLongIntBytesMatchValue = function(bytes, expected) {
+  let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+  let actual = ion.ParserBinaryRaw._readUnsignedLongIntFrom(binarySpan, bytes.length);
+  assert.equal(actual, expected)
+}
+
+let unsignedIntReadingTests = [
+  {bytes: [0x00], expected: 0},
+  {bytes: [0x01], expected: 1},
+  {bytes: [0x0F], expected: 15},
+  {bytes: [0x00, 0x00], expected: 0},
+  {bytes: maxValueByteArray(1), expected: maxValueForBytes(1)},
+  {bytes: maxValueByteArray(2), expected: maxValueForBytes(2)},
+  {bytes: maxValueByteArray(3), expected: maxValueForBytes(3)},
+  {bytes: [0x7F, 0xFF, 0xFF, 0xFF], expected: maxValueForBits(31)},
+];
+
+// Each 'bytes' array should be an incomplete serialization of each 'expected' value.
+let unsignedIntEofTests = [
+  {bytes: [], expected: 1},
+  {bytes: maxValueByteArray(1), expected: maxValueForBytes(2)},
+  {bytes: maxValueByteArray(2), expected: maxValueForBytes(3)},
+];
+
+describe('Reading unsigned ints', () => {
+  describe('Good', () => {
+    unsignedIntReadingTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => unsignedIntBytesMatchValue(bytes, expected)
+      );
+    });
+  });
+
+  describe('Overflow', () => {
+    // Test reading unsigned ints requiring 4-10 bytes.
+    // Expected to fail.
+    for (let numberOfBytes = 4; numberOfBytes <= 10; numberOfBytes++) {
+      let bytes = maxValueByteArray(numberOfBytes);
+      let expected = maxValueForBytes(numberOfBytes);
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected))
+      );
+    }
+  });
+
+  describe('EOF', () => {
+    unsignedIntEofTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected))
+      );
+    });
+  });
+
+  describe('LongInt', () => {
+    // Test reading unsigned ints requiring 4-10 bytes.
+    // Expected to pass.
+    for (let numberOfBytes = 4; numberOfBytes <= 10; numberOfBytes++) {
+      let expected = maxValueForBytes(numberOfBytes);
+      let bytes = maxValueByteArray(numberOfBytes);
+      it('Reading ' + expected + ' from bytes: ' + bytes.toString(), () => {
+        unsignedLongIntBytesMatchValue(bytes, expected);
+      });
+    }
+  });
+});
+
+/**
+ * Int
+ *
+ * Spec: http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
+ */
+
+let signedIntBytesMatch = function(bytes, expected) {
+  let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+  let actual = ion.ParserBinaryRaw._readSignedIntFrom(binarySpan, bytes.length).numberValue();
+  assert.equal(actual, expected);
+};
+
+let signedIntReadingTests = [
+  {bytes: [0x00], expected: 0},
+  {bytes: [0x80], expected: 0},
+  {bytes: [0x01], expected: 1},
+  {bytes: [0x81], expected: -1},
+  {bytes: [0x00 ,0x01], expected: 1},
+  {bytes: [0x80, 0x01], expected: -1},
+  {bytes: [0x04], expected: 4},
+  {bytes: [0x84], expected: -4},
+  {bytes: [0x7F], expected: 127},
+  {bytes: [0xFF], expected: -127},
+  {bytes: [0x7F, 0xFF], expected: maxValueForBits(15)},
+  {bytes: [0xFF, 0xFF], expected: -1 * maxValueForBits(15)},
+  {bytes: [0x7F, 0xFF, 0xFF], expected: maxValueForBits(23)},
+  {bytes: [0xFF, 0xFF, 0xFF], expected: -1 * maxValueForBits(23)},
+  {bytes: [0x7F, 0xFF, 0xFF, 0xFF], expected: maxValueForBits(31)},
+  {bytes: [0xFF, 0xFF, 0xFF, 0xFF], expected: -1 * maxValueForBits(31)},
+  {bytes: [0x7F, 0xFF, 0xFF, 0xFF, 0xFF], expected: maxValueForBits(39)},
+  {bytes: [0xFF, 0xFF, 0xFF, 0xFF, 0xFF], expected: -1 * maxValueForBits(39)},
+];
+
+describe('Reading signed ints', () => {
+  describe('Ok', () => {
+    signedIntReadingTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => signedIntBytesMatch(bytes, expected)
+      );
+    });
+  });
+});
+
+/**
+ * VarUInt
+ *
+ * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+ */
+
+let varUnsignedIntBytesMatchValue = function(bytes, expected) {
+  let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+  let actual = ion.ParserBinaryRaw._readVarUnsignedIntFrom(binarySpan);
+  assert.equal(actual, expected);
+};
+
+// The base test function called by the more specific flavors below.
+// Creates a test which will attempt to read the `expected` VarUInt from the provided input bytes, handling
+// any anticipated exceptions.
+let readVarUnsignedIntTest = function(testName, bytes, expected, throwsException) {
+  let test = function() {
+    varUnsignedIntBytesMatchValue(bytes, expected);
+  };
+  registerTest(testName, test, throwsException);
+};
+
+// Should read the `expected` VarUInt value from the provided input bytes.
+// Will fail if an exception is thrown or if the value that's read from the bytes is not equal to `expected`.
+let readVarUnsignedInt = function(bytes, expected) {
+  let testName = 'Read var unsigned int ' + expected + ' from bytes: ' + bytes;
+  let testThrows = false;
+  readVarUnsignedIntTest(testName, bytes, expected, testThrows);
+};
+
+// Should detect that overflow has occurred while reading and throw an exception.
+// Will fail if no exception is thrown.
+let overflowWhileReadingVarUnsignedInt = function(bytes, expected) {
+  let testName = 'Overflow while attempting to read var unsigned int ' + expected + ' from the bytes: ' + bytes;
+  let testThrows = true;
+  readVarUnsignedIntTest(testName, bytes, expected, testThrows);
+};
+
+let varUnsignedIntReadingTests = [
+  {bytes: [0x80], expected: 0},
+  {bytes: [0x00, 0x81], expected: 1},
+  {bytes: [0x00, 0x00, 0x81], expected: 1},
+  {bytes: [0x00, 0x00, 0x00, 0x81], expected: 1},
+  {bytes: [0x0E, 0xEB], expected: 1899},
+  {bytes: [0x0E, 0xEC], expected: 1900},
+];
+
+let varUnsignedIntOverflowTests = [
+  {bytes: [0x1F, 0x7F, 0x7F, 0x7F, 0xFF], expected: maxValueForBits(33)},
+  {bytes: [0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF], expected: maxValueForBits(42)},
+];
+
+describe('Reading variable unsigned ints', () => {
+  // Test all values that can be encoded in a single byte
+  registerTest('All single-byte encodings', function() {
+    for (let byte = 0; byte <= 0x7F; byte++) {
+      varUnsignedIntBytesMatchValue([byte | 0x80], byte);
+    }
+  }, false);
+
+  describe('Ok', () => {
+    varUnsignedIntReadingTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => varUnsignedIntBytesMatchValue(bytes, expected)
+      );
+    });
+  });
+
+  describe('Overflow', () => {
+    varUnsignedIntOverflowTests.forEach(({bytes, expected}) => {
+      it(
+          'Overflow while reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => assert.throws(() => varUnsignedIntBytesMatchValue(bytes, expected))
+      );
+    });
+  });
+});
+
+/**
+ * VarInt
+ *
+ * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
+ */
+
+let varSignedIntBytesMatchValue = function(bytes, expected) {
+  let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
+  let actual = ion.ParserBinaryRaw._readVarSignedIntFrom(binarySpan);
+  assert.equal(actual, expected)
+};
+
+let varSignedIntReadingTests = [
+  {bytes: [0x80], expected: 0},
+  {bytes: [0xC0], expected: -0},
+  {bytes: [0x81], expected: 1},
+  {bytes: [0xC1], expected: -1},
+  {bytes: [0x00, 0x81], expected: 1},
+  {bytes: [0x40, 0x81], expected: -1},
+  {bytes: [0x0E, 0xEB], expected: 1899},
+  {bytes: [0x4E, 0xEB], expected: -1899},
+  {bytes: [0x0E, 0xEC], expected: 1900},
+  {bytes: [0x4E, 0xEC], expected: -1900},
+  {bytes: [0x00, 0x00, 0x81], expected: 1},
+  {bytes: [0x00, 0x00, 0x00, 0x81], expected: 1},
+  {bytes: [0x3F, 0x7F, 0x7F, 0xFF], expected: maxValueForBits(27)},
+  {bytes: [0x7F, 0x7F, 0x7F, 0xFF], expected: -maxValueForBits(27)},
+];
+
+let varSignedIntOverflowTests = [
+  {bytes: [0x1F, 0x7F, 0x7F, 0x7F, 0xFF], expected: maxValueForBits(33)},
+  {bytes: [0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF], expected: -maxValueForBits(42)},
+];
+
+describe('Reading variable signed ints', () => {
+  it('All positive, single-byte encodings.', function() {
+    for (let byte = 0; byte <= 0x3F; byte++) {
+      varSignedIntBytesMatchValue([byte | 0x80], byte);
+    }
+  });
+
+  it('All negative, single-byte encodings.', function() {
+    for (let byte = 0; byte <= 0x3F; byte++) {
+      varSignedIntBytesMatchValue([byte | 0xC0], -byte);
+    }
+  });
+
+  describe('Ok', () => {
+    varSignedIntReadingTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => varSignedIntBytesMatchValue(bytes, expected)
+      );
+    });
+  });
+
+  describe('Overflow', () => {
+    varSignedIntOverflowTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => assert.throws(() => varSignedIntBytesMatchValue(bytes, expected))
+      );
+    });
+  });
+});
+
+/**
+ * Float
+ *
+ * Spec: http://amzn.github.io/ion-docs/docs/binary.html#4-float
+ */
+
+let serializeFloat = function(value, viewType, numberOfBytes) {
+  let buffer = new ArrayBuffer(numberOfBytes);
+  let view = new viewType(buffer);
+  view[0] = value;
+  let bytes = new Uint8Array(buffer);
+  bytes.reverse(); // Big endian
+  return bytes;
+};
+
+let serializeFloat32 = function(value) {
+  return serializeFloat(value, Float32Array, 4);
+};
+
+let serializeFloat64 = function(value) {
+  return serializeFloat(value, Float64Array, 8);
+};
+
+let floatBytesMatchValue = function(bytes, expected, comparison = (x, y) => assert.equal(x, y)) {
+  let binarySpan = new ion.BinarySpan(bytes);
+  let actual = ion.ParserBinaryRaw._readFloatFrom(binarySpan, binarySpan.getRemaining());
+  comparison(actual, expected);
+};
+
+let float32TestValues = [
+  Number.NEGATIVE_INFINITY,
+  Number.POSITIVE_INFINITY,
+  0.0,
+  -0.0,
+  12.5,
+  -12.5,
+  -1230000000,
+  1230000000,
+];
+
+// Test the same values for 64 bit floats plus a few extra.
+let float64TestValues = float32TestValues.slice(0);
+float64TestValues.push(
+    Number.MIN_SAFE_INTEGER,
+    Number.MAX_SAFE_INTEGER
+);
+
+describe("Reading floats", () => {
+  describe("32-bit", () => {
+    float32TestValues.forEach((f32) => {
+      it('' + f32, () => {
+        let bytes = serializeFloat32(f32);
+        floatBytesMatchValue(bytes, f32);
+      });
+    });
+
+    it('NaN', () => {
+      let expected = Number.NaN;
+      let bytes = serializeFloat32(expected);
+      floatBytesMatchValue(bytes, expected, (x) =>
+        assert.isTrue(Number.isNaN(x))
+      );
+    });
+  });
+
+  describe("64-bit", () => {
+    float64TestValues.forEach((f64) => {
+      it('' + f64, () => {
+        let bytes = serializeFloat64(f64);
+        floatBytesMatchValue(bytes, f64);
+      });
+    });
+
+    it('NaN', () => {
+      let expected = Number.NaN;
+      let bytes = serializeFloat64(expected);
+      floatBytesMatchValue(bytes, expected, (x) =>
+        assert.isTrue(Number.isNaN(x))
+      );
+    });
+  });
+});
+

--- a/tests/unit/IonParserBinaryRawTest.js
+++ b/tests/unit/IonParserBinaryRawTest.js
@@ -43,7 +43,7 @@ define([
     let readUnsignedIntTest = function(testName, bytes, expected, throwsException) {
       let test = function() {
         let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-        let actual = ion.ParserBinaryRaw.readUnsignedIntFrom(binarySpan, bytes.length);
+        let actual = ion.ParserBinaryRaw._readUnsignedIntFrom(binarySpan, bytes.length);
         assert.equal(actual, expected)
       }
       registerTest(testName, test, throwsException);
@@ -117,7 +117,7 @@ define([
       let testThrows = false;
       let test = function() {
         let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-        let actual = ion.ParserBinaryRaw.readUnsignedLongIntFrom(binarySpan, bytes.length);
+        let actual = ion.ParserBinaryRaw._readUnsignedLongIntFrom(binarySpan, bytes.length);
         assert.equal(actual, expected)
       }
       registerTest(testName, test, throwsException);
@@ -141,7 +141,7 @@ define([
     let readSignedIntTest = function(testName, bytes, expected, throwsException) {
       let test = function() {
         let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-        let actual = ion.ParserBinaryRaw.readSignedIntFrom(binarySpan, bytes.length).numberValue();
+        let actual = ion.ParserBinaryRaw._readSignedIntFrom(binarySpan, bytes.length).numberValue();
         assert.equal(actual, expected)
       }
       registerTest(testName, test, throwsException);
@@ -190,7 +190,7 @@ define([
 
     let varUnsignedIntBytesMatchValue = function(bytes, expected) {
       let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-      let actual = ion.ParserBinaryRaw.readVarUnsignedIntFrom(binarySpan);
+      let actual = ion.ParserBinaryRaw._readVarUnsignedIntFrom(binarySpan);
       assert.equal(actual, expected);
     }
 
@@ -246,7 +246,7 @@ define([
 
     let varSignedIntBytesMatchValue = function(bytes, expected) {
       let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-      let actual = ion.ParserBinaryRaw.readVarSignedIntFrom(binarySpan);
+      let actual = ion.ParserBinaryRaw._readVarSignedIntFrom(binarySpan);
       assert.equal(actual, expected)
     };
 
@@ -333,7 +333,7 @@ define([
 
     let floatBytesMatchValue = function(bytes, expected, comparison) {
       let binarySpan = new ion.BinarySpan(bytes);
-      let actual = ion.ParserBinaryRaw.readFloatFrom(binarySpan, binarySpan.getRemaining());
+      let actual = ion.ParserBinaryRaw._readFloatFrom(binarySpan, binarySpan.getRemaining());
       // Default to asserting equality, but allow the comparison function to be overridden by a parameter
       comparison = comparison || function(actual, expected) {
         assert.equal(actual, expected)


### PR DESCRIPTION
*Description of changes:*

Follow-on work from #439, #440, #445.

* Migrates the `IonParserBinaryRaw` unit tests to Mocha.
* Removes the `private` visibility modifier from a number of internal static methods and prefixes them with `_`, allowing them to be referenced from the test suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
