### PR TITLE
Removes text parser logic that performed UTF-16 and UTF-8 encoding on clob bytes

### DIFF
--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -40,6 +40,8 @@ const BEGINNING_OF_CONTAINER = -2; // cloned from IonParserTextRaw
 const EOF = -1;
 const T_IDENTIFIER = 9;
 const T_STRING1 = 11;
+const T_CLOB2 = 14;
+const T_CLOB3 = 15;
 const T_STRUCT = 19;
 
 export class TextReader implements Reader {
@@ -68,8 +70,11 @@ export class TextReader implements Reader {
   load_raw() {
     let t: TextReader = this;
     if (t._raw !== undefined) return;
-    t._raw = t._parser.get_value_as_string(t._raw_type);
-    return;
+    if (t._raw_type === T_CLOB2 || t._raw_type === T_CLOB3) {
+        t._raw = t._parser.get_value_as_uint8array(t._raw_type);
+    } else {
+        t._raw = t._parser.get_value_as_string(t._raw_type);
+    }
   }
 
   skip_past_container() {
@@ -265,7 +270,7 @@ export class TextReader implements Reader {
                 if (this.isNull()) {
                     return null;
                 }
-                return encodeUtf8(this._raw);
+                return this._raw;
         }
         throw new Error('Current value is not a blob or clob.');
     }

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -44,6 +44,14 @@ class IonTextReaderTests {
         assert.equal(ionReader.value(), true);
     }
 
+    @test "Read clob value"() {
+        let ionToRead = '{{"\\xc2\\x80"}}';
+        let ionReader = ion.makeReader(ionToRead);
+        ionReader.next();
+
+        assert.deepEqual(ionReader.value(), Uint8Array.from([194, 128]));
+    }
+
     @test "Read boolean value in struct"() {
         let ionToRead = "{ a: false }";
         let ionReader = ion.makeReader(ionToRead);


### PR DESCRIPTION
The text reader currently converts clob bytes to a string via `String.fromCharCode` (which applies UTF-16 encoding), then `byteValue()` converts that string UTF-8 bytes.  This implementation is incorrect.

An Ion clob value does have any particular encoding--it is just a collection of bytes intended to represent text.  Any encoding is an application-level concern, and encoding should thereby *not* be performed by an Ion parser implementation.

Resolves #481 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
