### PR TITLE
Decimal constructors for number, JSBI, and string.

### DIFF
--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -13,7 +13,7 @@
  */
 
 import JSBI from "jsbi";
-import {_sign} from "./util";
+import {_hasValue, _sign} from "./util";
 import {JsbiSupport} from "./JsbiSupport";
 
 /**
@@ -49,27 +49,68 @@ export class Decimal {
     public static readonly ONE = new Decimal(1, 0);
 
     /**
-     * Creates a new Decimal value.
-     * @param coefficient   See the {@link Decimal} class-level documentation for details.
-     * @param exponent      See the {@link Decimal} class-level documentation for details.
+     * Creates a new Decimal value. Three parameter sets are supported:
+     *
+     *  (text: string)
+     *      The provided text will be parsed into a Decimal value.
+     *
+     *  (coefficient: number, coefficient: number)
+     *      A Decimal value will be constructed using the provided coefficient and exponent values.
+     *
+     *  (coefficient: BigInt, coefficient: number, isNegative?: boolean)
+     *      A Decimal value will be constructed using the provided coefficient and exponent values.
+     *      Because the BigInt data type cannot represent -0, a third parameter called `isNegative` may be supplied
+     *      to explicitly set the sign of the Decimal following construction. If this flag is not specified,
+     *      the provided coefficient's sign will be used.
      */
-    constructor(coefficient: number, exponent: number) {
+    constructor(coefficient: number | JSBI | string,
+                exponent?: number,
+                isNegative?: boolean) {
+        if(typeof coefficient === "string") {
+            return Decimal.parse(coefficient);
+        }
+
+        if (!_hasValue(exponent)) {
+            throw new Error("Decimal's constructor was called with a numeric coefficient but no exponent.");
+        }
+
+        if (typeof coefficient === "number") {
+            return Decimal._fromNumberCoefficient(coefficient, exponent);
+        }
+
+        if(coefficient instanceof JSBI) {
+            if (!_hasValue(isNegative)) {
+                // If isNegative was not specified, infer isNegative from the coefficient.
+                // This will work for all values except -0.
+                isNegative = JsbiSupport.isNegative(coefficient);
+            } else if (isNegative && !JsbiSupport.isNegative(coefficient)) {
+                // If isNegative was specified, make sure that the coefficent's sign agrees with it.
+                coefficient = JSBI.unaryMinus(coefficient);
+            }
+            return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);
+        }
+
+        throw new Error(`Unsupported parameter set (${coefficient}, ${exponent}, ${isNegative} passed to Decimal constructor.`);
+    }
+
+    /**
+     * Allows a Decimal to be constructed using a coefficient in the range
+     * [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER].
+     * @hidden
+     */
+    static _fromNumberCoefficient(coefficient: number, exponent: number): Decimal {
         if (!Number.isInteger(coefficient)) {
             throw new Error("The provided coefficient was not an integer. (" + coefficient + ")");
         }
-        let isNegative: boolean = coefficient < 0 || Object.is(coefficient, -0);
-        this._initialize(
-            isNegative,
-            JSBI.BigInt(coefficient),
-            exponent
-        );
+        let isNegative = coefficient < 0 || Object.is(coefficient, -0);
+        return this._fromBigIntCoefficient(isNegative, JSBI.BigInt(coefficient), exponent);
     }
 
     /**
      * Allows a Decimal to be constructed using a coefficient of arbitrary size.
      * @hidden
      */
