### PR TITLE
Adds an 'npm prepare' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/commonjs/es6/Ion.d.ts",
   "scripts": {
     "commit": "git-cz",
+    "prepare": "grunt",
     "test": "nyc mocha",
     "release": "grunt release"
   },


### PR DESCRIPTION
With this change, executing `npm install amzn/ion-js#pcornell-npm-prepare` in an empty directory builds ion-js, resulting in a `node_modules/ion-js/dist` folder, and executing `node` followed by `ion = require('ion-js')` produces a usable `ion` variable.

References:
* https://docs.npmjs.com/misc/scripts
* https://itnext.io/step-by-step-building-and-publishing-an-npm-typescript-package-44fe7164964c (specifically the section titled "Use the magic scripts in NPM")

Resolves #502 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
