### PR TITLE
Adds tslint, tslint:src, and tslint:test build targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,9 +24,9 @@ module.exports = function(grunt) {
     jshint: {
       files: []
     },
-      /**
-       * Typescript document generator
-       */
+    /**
+     * Typescript document generator
+     */
     typedoc: {
       build: {
         src: 'src/**/*'
@@ -43,11 +43,16 @@ module.exports = function(grunt) {
         tsconfig: 'tsconfig.commonjs.json'
       }
     },
-      /**
-       * Copy of generated .js files to
-       *  1. the dist folder
-       *  2. the browser folder for use within a browser
-       */
+    tslint: {
+      all: ['src/**/*.ts', 'test/**/*.ts'],
+      src: 'src/**/*.ts',
+      test: 'test/**/*.ts',
+    },
+    /**
+     * Copy of generated .js files to
+     *  1. the dist folder
+     *  2. the browser folder for use within a browser
+     */
     copy: {
       bundle: {
         files: [
@@ -148,6 +153,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-ts');
+  grunt.loadNpmTasks('grunt-tslint');
   grunt.loadNpmTasks('grunt-typedoc');
 
   // Copy tasks

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "grunt-contrib-uglify": "^4.0.1",
     "grunt-shell": "^3.0.1",
     "grunt-ts": "^6.0.0-beta.21",
+    "grunt-tslint": "^5.0.2",
     "grunt-typedoc": "^0.2.4",
     "mocha": "^6.2.0",
     "mocha-typescript": "^1.1.17",
@@ -73,6 +74,7 @@
     "semantic-release": "^15.13.24",
     "source-map-support": "^0.5.13",
     "ts-node": "^8.4.1",
+    "tslint": "^5.20.1",
     "typedoc": "^0.15.0",
     "typescript": "^3.6.2"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tslint:recommended"
+}
+


### PR DESCRIPTION
Initial config simply uses tslint's "recommended" set of rules.  Some rules come with "fixers" that modify the source to align with the rule's notion of "correct."  I'd suggest we configure and apply fixers as time and inclination permits.

Resolves #345 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
