### PR TITLE
Exposed Decimal#getCoefficient() and getExponent().

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -131,8 +131,8 @@ export class BinaryWriter extends AbstractWriter {
 
     if (typeof value == 'string') value = Decimal.parse(value);
 
-    let exponent: number = value._getExponent();
-    let coefficient: JSBI = value._getCoefficient();
+    let exponent: number = value.getExponent();
+    let coefficient: JSBI = value.getCoefficient();
     let isPositiveZero: boolean = JSBI.equal(coefficient, JsbiSupport.ZERO) && !value.isNegative();
     if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
       // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal
@@ -258,10 +258,10 @@ export class BinaryWriter extends AbstractWriter {
     if (value.getPrecision() >= TimestampPrecision.SECONDS) {
         writer.writeVariableLengthUnsignedInt(value.getSecondsInt());
         let fractionalSeconds = value._getFractionalSeconds();
-        if (fractionalSeconds._getExponent() !== 0) {
-            writer.writeVariableLengthSignedInt(fractionalSeconds._getExponent());
-            if (!JsbiSupport.isZero(fractionalSeconds._getCoefficient())) {
-              writer.writeBytes(JsbiSerde.toSignedIntBytes(fractionalSeconds._getCoefficient(), fractionalSeconds.isNegative()));
+        if (fractionalSeconds.getExponent() !== 0) {
+            writer.writeVariableLengthSignedInt(fractionalSeconds.getExponent());
+            if (!JsbiSupport.isZero(fractionalSeconds.getCoefficient())) {
+              writer.writeBytes(JsbiSerde.toSignedIntBytes(fractionalSeconds.getCoefficient(), fractionalSeconds.isNegative()));
             }
         }
     }

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -209,16 +209,19 @@ export class Decimal {
     }
 
     /**
-     * @hidden
+     * Returns a BigInt representing the coefficient of this Decimal value.
+     *
+     * Note that the BigInt data type is unable to represent -0 natively. If you wish to check for a -0 coefficient,
+     * test whether the coefficient is zero and then call [[isNegative]].
      */
-    _getCoefficient() : JSBI {
+    getCoefficient() : JSBI {
         return this._coefficient;
     }
 
     /**
-     * @hidden
+     * Returns a number representing the exponent of this Decimal value.
      */
-    _getExponent() : number {
+    getExponent() : number {
         return this._exponent;
     }
 
@@ -229,10 +232,10 @@ export class Decimal {
      * precision to match when returning 0.
      */
     equals(that : Decimal) : boolean {
-        return this._getExponent() === that._getExponent()
-            && _sign(this._getExponent()) === _sign(that._getExponent())
+        return this.getExponent() === that.getExponent()
+            && _sign(this.getExponent()) === _sign(that.getExponent())
             && this.isNegative() === that.isNegative()
-            && JSBI.equal(this._getCoefficient(), that._getCoefficient());
+            && JSBI.equal(this.getCoefficient(), that.getCoefficient());
     }
 
     /**

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -114,13 +114,13 @@ export class TextWriter extends AbstractWriter {
                 this.writeUtf8("null.decimal");
             } else {
                 let s = '';
-                let coefficient = value._getCoefficient();
+                let coefficient = value.getCoefficient();
                 if (JsbiSupport.isZero(coefficient) && value.isNegative()) {
                     s += '-';
                 }
                 s += coefficient.toString() + 'd';
 
-                let exponent = value._getExponent();
+                let exponent = value.getExponent();
                 if (exponent === 0 && _sign(exponent) === -1) {
                     s += '-';
                 }

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -326,15 +326,15 @@ export class Timestamp {
      * @hidden
      */
     static _splitSecondsDecimal(secondsDecimal: Decimal) : [string, string] {
-        let coefStr = secondsDecimal._getCoefficient().toString();
-        let exp = secondsDecimal._getExponent();
+        let coefStr = secondsDecimal.getCoefficient().toString();
+        let exp = secondsDecimal.getExponent();
         let secondsStr = '';
         let fractionStr = '';
         if (exp < 0) {
             let idx = Math.max(coefStr.length + exp, 0);
             secondsStr = coefStr.substr(0, idx);
             fractionStr = coefStr.substr(idx);
-            if (-secondsDecimal._getExponent() - coefStr.length > 0) {
+            if (-secondsDecimal.getExponent() - coefStr.length > 0) {
                 fractionStr = '0'.repeat(-exp - coefStr.length) + fractionStr;
             }
         } else if (exp > 0) {

--- a/test/IonDecimal.ts
+++ b/test/IonDecimal.ts
@@ -35,11 +35,11 @@ function test(decimalString,
 
     let decimal = ion.Decimal.parse(decimalString);
 
-    assert.deepEqual(decimal._getCoefficient(), JSBI.BigInt(expectedCoefficient), '_getCoefficient()');
+    assert.deepEqual(decimal.getCoefficient(), JSBI.BigInt(expectedCoefficient), '_getCoefficient()');
     assert.equal(decimal.isNegative(), Object.is(Number(expectedCoefficient), -0) || JsbiSupport.isNegative(JSBI.BigInt(expectedCoefficient)), 'coefficient sign');
 
-    assert.equal(decimal._getExponent(), expectedExponent, '_getExponent()');
-    assert.equal(util._sign(decimal._getExponent()), util._sign(expectedExponent), 'exponent sign');
+    assert.equal(decimal.getExponent(), expectedExponent, '_getExponent()');
+    assert.equal(util._sign(decimal.getExponent()), util._sign(expectedExponent), 'exponent sign');
 
     assert.equal(decimal.isNegative(), decimalString.trim()[0] === '-', 'isNegative()');
 
@@ -221,9 +221,13 @@ let decimalFromNumberNumberTests: ({coefficient: number, exponent: number})[] = 
     {coefficient: -10000000000000001, exponent: 9},
 ];
 
-let toStringWithSign = (value: number | JSBI, isNegative) => {
-    if ((typeof value === 'number' && Object.is(-0, value))
-        || (value instanceof JSBI && isNegative === true && JsbiSupport.isZero(value))) {
+let isNegativeZero = (value: number | JSBI, isNegative?: boolean): boolean => {
+    return (typeof value === 'number' && Object.is(-0, value))
+        || (value instanceof JSBI && isNegative === true && JsbiSupport.isZero(value));
+};
+
+let toStringWithSign = (value: number | JSBI, isNegative): string => {
+    if (isNegativeZero(value, isNegative)) {
         return '-0';
     }
     return value.toString();
@@ -250,6 +254,12 @@ let decimalConstructorTest = (coefficient, exponent, isNegative?) => {
 
     it(testName, () => {
         assert.isTrue(decimalFromText.equals(decimalValue));
+        assert.deepEqual(JSBI.BigInt(coefficient), decimalValue.getCoefficient());
+        assert.equal(exponent, decimalValue.getExponent());
+        assert.equal(
+            isNegativeZero(coefficient, isNegative),
+            isNegativeZero(decimalValue.getCoefficient(), decimalValue.isNegative())
+        );
     });
 };
 


### PR DESCRIPTION
*Issue #, if available:* #354, #419 

*Description of changes:*

Exposes `Decimal`'s `getCoefficient(): JSBI` and `getExponent(): number` methods and adds related tests. The bulk of the diff is comprised of lines that removed the underscore from `_getCoefficient()` or `_getExponent()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
