### PR TITLE
(Docs) Removes link to typedoc in footer

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -36,5 +36,7 @@
     "src/SignAndMagnitudeInt.ts"
   ],
 
-  "out": "docs/api/"
+  "out": "docs/api/",
+
+  "hideGenerator": true
 }


### PR DESCRIPTION
*Description of changes:*

Removes the link to typedoc found in the footer of each generated HTML page. 
The generated link uses `target=_blank` which can be used for phishing 
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
