### PR TITLE
Retains copyright header by prefixing with /*!

### DIFF
--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IntSize.ts
+++ b/src/IntSize.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonBinary.ts
+++ b/src/IonBinary.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonCatalog.ts
+++ b/src/IonCatalog.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonConstants.ts
+++ b/src/IonConstants.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonImport.ts
+++ b/src/IonImport.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonLocalSymbolTable.ts
+++ b/src/IonLocalSymbolTable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonLowLevelBinaryWriter.ts
+++ b/src/IonLowLevelBinaryWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonPrettyTextWriter.ts
+++ b/src/IonPrettyTextWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSubstituteSymbolTable.ts
+++ b/src/IonSubstituteSymbolTable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSymbol.ts
+++ b/src/IonSymbol.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSymbolIndex.ts
+++ b/src/IonSymbolIndex.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSymbols.ts
+++ b/src/IonSymbols.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonSystemSymbolTable.ts
+++ b/src/IonSystemSymbolTable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonTests.ts
+++ b/src/IonTests.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonText.ts
+++ b/src/IonText.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonType.ts
+++ b/src/IonType.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonTypes.ts
+++ b/src/IonTypes.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonWriteable.ts
+++ b/src/IonWriteable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/JsbiSerde.ts
+++ b/src/JsbiSerde.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/JsbiSupport.ts
+++ b/src/JsbiSupport.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/SignAndMagnitudeInt.ts
+++ b/src/SignAndMagnitudeInt.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/AbstractWriter.ts
+++ b/test/AbstractWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IntSize.ts
+++ b/test/IntSize.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonAnnotations.ts
+++ b/test/IonAnnotations.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonBinaryReader.ts
+++ b/test/IonBinaryReader.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonBinaryTimestamp.ts
+++ b/test/IonBinaryTimestamp.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonBinaryWriter.ts
+++ b/test/IonBinaryWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonCatalog.ts
+++ b/test/IonCatalog.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonDecimal.ts
+++ b/test/IonDecimal.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonImport.ts
+++ b/test/IonImport.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonLocalSymbolTable.ts
+++ b/test/IonLocalSymbolTable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonLowLevelBinaryWriter.ts
+++ b/test/IonLowLevelBinaryWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonText.ts
+++ b/test/IonText.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonTextWriter.ts
+++ b/test/IonTextWriter.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonTimestamp.ts
+++ b/test/IonTimestamp.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonUnicode.ts
+++ b/test/IonUnicode.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonWriteable.ts
+++ b/test/IonWriteable.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/IonWriterUndefinedParameters.ts
+++ b/test/IonWriterUndefinedParameters.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/spans.ts
+++ b/test/spans.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/textNulls.ts
+++ b/test/textNulls.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/writeSymbolTokens.ts
+++ b/test/writeSymbolTokens.ts
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright 2012 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
A build with these changes retains the copyright header:
* at the top of each `.js` file (for amd/commonjs/es6 module systems)
* at the top of each `.d.ts` file (for amd/commonjs/es6 module systems)
* 32 times throughout `browser/js/ion-bundle.js`
* 0 times in `browser/js/ion-bundle.min.js`

In all cases, the `/*!` prefix is still present in the generated files (as opposed to being changed to `/*`).

Resolves #504 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
