### PR TITLE
Bumps version to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-js",
-  "version": "3.2.0-SNAPSHOT",
+  "version": "3.1.1",
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",


### PR DESCRIPTION
I've unpublished the 3.1.0 release because it unintentionally included a .zip of the dist folder.  Trying again with a 3.1.1 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
