### PR TITLE
Typedoc fixes to render IntSize and exclude new internal modules

### DIFF
--- a/src/IntSize.ts
+++ b/src/IntSize.ts
@@ -15,8 +15,10 @@
 /**
  * Represents whether a given Ion int value will fit safely within a Number or if it requires a BigInt.
  */
-enum IntSize {
+export enum IntSize {
+    /** The Ion int value fits safely in a number. */
     Number,
+    /** The Ion int value requies a BigInt. */
     BigInt
 }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -29,7 +29,11 @@
     "src/IonLowLevel*.ts",
 
     "src/IonTest*.ts",
-    "src/IonEvent*.ts"
+    "src/IonEvent*.ts",
+
+    "src/JsbiSerde.ts",
+    "src/JsbiSupport.ts",
+    "src/SignAndMagnitudeInt.ts"
   ],
 
   "out": "docs/api/"


### PR DESCRIPTION
Without these changes, the `IntSize` module renders without a link to the enum itself.

And I believe we don't want the Jsbi* and SignAndMagnitudeInt modules to be considered part of the API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