-    static _fromJsbiCoefficient(isNegative: boolean, coefficient: JSBI, exponent: number) {
+    static _fromBigIntCoefficient(isNegative: boolean, coefficient: JSBI, exponent: number): Decimal {
         let value = Object.create(this.prototype);
         value._initialize(isNegative, coefficient, exponent);
         return value;
@@ -295,6 +336,6 @@ export class Decimal {
 
         let coefficient: JSBI = JSBI.BigInt(coefficientText);
         let isNegative: boolean = JsbiSupport.isNegative(coefficient) || (coefficientText.startsWith("-0"));
-        return Decimal._fromJsbiCoefficient(isNegative, coefficient, exponent);
+        return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);
     }
 }

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -49,23 +49,28 @@ export class Decimal {
     public static readonly ONE = new Decimal(1, 0);
 
     /**
-     * Creates a new Decimal value. Three parameter sets are supported:
+     * Creates a new Decimal value by parsing the provided text.
      *
-     *  (text: string)
-     *      The provided text will be parsed into a Decimal value.
-     *
-     *  (coefficient: number, coefficient: number)
-     *      A Decimal value will be constructed using the provided coefficient and exponent values.
-     *
-     *  (coefficient: BigInt, coefficient: number, isNegative?: boolean)
-     *      A Decimal value will be constructed using the provided coefficient and exponent values.
-     *      Because the BigInt data type cannot represent -0, a third parameter called `isNegative` may be supplied
-     *      to explicitly set the sign of the Decimal following construction. If this flag is not specified,
-     *      the provided coefficient's sign will be used.
+     * @param decimalText   An Ion-encoded decimal value.
      */
-    constructor(coefficient: number | JSBI | string,
-                exponent?: number,
-                isNegative?: boolean) {
+    constructor(decimalText: string);
+
+    /**
+     * Creates a new Decimal value using the provided coefficient and exponent values.
+     */
+    constructor(coefficient: number, exponent: number);
+    
+    /**
+     * Creates a new Decimal value using the provided coefficient and exponent values.
+     * Because the BigInt data type cannot represent -0, a third parameter called `isNegative` may be supplied
+     * to explicitly set the sign of the Decimal following construction. If this flag is not specified,
+     * the provided coefficient's sign will be used. If isNegative is specified but is not in agreement with
+     * the coefficient's sign, the value of isNegative takes precedence.
+     */
+    constructor(coefficient: JSBI, exponent: number, isNegative?: boolean);
+
+    // This is the unified implementation of the above signatures and is not visible to users.
+    constructor(coefficient: number | JSBI | string, exponent?: number, isNegative?: boolean) {
         if(typeof coefficient === "string") {
             return Decimal.parse(coefficient);
         }
@@ -84,7 +89,7 @@ export class Decimal {
                 // This will work for all values except -0.
                 isNegative = JsbiSupport.isNegative(coefficient);
             } else if (isNegative && !JsbiSupport.isNegative(coefficient)) {
-                // If isNegative was specified, make sure that the coefficent's sign agrees with it.
+                // If isNegative was specified, make sure that the coefficient's sign agrees with it.
                 coefficient = JSBI.unaryMinus(coefficient);
             }
             return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -57,6 +57,9 @@ export class Decimal {
 
     /**
      * Creates a new Decimal value using the provided coefficient and exponent values.
+     *
+     * @param coefficient   See the class-level [[Decimal]] documentation for details.
+     * @param exponent      See the class-level [[Decimal]] documentation for details.
      */
     constructor(coefficient: number, exponent: number);
     
@@ -66,6 +69,10 @@ export class Decimal {
      * to explicitly set the sign of the Decimal following construction. If this flag is not specified,
      * the provided coefficient's sign will be used. If isNegative is specified but is not in agreement with
      * the coefficient's sign, the value of isNegative takes precedence.
+     *
+     * @param coefficient   See the class-level [[Decimal]] documentation for details.
+     * @param exponent      See the class-level [[Decimal]] documentation for details.
+     * @param isNegative    Must be set to 'true' when constructing -0. May be omitted otherwise.
      */
     constructor(coefficient: JSBI, exponent: number, isNegative?: boolean);
 
@@ -88,7 +95,7 @@ export class Decimal {
                 // If isNegative was not specified, infer isNegative from the coefficient.
                 // This will work for all values except -0.
                 isNegative = JsbiSupport.isNegative(coefficient);
-            } else if (isNegative && !JsbiSupport.isNegative(coefficient)) {
+            } else if (isNegative != JsbiSupport.isNegative(coefficient)) {
                 // If isNegative was specified, make sure that the coefficient's sign agrees with it.
                 coefficient = JSBI.unaryMinus(coefficient);
             }

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -250,7 +250,7 @@ export class ParserBinaryRaw {
         let signedInt = ParserBinaryRaw._readSignedIntFrom(input,  numberOfCoefficientBytes);
         let isNegative = signedInt.isNegative;
         let coefficient = isNegative ? JSBI.unaryMinus(signedInt.magnitude) : signedInt.magnitude;
-        return Decimal._fromJsbiCoefficient(
+        return Decimal._fromBigIntCoefficient(
             isNegative,
             coefficient,
             exponent
@@ -313,7 +313,7 @@ export class ParserBinaryRaw {
                 isNegative = deserializedSignedInt._isNegative;
                 coefficient = deserializedSignedInt._magnitude;
             }
-            let dec = Decimal._fromJsbiCoefficient(isNegative, coefficient, exponent);
+            let dec = Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);
             let [_, fractionStr] = Timestamp._splitSecondsDecimal(dec);
             fractionalSeconds = Decimal.parse(secondInt + '.' + fractionStr);
         }

--- a/test/IonDecimal.ts
+++ b/test/IonDecimal.ts
@@ -206,7 +206,64 @@ let decimalEqualsTests: ({input1: string, input2: string, expected: boolean, ski
     {input1: '10000000000000000.00000000000000000', input2: '10000000000000000.0000000000000000', expected: false},
 ];
 
+let decimalFromNumberNumberTests: ({coefficient: number, exponent: number})[] = [
+    {coefficient: 0, exponent: 0},
+    {coefficient: -0, exponent: -0},
+    {coefficient: -0, exponent: 0},
+    {coefficient: 0, exponent: -0},
+    {coefficient: 314, exponent: 2},
+    {coefficient: -314, exponent: -2},
+    {coefficient: 314, exponent: -2},
+    {coefficient: -314, exponent: 2},
+    {coefficient: -10000000000000001, exponent: -9},
+    {coefficient: 10000000000000001, exponent: 9},
+    {coefficient: 10000000000000001, exponent: -9},
+    {coefficient: -10000000000000001, exponent: 9},
+];
+
+let toStringWithSign = (value: number | JSBI, isNegative) => {
+    if ((typeof value === 'number' && Object.is(-0, value))
+        || (value instanceof JSBI && isNegative === true && JsbiSupport.isZero(value))) {
+        return '-0';
+    }
+    return value.toString();
+};
+
+let decimalConstructorTest = (coefficient, exponent, isNegative?) => {
+    let coefficientText = toStringWithSign(coefficient, isNegative);
+    let exponentText = toStringWithSign(exponent, isNegative);
+    let testName = `(${coefficientText}, ${exponentText})`;
+
+    it(testName, () => {
+        let decimalValue = new Decimal(coefficient, exponent, isNegative);
+        let writer = ion.makeTextWriter();
+        writer.writeDecimal(decimalValue);
+        writer.close();
+        let ionData = writer.getBytes();
+        let reader = ion.makeReader(ionData);
+        assert.equal(ion.IonTypes.DECIMAL, reader.next());
+        let decimalFromText = reader.decimalValue();
+        assert.isTrue(decimalFromText.equals(decimalValue));
+    });
+};
+
 describe('Decimal', () => {
+    describe('Constructor variants', () => {
+        describe('(number, number)', () => {
+            decimalFromNumberNumberTests.forEach(({coefficient, exponent}) => {
+                decimalConstructorTest(coefficient, exponent);
+            });
+        });
+
+        describe('(BigInt, number, boolean)', () => {
+            decimalFromNumberNumberTests.forEach(({coefficient, exponent}) => {
+                let isNegative = coefficient < 0 || Object.is(-0, coefficient);
+                let bigIntCoefficient = JSBI.BigInt(coefficient);
+                decimalConstructorTest(bigIntCoefficient, exponent, isNegative);
+            });
+        });
+    });
+
     describe('Parsing', () => {
         decimalParsingTests.forEach(
             ({inputString, coefficient, exponent, numberValue, text}) => {


### PR DESCRIPTION
*Issue #, if available:* #354, #419 

*Description of changes:*

`Decimal`'s constructor now supports three sets of parameters:

```typescript
// Parsing a string (same behavior as Decimal.parse)
new Decimal(text: string)

// Providing an explicit coefficient and exponent as numbers
new Decimal(coefficient: number, exponent: number)

// Providing a BigInt coefficient, a number exponent, 
// and an optional explicit sign to accommodate -0.
new Decimal(coefficient: number, exponent: number, isNegative?: boolean)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
