### PR TITLE
Read Symbol IDs into Number, not BigInt.

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -232,6 +232,52 @@ export class ParserBinaryRaw {
     }
 
     /**
+     * Reads an unsigned integer that is small enough to be stored in a Number without losing precision.
+     * This is valuable for use cases like Symbol IDs, which are unlikely to grow beyond a few bytes.
+     *
+     * For simplicity, the current implementation supports reading integers up to 6 bytes (i.e. (2^48) - 1)
+     * rather than Number's maximum safe integer value, 2^53 - 1.     *
+     *
+     * @throws Error if the unsigned int was too large to store in a Number.
+     * @hidden
+     */
+    static _readSafeUnsignedIntFrom(input: BinarySpan, numberOfBytes: number) : number {
+        let value = 0;
+        let bytesRead = 0;
+        let bytesAvailable = input.getRemaining();
+        let byte;
+        if (numberOfBytes < 1) {
+            return 0;
+        } else if (numberOfBytes > 6) {
+            throw new Error(
+                `Attempted to read a ${numberOfBytes}-byte unsigned integer,`
+                + ` which is too large for a to be stored in a number without losing precision.`
+            );
+        }
+
+        if (bytesAvailable < numberOfBytes) {
+            throw new Error(
+                `Attempted to read a ${numberOfBytes}-byte unsigned integer,`
+                + ` but only ${bytesAvailable} bytes were available.`
+            );
+        }
+
+        while (bytesRead < numberOfBytes) {
+            byte = input.next();
+            bytesRead++;
+            // Avoid using bitshifting to preserve Number's precision beyond 31 bits.
+            value *= 256;
+            value = value + byte;
+        }
+
+        return value;
+    }
+
+    private readSafeUnsignedInt(): number {
+        return ParserBinaryRaw._readSafeUnsignedIntFrom(this._in, this._len);
+    }
+
+    /**
      * Reads a Decimal value from the provided BinarySpan.
      *
      * @param input The BinarySpan to read from.
@@ -488,7 +534,7 @@ export class ParserBinaryRaw {
                 this._curr = this.read_timestamp_value();
                 break;
             case IonBinary.TB_SYMBOL:
-                this._curr = this.readUnsignedInt();
+                this._curr = this.readSafeUnsignedInt();
                 break;
             case IonBinary.TB_STRING:
                 this._curr = this.read_string_value();

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -44,7 +44,7 @@ let maxValueByteArray = function(numberOfBytes) {
 let unsignedIntBytesMatchValue = (bytes,
                                   expected,
                                   readFrom: (input: ion.BinarySpan, numberOfBytes: number) => any =
-                                      ion.ParserBinaryRaw._readUnsignedIntFrom) => {
+                                      ion.ParserBinaryRaw._readUnsignedIntAsBigIntFrom) => {
   let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
   let actual = readFrom(binarySpan, bytes.length);
   assert.equal(actual, expected)
@@ -94,7 +94,7 @@ describe('Reading unsigned ints', () => {
     unsignedIntReadingTests.forEach(({bytes, expected}) => {
       it(
           'Reading ' + expected + ' from bytes: ' + bytes.toString(),
-          () => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readSafeUnsignedIntFrom)
+          () => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readUnsignedIntAsNumberFrom)
       );
     });
   });
@@ -105,7 +105,7 @@ describe('Reading unsigned ints', () => {
       let bytes = maxValueByteArray(numberOfBytes);
       it(
           'Reading ' + expected + ' from bytes: ' + bytes.toString(),
-          () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readSafeUnsignedIntFrom))
+          () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readUnsignedIntAsNumberFrom))
       );
     }
   });

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -41,9 +41,12 @@ let maxValueByteArray = function(numberOfBytes) {
   return data;
 };
 
-let unsignedIntBytesMatchValue = function(bytes, expected) {
+let unsignedIntBytesMatchValue = (bytes,
+                                  expected,
+                                  readFrom: (input: ion.BinarySpan, numberOfBytes: number) => any =
+                                      ion.ParserBinaryRaw._readUnsignedIntFrom) => {
   let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
-  let actual = ion.ParserBinaryRaw._readUnsignedIntFrom(binarySpan, bytes.length);
+  let actual = readFrom(binarySpan, bytes.length);
   assert.equal(actual, expected)
 };
 
@@ -55,6 +58,9 @@ let unsignedIntReadingTests = [
   {bytes: maxValueByteArray(1), expected: maxValueForBytes(1)},
   {bytes: maxValueByteArray(2), expected: maxValueForBytes(2)},
   {bytes: maxValueByteArray(3), expected: maxValueForBytes(3)},
+  {bytes: maxValueByteArray(4), expected: maxValueForBytes(4)},
+  {bytes: maxValueByteArray(5), expected: maxValueForBytes(5)},
+  {bytes: maxValueByteArray(6), expected: maxValueForBytes(6)},
   {bytes: [0x7F, 0xFF, 0xFF, 0xFF], expected: maxValueForBits(31)},
 ];
 
@@ -82,6 +88,26 @@ describe('Reading unsigned ints', () => {
           () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected))
       );
     });
+  });
+
+  describe('Safe', () => {
+    unsignedIntReadingTests.forEach(({bytes, expected}) => {
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readSafeUnsignedIntFrom)
+      );
+    });
+  });
+
+  describe('Throwing when ints are outside of the safe integer range', () => {
+    for (let numberOfBytes = 7; numberOfBytes <= 10; numberOfBytes++) {
+      let expected = maxValueForBytes(numberOfBytes);
+      let bytes = maxValueByteArray(numberOfBytes);
+      it(
+          'Reading ' + expected + ' from bytes: ' + bytes.toString(),
+          () => assert.throws(() => unsignedIntBytesMatchValue(bytes, expected, ion.ParserBinaryRaw._readSafeUnsignedIntFrom))
+      );
+    }
   });
 
   describe('BigInt', () => {
@@ -342,4 +368,3 @@ describe("Reading floats", () => {
     });
   });
 });
-


### PR DESCRIPTION
*Issue #, if available:* 

#466 

*Description of changes:*

Following #465, all binary `UInt`s were read in as `JSBI` (`BigInt`) values. This allowed `int`s to be any size and enabled arbitrarily precise `Decimal` and `Timestamp` values. However, the change also applied to symbol IDs, which are unlikely to ever grow beyond `Number.SAFE_MAX_INTEGER` in practice.

This PR changes the `IonBinaryReader` to read symbol IDs as `number` values, which should be much faster.

Note:
* Using bitshifting on `number` values causes them to lose precision for values greater than 31 bits in size. This PR avoids bitshifting to accommodate larger values.
* For simplicity, this implementation supports up to 48 bits (6 bytes) rather than 53 (`MAX_SAFE_INTEGER`). We can add support for the final 5 bits if and when we have a use case that requires it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
