### PR TITLE
Decimal: -0 exponent is equiv to a 0 exponent.

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -133,6 +133,7 @@ export class BinaryWriter extends AbstractWriter {
 
     let exponent: number = value.getExponent();
     let coefficient: JSBI = value.getCoefficient();
+
     let isPositiveZero: boolean = JSBI.equal(coefficient, JsbiSupport.ZERO) && !value.isNegative();
     if (isPositiveZero && exponent === 0 && _sign(exponent) === 1) {
       // Special case per the spec: http://amzn.github.io/ion-docs/docs/binary.html#5-decimal

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -135,6 +135,11 @@ export class Decimal {
     private _initialize(isNegative: boolean, coefficient: JSBI, exponent: number) {
         this._isNegative = isNegative;
         this._coefficient = coefficient;
+        // If the exponent is -0, set it to 0, which is equivalent.
+        // See: https://github.com/amzn/ion-js/issues/474
+        if (Object.is(-0, exponent)) {
+            exponent = 0;
+        }
         this._exponent = exponent;
     }
 

--- a/test/IonBinaryWriter.ts
+++ b/test/IonBinaryWriter.ts
@@ -237,8 +237,18 @@ let decimalWriterTests = [
         expected: [0x50]
     },
     {
+        name: "Writes 0d-0 as equiv 0d0 decimal",
+        instructions: (writer) => writer.writeDecimal(ion.Decimal.parse("0d-0")),
+        expected: [0x50]
+    },
+    {
         name: "Writes negative zero decimal",
         instructions: (writer) => writer.writeDecimal(ion.Decimal.parse("-0")),
+        expected: [0x52, 0x80, 0x80]
+    },
+    {
+        name: "Writes -0d-0 as equiv -0d0 decimal",
+        instructions: (writer) => writer.writeDecimal(ion.Decimal.parse("-0d-0")),
         expected: [0x52, 0x80, 0x80]
     },
     {

--- a/test/IonDecimal.ts
+++ b/test/IonDecimal.ts
@@ -75,8 +75,8 @@ function testCompareTo(decimalString1, decimalString2, expected) {
 let decimalParsingTests = [
     {inputString: '0d0', coefficient: '0', exponent: 0, numberValue: 0, text: '0'},
     {inputString: '-0d0', coefficient: '-0', exponent: 0, numberValue: -0, text: '-0'},
-    {inputString: '0d-0', coefficient: '0', exponent: -0, numberValue: 0, text: '0'},
-    {inputString: '-0d-0', coefficient: '-0', exponent: -0, numberValue: -0, text: '-0'},
+    {inputString: '0d-0', coefficient: '0', exponent: 0, numberValue: 0, text: '0'},
+    {inputString: '-0d-0', coefficient: '-0', exponent: 0, numberValue: -0, text: '-0'},
     {inputString: '0.', coefficient: '0', exponent: 0, numberValue: 0, text: '0'},
     {inputString: '-0.', coefficient: '-0', exponent: 0, numberValue: -0, text: '-0'},
     {inputString: '0d5', coefficient: '0', exponent: 5, numberValue: 0, text: '0E+5'},
@@ -179,13 +179,13 @@ let decimalEqualsTests: ({input1: string, input2: string, expected: boolean, ski
     {input1: '0', input2: '0d1', expected: false},
     {input1: '0', input2: '0d-1', expected: false},
 
-    {input1: '0', input2: '0d-0', expected: false},
+    {input1: '0', input2: '0d-0', expected: true},
     {input1: '-0', input2: '-0', expected: true},
     {input1: '-0', input2: '-0d0', expected: true},
 
     {input1: '-0', input2: '-0d1', expected: false},
     {input1: '-0', input2: '-0d-1', expected: false},
-    {input1: '-0', input2: '-0d-0', expected: false},
+    {input1: '-0', input2: '-0d-0', expected: true},
 
     {input1: '0', input2: '-0', expected: false},
     {input1: '0', input2: '-0d0', expected: false},


### PR DESCRIPTION
*Issue #, if available:* #474 

*Description of changes:*

As per the spec:
> Decimals should be considered equivalent if and only if their data model tuples are equivalent, where exponents of +0 and -0 are considered equivalent.

This PR enforces this behavior and aligns `ion-js`'s binary `decimal` output with that of `ion-java`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
