### PR TITLE
Enables typescript compiler's strictNullChecks option and updates code as needed

### DIFF
--- a/src/AbstractWriter.ts
+++ b/src/AbstractWriter.ts
@@ -23,7 +23,7 @@ export interface AbstractWriter extends Writer {
 }
 
 export abstract class AbstractWriter implements Writer {
-    protected _annotations = [];
+    protected _annotations: string[] = [];
 
     addAnnotation(annotation: string): void {
         if (!this._isString(annotation)) {
@@ -55,7 +55,7 @@ export abstract class AbstractWriter implements Writer {
     }
 
     private _writeValues(reader: Reader, _depth = 0): void {
-        let type: IonType = reader.type();
+        let type: IonType | null = reader.type();
         if (type === null) {
             type = reader.next();
         }
@@ -66,13 +66,14 @@ export abstract class AbstractWriter implements Writer {
     }
 
     private _writeValue(reader: Reader, _depth = 0): void {
-        let type: IonType = reader.type();
+        let type: IonType | null = reader.type();
         if (type === null) {
             return;
         }
         if (_depth > 0) {
-            if (reader.fieldName() != null) {
-                this.writeFieldName(reader.fieldName());
+            let fieldName = reader.fieldName();
+            if (fieldName !== null) {
+                this.writeFieldName(fieldName);
             }
         }
         this.setAnnotations(reader.annotations());

--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -57,16 +57,14 @@ export type ReaderBuffer = ReaderOctetBuffer | string;
  *                  binary buffer.
  */
 export function makeReader(buf: ReaderBuffer): Reader {
-    // TODO #387 make the catalog an optional parameter
-    const catalog = null;
     if ((typeof buf) === "string") {
-        return new TextReader(new StringSpan(<string>buf), catalog);
+        return new TextReader(new StringSpan(<string>buf));
     }
     const bufArray = new Uint8Array(buf as ReaderOctetBuffer);
     if (isBinary(bufArray)) {
-        return new BinaryReader(new BinarySpan(bufArray), catalog);
+        return new BinaryReader(new BinarySpan(bufArray));
     } else {
-        return new TextReader(new StringSpan(decodeUtf8(bufArray)), catalog);
+        return new TextReader(new StringSpan(decodeUtf8(bufArray)));
     }
 }
 

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -133,10 +133,6 @@ export class BinaryWriter extends AbstractWriter {
         _assertDefined(value);
         this.checkWriteValue();
 
-        if (typeof value == 'string') {
-            value = Decimal.parse(value);
-        }
-
         if (value === null) {
             this.writeNull(IonTypes.DECIMAL);
             return;

--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -38,6 +38,8 @@ const NULL_VALUE_FLAG: number = 15;
 
 const TYPE_DESCRIPTOR_LENGTH: number = 1;
 
+let EMPTY_UINT8ARRAY = new Uint8Array();
+
 /** Possible writer states */
 enum States {
     /** The writer expects a value (a call to writeInt(), writeString(), etc.) or a transition (stepOut(), close()) */
@@ -95,7 +97,7 @@ export class BinaryWriter extends AbstractWriter {
         return this.writer.getBytes();
     }
 
-    writeBlob(value: Uint8Array): void {
+    writeBlob(value: Uint8Array | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -105,7 +107,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.BLOB, this.encodeAnnotations(this._annotations), value));
     }
 
-    writeBoolean(value: boolean): void {
+    writeBoolean(value: boolean | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -116,7 +118,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BooleanNode(this.writer, this.getCurrentContainer(), this.encodeAnnotations(this._annotations), value));
     }
 
-    writeClob(value: Uint8Array): void {
+    writeClob(value: Uint8Array | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -127,15 +129,18 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.CLOB, this.encodeAnnotations(this._annotations), value));
     }
 
-    writeDecimal(value: Decimal | string): void {
+    writeDecimal(value: Decimal | null): void {
         _assertDefined(value);
         this.checkWriteValue();
+
+        if (typeof value == 'string') {
+            value = Decimal.parse(value);
+        }
+
         if (value === null) {
             this.writeNull(IonTypes.DECIMAL);
             return;
         }
-
-        if (typeof value == 'string') value = Decimal.parse(value);
 
         let exponent: number = value.getExponent();
         let coefficient: JSBI = value.getCoefficient();
@@ -149,7 +154,7 @@ export class BinaryWriter extends AbstractWriter {
 
         let isNegative = value.isNegative();
         let writeCoefficient = isNegative || JSBI.notEqual(coefficient, JsbiSupport.ZERO);
-        let coefficientBytes: Uint8Array | null = writeCoefficient ? JsbiSerde.toSignedIntBytes(coefficient, isNegative) : null;
+        let coefficientBytes: Uint8Array = writeCoefficient ? JsbiSerde.toSignedIntBytes(coefficient, isNegative) : EMPTY_UINT8ARRAY;
 
         let bufLen = LowLevelBinaryWriter.getVariableLengthSignedIntSize(exponent) + (writeCoefficient ? coefficientBytes.length : 0);
         let writer: LowLevelBinaryWriter = new LowLevelBinaryWriter(new Writeable(bufLen));
@@ -160,7 +165,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.DECIMAL, this.encodeAnnotations(this._annotations), writer.getBytes()));
     }
 
-    writeFloat32(value: number): void {
+    writeFloat32(value: number | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -183,7 +188,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.FLOAT, this.encodeAnnotations(this._annotations), bytes));
     }
 
-    writeFloat64(value: number): void {
+    writeFloat64(value: number | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -225,7 +230,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new NullNode(this.writer, this.getCurrentContainer(), type, this.encodeAnnotations(this._annotations)));
     }
 
-    writeString(value: string): void {
+    writeString(value: string | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -236,7 +241,7 @@ export class BinaryWriter extends AbstractWriter {
         this.addNode(new BytesNode(this.writer, this.getCurrentContainer(), IonTypes.STRING, this.encodeAnnotations(this._annotations), encodeUtf8(value)));
     }
 
-    writeSymbol(value: string): void {
+    writeSymbol(value: string | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -249,7 +254,7 @@ export class BinaryWriter extends AbstractWriter {
         }
     }
 
-    writeTimestamp(value: Timestamp): void {
+    writeTimestamp(value: Timestamp | null): void {
         _assertDefined(value);
         this.checkWriteValue();
         if (value === null) {
@@ -433,7 +438,7 @@ export class BinaryWriter extends AbstractWriter {
         this.datagram[0].write();
     }
 
-    private writeImport(import_: Import) {
+    private writeImport(import_: Import | null) {
         if (!import_) {
             return;
         }
@@ -459,7 +464,7 @@ export interface Node {
 export abstract class AbstractNode implements Node {
     protected constructor(
         private readonly _writer: LowLevelBinaryWriter,
-        private readonly parent: Node,
+        private readonly parent: Node | null,
         private readonly _type: IonType,
         private readonly annotations: Uint8Array
     ) {
@@ -688,6 +693,8 @@ class IntNode extends LeafNode {
             if (value instanceof JSBI) {
                 if (JsbiSupport.isNegative(value)) {
                     magnitude = JSBI.unaryMinus(value);
+                } else {
+                    magnitude = value;
                 }
             } else {
                 magnitude = Math.abs(value);
@@ -731,7 +738,7 @@ class BytesNode extends LeafNode {
 }
 
 export class NullNode extends LeafNode {
-    constructor(writer: LowLevelBinaryWriter, parent: Node, type: IonType, annotations: Uint8Array) {
+    constructor(writer: LowLevelBinaryWriter, parent: Node | null, type: IonType, annotations: Uint8Array) {
         super(writer, parent, type, annotations);
     }
 

--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -82,9 +82,9 @@ export class Decimal {
     constructor(coefficient: JSBI, exponent: number, isNegative?: boolean);
 
     // This is the unified implementation of the above signatures and is not visible to users.
-    constructor(coefficient: number | JSBI | string, exponent?: number, isNegative?: boolean) {
+    constructor(coefficient: number | JSBI | string, exponent?: number, isNegative: boolean = false) {
         if (typeof coefficient === "string") {
-            return Decimal.parse(coefficient);
+            return Decimal.parse(coefficient)!;
         }
 
         if (!_hasValue(exponent)) {
@@ -92,7 +92,7 @@ export class Decimal {
         }
 
         if (typeof coefficient === "number") {
-            return Decimal._fromNumberCoefficient(coefficient, exponent);
+            return Decimal._fromNumberCoefficient(coefficient, exponent!);
         }
 
         if (coefficient instanceof JSBI) {
@@ -104,7 +104,7 @@ export class Decimal {
                 // If isNegative was specified, make sure that the coefficient's sign agrees with it.
                 coefficient = JSBI.unaryMinus(coefficient);
             }
-            return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);
+            return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent!);
         }
 
         throw new Error(`Unsupported parameter set (${coefficient}, ${exponent}, ${isNegative} passed to Decimal constructor.`);
@@ -138,22 +138,22 @@ export class Decimal {
      * returns a new Decimal object corresponding to the value.  If a string such as
      * '5' is provided, a 'd0' suffix is assumed.
      */
-    static parse(str: string): Decimal {
+    static parse(str: string): Decimal | null {
         let exponent = 0;
         if (str === 'null' || str === 'null.decimal') return null;
         let d = str.match('[d|D]');
         let exponentDelimiterIndex = str.length;
-        if (d) {
-            exponent = Number(str.substring(d.index + 1, str.length));
-            exponentDelimiterIndex = d.index;
+        if (d !== undefined && d !== null) {
+            exponent = Number(str.substring(d.index! + 1, str.length));
+            exponentDelimiterIndex = d.index!;
         }
         let f = str.match('\\.');
         let coefficientText: string;
         if (f) {
-            let exponentShift = d ? (d.index - 1) - f.index : (str.length - 1) - f.index;
+            let exponentShift = d ? (d.index! - 1) - f.index! : (str.length - 1) - f.index!;
             exponent -= exponentShift;
             // Remove the '.' from the input string.
-            coefficientText = str.substring(0, f.index) + str.substring(f.index + 1, exponentDelimiterIndex);
+            coefficientText = str.substring(0, f.index) + str.substring(f.index! + 1, exponentDelimiterIndex);
         } else {
             coefficientText = str.substring(0, exponentDelimiterIndex);
         }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -36,8 +36,8 @@ export enum IonEventType {
 
 export interface IonEvent {
     eventType: IonEventType;
-    ionType: IonType;
-    fieldName: string;
+    ionType: IonType | null;
+    fieldName: string | null;
     annotations: string[];
     depth: number;
     ionValue: any;
@@ -51,14 +51,14 @@ export interface IonEvent {
 
 abstract class AbstractIonEvent implements IonEvent {
     eventType: IonEventType;
-    ionType: IonType;
-    fieldName: string;
+    ionType: IonType | null;
+    fieldName: string | null;
     annotations: string[];
     depth: number;
     ionValue: any;
 
 
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: any) {
+    constructor(eventType: IonEventType, ionType: IonType | null, fieldName: string | null, annotations: string[], depth: number, ionValue: any) {
         this.eventType = eventType;
         this.ionType = ionType;
         this.fieldName = fieldName;
@@ -183,7 +183,7 @@ abstract class AbstractIonEvent implements IonEvent {
 
 export class IonEventFactory {
 
-    makeEvent(eventType: IonEventType, ionType: IonType, fieldName: string, depth: number, annotations: string[], isNull: boolean, value: any): IonEvent {
+    makeEvent(eventType: IonEventType, ionType: IonType, fieldName: string | null, depth: number, annotations: string[], isNull: boolean, value: any): IonEvent {
         if (isNull) {
             return new IonNullEvent(eventType, ionType, fieldName, annotations, depth);
         }
@@ -235,15 +235,14 @@ export class IonEventFactory {
                 throw new Error("symbol tables unsupported.");
             case IonEventType.CONTAINER_END :
             case IonEventType.STREAM_END :
-                return new IonEndEvent(eventType, null, null, [], depth);
+                return new IonEndEvent(eventType, depth);
         }
     }
 }
 
 class IonNullEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number) {
         super(eventType, ionType, fieldName, annotations, depth, null);
-
     }
 
     valueEquals(expected: IonNullEvent): boolean {
@@ -251,12 +250,12 @@ class IonNullEvent extends AbstractIonEvent {
     }
 
     writeIonValue(writer: Writer): void {
-        writer.writeNull(this.ionType);
+        writer.writeNull(this.ionType !== null ? this.ionType : IonTypes.NULL );
     }
 }
 
 class IonIntEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: number) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -271,7 +270,7 @@ class IonIntEvent extends AbstractIonEvent {
 }
 
 class IonBoolEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: boolean) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: boolean) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -286,7 +285,7 @@ class IonBoolEvent extends AbstractIonEvent {
 }
 
 class IonFloatEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: number) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -302,7 +301,7 @@ class IonFloatEvent extends AbstractIonEvent {
 }
 
 class IonDecimalEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: Decimal) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: Decimal) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -317,7 +316,7 @@ class IonDecimalEvent extends AbstractIonEvent {
 }
 
 class IonSymbolEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: string) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: string) {
         //if(ionValue === '$ion_1_0') ionValue = "$ion_user_value::" + ionValue;
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
@@ -333,7 +332,7 @@ class IonSymbolEvent extends AbstractIonEvent {
 }
 
 class IonStringEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: string) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: string) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -349,7 +348,7 @@ class IonStringEvent extends AbstractIonEvent {
 }
 
 class IonTimestampEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: Timestamp) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: Timestamp) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
 
     }
@@ -364,7 +363,7 @@ class IonTimestampEvent extends AbstractIonEvent {
 }
 
 class IonBlobEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: string) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: string) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
 
@@ -383,7 +382,7 @@ class IonBlobEvent extends AbstractIonEvent {
 }
 
 class IonClobEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number, ionValue: Uint8Array) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number, ionValue: Uint8Array) {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
 
@@ -402,7 +401,7 @@ class IonClobEvent extends AbstractIonEvent {
 
 abstract class AbsIonContainerEvent extends AbstractIonEvent {
 
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number) {
         super(eventType, ionType, fieldName, annotations, depth, null);
     }
 
@@ -414,7 +413,7 @@ abstract class AbsIonContainerEvent extends AbstractIonEvent {
 }
 
 class IonStructEvent extends AbsIonContainerEvent {//no embed support as of yet.
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number) {
         super(eventType, ionType, fieldName, annotations, depth);
 
     }
@@ -452,7 +451,7 @@ class IonStructEvent extends AbsIonContainerEvent {//no embed support as of yet.
 }
 
 class IonListEvent extends AbsIonContainerEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number) {
         super(eventType, ionType, fieldName, annotations, depth);
 
     }
@@ -475,7 +474,7 @@ class IonListEvent extends AbsIonContainerEvent {
 }
 
 class IonSexpEvent extends AbsIonContainerEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
+    constructor(eventType: IonEventType, ionType: IonType, fieldName: string | null, annotations: string[], depth: number) {
         super(eventType, ionType, fieldName, annotations, depth);
 
     }
@@ -498,8 +497,8 @@ class IonSexpEvent extends AbsIonContainerEvent {
 }
 
 class IonEndEvent extends AbstractIonEvent {
-    constructor(eventType: IonEventType, ionType: IonType, fieldName: string, annotations: string[], depth: number) {
-        super(eventType, ionType, fieldName, annotations, depth, undefined);
+    constructor(eventType: IonEventType, depth: number) {
+        super(eventType, null, null, [], depth, undefined);
 
     }
 

--- a/src/IonImport.ts
+++ b/src/IonImport.ts
@@ -29,17 +29,17 @@ import {SharedSymbolTable} from "./IonSharedSymbolTable";
 export class Import {
     private readonly _offset: number;
     private readonly _length: number;
-    private readonly _parent: Import;
+    private readonly _parent: Import | null;
     private readonly _symbolTable: SharedSymbolTable;
 
-    constructor(parent: Import, symbolTable: SharedSymbolTable, length?: number) {
+    constructor(parent: Import | null, symbolTable: SharedSymbolTable, length?: number | null) {
         this._parent = parent;
         this._symbolTable = symbolTable;
         this._offset = this.parent ? this.parent.offset + this.parent.length : 1;
         this._length = length || this.symbolTable.numberOfSymbols;
     }
 
-    get parent(): Import {
+    get parent(): Import | null {
         return this._parent;
     }
 
@@ -55,7 +55,7 @@ export class Import {
         return this._symbolTable;
     }
 
-    getSymbolText(symbolId: number): string {
+    getSymbolText(symbolId: number): string | undefined {
         if (this.parent === undefined) throw new Error("Illegal parent state.");
         if (this.parent !== null) {
             let parentSymbol = this.parent.getSymbolText(symbolId);
@@ -71,7 +71,7 @@ export class Import {
         return undefined;
     }
 
-    getSymbolId(symbolText: string): number {
+    getSymbolId(symbolText: string): number | undefined {
         let symbolId;
         if (this.parent !== null) {
             symbolId = this.parent.getSymbolId(symbolText);

--- a/src/IonLocalSymbolTable.ts
+++ b/src/IonLocalSymbolTable.ts
@@ -22,20 +22,26 @@ import {SymbolIndex} from "./IonSymbolIndex";
  * symbol table or from a shared symbol table via an import.
  */
 export class LocalSymbolTable {
-    private offset: number;
+    private readonly _import: Import;
+    private readonly offset: number;
     private index: SymbolIndex = {};
 
-    constructor(private _import: Import = getSystemSymbolTableImport(), symbols: string[] = []) {
-        this.offset = _import.offset + _import.length;
+    constructor(theImport: Import | null, symbols: (string | null)[] = []) {
+        if (theImport === null) {
+            this._import = getSystemSymbolTableImport();
+        } else {
+            this._import = theImport;
+        }
+        this.offset = this._import.offset + this._import.length;
 
         for (let symbol_ of symbols) {
             this.addSymbol(symbol_);
         }
     }
 
-    private _symbols: string[] = [];
+    private _symbols: (string | null)[] = [];
 
-    get symbols(): string[] {
+    get symbols(): (string | null)[] {
         return this._symbols;
     }
 
@@ -51,18 +57,22 @@ export class LocalSymbolTable {
         return this._import.getSymbolId(symbol_) || this.index[symbol_];
     }
 
-    addSymbol(symbol_: string): number {
-        let existingSymbolId = this.getSymbolId(symbol_);
-        if (existingSymbolId !== undefined) return existingSymbolId;
+    addSymbol(symbol_: string | null): number {
+        if (symbol_ !== null) {
+            let existingSymbolId = this.getSymbolId(symbol_);
+            if (existingSymbolId !== undefined) return existingSymbolId;
+        }
         let symbolId = this.offset + this.symbols.length;
         this.symbols.push(symbol_);
-        this.index[symbol_] = symbolId;
+        if (symbol_ !== null) {
+            this.index[symbol_] = symbolId;
+        }
         return symbolId;
     }
 
-    getSymbolText(symbolId: number): string {
+    getSymbolText(symbolId: number): string | null {
         if (symbolId > this.maxId) throw new Error("SymbolID greater than maxID.");
-        let importedSymbol: string = this.import.getSymbolText(symbolId);
+        let importedSymbol: string | undefined = this.import.getSymbolText(symbolId);
         if (importedSymbol !== undefined) return importedSymbol;
         let index = symbolId - this.offset;
         return this.symbols[index];

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -102,14 +102,12 @@ const ESC_x =   CH_x; //  values['x'] = ESCAPE_HEX;      //    any  \xHH  2-digi
 const ESC_u =    117; //  values['u'] = ESCAPE_LITTLE_U; //    any  \ uHHHH  4-digit hexadecimal unicode character
 const ESC_U =     85; //  values['U'] = ESCAPE_BIG_U;    //    any  \ UHHHHHHHH  8-digit hexadecimal unicode character
 
-const empty_array: any[] = [];
-
 const INF = [CH_i, CH_n, CH_f];
 
 // mask the 6 hi-order bits of a UTF-16 surrogate; the 10 low-order bits are the ones of interest
 const _UTF16_MASK = 0x03ff;
 
-export function get_ion_type(t: number): IonType {
+export function get_ion_type(t: number): IonType | null {
     switch (t) {
         case EOF:             return null;
         case ERROR:           return null;
@@ -224,8 +222,8 @@ export class ParserTextRaw {
     private _ann: any[];
     private _msg: string;
     private _error_msg: string;
-    private _fieldname: string;
-    private _fieldnameType: number;
+    private _fieldname: string | null;
+    private _fieldnameType: number | null;
 
     private readonly _read_value_helper_helpers: ReadValueHelpers;
 
@@ -272,11 +270,11 @@ export class ParserTextRaw {
         this._read_value_helper_helpers = helpers;
     }
 
-    fieldName(): string {
+    fieldName(): string | null {
         return this._fieldname;
     }
 
-    fieldNameType(): number {
+    fieldNameType(): number | null {
         return this._fieldnameType;
     }
 
@@ -293,7 +291,7 @@ export class ParserTextRaw {
         return this._curr_null;
     }
 
-    bigIntValue(): JSBI {
+    bigIntValue(): JSBI | null {
         if (this.isNull()) {
             return null;
         }
@@ -307,7 +305,7 @@ export class ParserTextRaw {
         }
     }
 
-    numberValue(): number {
+    numberValue(): number | null {
         if (this.isNull()) return null;
         let s = this.get_value_as_string(this._curr);
         switch (this._curr) {
@@ -325,16 +323,15 @@ export class ParserTextRaw {
         }
     }
 
-    booleanValue(): boolean {
+    booleanValue(): boolean | null {
         if (this.isNull()) return null;
         let s: string = this.get_value_as_string(T_BOOL);
-        if (s == "true") {
+        if (s === "true") {
             return true;
-        } else if (s == "false") {
+        } else if (s === "false") {
             return false;
-        } else {
-            return undefined;
         }
+        throw new Error("Unrecognized Boolean value '" + s + "'");
     }
 
     get_value_as_string(t: number): string {
@@ -407,7 +404,7 @@ export class ParserTextRaw {
     }
 
     get_value_as_uint8array(t: number): Uint8Array {
-        let bytes = [];
+        let bytes: number[] = [];
         switch (t) {
             case T_CLOB2:
                 for (let index = this._start; index < this._end; index++) {
@@ -450,7 +447,7 @@ export class ParserTextRaw {
         return Uint8Array.from(bytes);
     }
 
-    next(): number {
+    next(): number | undefined {
         this.clearFieldName();
         this._ann = [];
         if (this._value_type === ERROR) {
@@ -461,7 +458,7 @@ export class ParserTextRaw {
         let t: number;
         if (this._curr === ERROR) {
             this._value.push(ERROR);
-            t = undefined;
+            return undefined;
         } else {
             t = this._curr;
         }
@@ -581,7 +578,7 @@ export class ParserTextRaw {
 
     private _load_field_name() {
         this._fieldnameType = this._value_pop();
-        let s = this.get_value_as_string(this._fieldnameType);
+        let s = this.get_value_as_string(this._fieldnameType!);
 
         switch (this._fieldnameType) {
             case T_IDENTIFIER:
@@ -717,7 +714,6 @@ export class ParserTextRaw {
     }
 
     private _read_value_helper_letter(ch1: number, accept_operator_symbols: boolean, calling_op: ReadValueHelper) {
-        let tempNullStart = this._start;
         this._read_symbol();
         let type = this._value_pop();
         if (type != T_IDENTIFIER) throw new Error("Expecting symbol here.");
@@ -1129,11 +1125,6 @@ export class ParserTextRaw {
         this._value_push(T_BLOB);
     }
 
-    private _read_comma(): void {
-        let ch = this._read_after_whitespace(true);
-        if (ch != CH_CM) this._error("expected ','");
-    }
-
     private _read_close_double_brace(): void {
         let ch = this._read_after_whitespace(false);
         if (ch != CH_CC || this._read() != CH_CC) {
@@ -1197,7 +1188,6 @@ export class ParserTextRaw {
 
     private _skip_triple_quote_gap(entryIndex: number, end: number, acceptComments: boolean): number {
         let tempIndex: number = entryIndex + 3;
-        let ch: number = this._in.valueAt(tempIndex);
         tempIndex = this.indexWhiteSpace(tempIndex, acceptComments);
         if (tempIndex + 2 <= end && this.verifyTriple(tempIndex)) {//index === ' index + 1 === ' index + 2 === ' and not at the end of the value
             return tempIndex + 4;//indexes us past the triple quote we just found
@@ -1210,8 +1200,7 @@ export class ParserTextRaw {
         // actually converts the escape sequence to a byte
         let ch;
         if (ii + 1 >= end) {
-            this._error("invalid escape sequence");
-            return;
+            throw new Error("invalid escape sequence");
         }
         ch = this._in.valueAt(ii + 1);
         this._esc_len = 1;
@@ -1251,8 +1240,7 @@ export class ParserTextRaw {
                 return IonText.ESCAPED_NEWLINE;
             case ESC_x: // = CH_x, //  values['x'] = ESCAPE_HEX; //    any  \xHH  2-digit hexadecimal unicode character equivalent to \ u00HH
                 if (ii + 3 >= end) {
-                    this._error("invalid escape sequence");
-                    return;
+                    throw new Error("invalid escape sequence");
                 }
                 ch = this._get_N_hexdigits(ii + 2, ii + 4);
                 this._esc_len = 3;
@@ -1291,30 +1279,27 @@ export class ParserTextRaw {
                 return IonText.ESCAPED_NEWLINE;
             case ESC_x: // = CH_x, //  values['x'] = ESCAPE_HEX; //    any  \xHH  2-digit hexadecimal unicode character equivalent to \ u00HH
                 if (ii + 3 >= end) {
-                    this._error("invalid escape sequence");
-                    return;
+                    throw new Error("invalid escape sequence");
                 }
                 ch = this._get_N_hexdigits(ii + 2, ii + 4);
                 this._esc_len = 3;
                 break;
             case ESC_u: // = 117, //  values['u'] = ESCAPE_LITTLE_U; //    any  \ uHHHH  4-digit hexadecimal unicode character
                 if (ii + 5 >= end) {
-                    this._error("invalid escape sequence");
-                    return;
+                    throw new Error("invalid escape sequence");
                 }
                 ch = this._get_N_hexdigits(ii + 2, ii + 6);
                 this._esc_len = 5;
                 break;
             case ESC_U: // = 85, //  values['U'] = ESCAPE_BIG_U; //    any  \ UHHHHHHHH  8-digit hexa
                 if (ii + 9 >= end) {
-                    this._error("invalid escape sequence");
-                    return;
+                    throw new Error("invalid escape sequence");
                 }
                 ch = this._get_N_hexdigits(ii + 2, ii + 10);
                 this._esc_len = 9;
                 break;
             default:
-                this._error("unexpected character after escape slash");
+                throw new Error("unexpected character after escape slash");
         }
         return ch;
     }
@@ -1443,14 +1428,8 @@ export class ParserTextRaw {
         return ch;
     }
 
-    private _peek_after_whitespace(recognize_comments: boolean): number {
-        let ch = this._read_after_whitespace(recognize_comments);
-        this._unread(ch);
-        return ch;
-    }
-
     private _peek_4_digits(ch1: number): number {
-        let ii, ch, is_digits = true, chars = [];
+        let ii: number, ch: number, is_digits = true, chars: number[] = [];
         if (!IonText.is_digit(ch1)) return ERROR;
         for (ii = 0; ii < 3; ii++) {
             ch = this._read();
@@ -1462,7 +1441,7 @@ export class ParserTextRaw {
         }
         ch = (is_digits && ii == 3) ? this._peek() : ERROR;
         while (chars.length > 0) {
-            this._unread(chars.pop());
+            this._unread(chars.pop()!);
         }
         return ch;
     }
@@ -1489,7 +1468,7 @@ export class ParserTextRaw {
         while (n--) {
             if (!IonText.is_digit(ch = this._read())) throw new Error("Expected digit, got: " + String.fromCharCode(ch));
         }
-        return ch;
+        return ch!;
     }
 
     private _readPastNDigits(n: number): number {//This is clearly bugged it reads n + 1 digits.
@@ -1517,29 +1496,6 @@ export class ParserTextRaw {
             ii++;
         }
         return ch;
-    }
-
-    private _read_hours_and_minutes(ch: number): number {
-        if (!IonText.is_digit(ch)) return ERROR;
-        ch = this._readPastNDigits(1);   // rest of hours
-        if (ch == CH_CL) {
-            ch = this._readPastNDigits(2); // minutes
-        } else {
-            ch = ERROR; // if there are hours you have to include minutes
-        }
-        return ch;
-    }
-
-    private _check_for_keywords(): void {
-        let len, s, v = this._value_pop();
-        if (v == T_IDENTIFIER) {
-            len = this._end - this._start;
-            if (len >= 3 && len <= 5) {
-                s = this.get_value_as_string(v);
-                v = get_keyword_type(s);
-            }
-        }
-        this._value_push(v);
     }
 
     private _error(msg: string): void {

--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -49,7 +49,7 @@ export class SharedSymbolTable {
         return this._version;
     }
 
-    getSymbolText(symbolId: number): string {
+    getSymbolText(symbolId: number): string | undefined {
         if (symbolId < 0) {
             throw new Error(
                 `Index ${symbolId} is out of bounds for the SharedSymbolTable name=${this.name}, version=${this.version}`
@@ -61,11 +61,7 @@ export class SharedSymbolTable {
         return this._symbols[symbolId];
     }
 
-    getSymbolId(text: string): number {
-        let symbolId = this._idsByText[text];
-        if (symbolId === undefined) {
-            return null;
-        }
-        return symbolId;
+    getSymbolId(text: string): number | undefined {
+        return this._idsByText[text];
     }
 }

--- a/src/IonSpan.ts
+++ b/src/IonSpan.ts
@@ -149,7 +149,7 @@ export class StringSpan extends Span {
     }
 
     peek(): number {
-        return this.valueAt(this._pos);
+        return this.valueAt(this._pos)!;
     }
 
     skip(dist: number): void {
@@ -259,7 +259,7 @@ export class BinarySpan extends Span {
     }
 
     valueAt(ii: number): number {
-        if (ii < this._start || ii >= this._limit) return undefined;
+        if (ii < this._start || ii >= this._limit) return EOF;
         return (this._src[ii]);
     }
 

--- a/src/IonSubstituteSymbolTable.ts
+++ b/src/IonSubstituteSymbolTable.ts
@@ -27,11 +27,11 @@ export class SubstituteSymbolTable extends SharedSymbolTable {
                 "Cannot instantiate a SubstituteSymbolTable with a negative length. (" + length + ")"
             );
         }
-        super("_substitute", undefined, []);
+        super("_substitute", -1, []);
         this._numberOfSymbols = length;
     }
 
-    getSymbolText(symbolId: number): string {
+    getSymbolText(symbolId: number): string | undefined {
         if (symbolId < 0) {
             throw new Error(
                 `Index ${symbolId} is out of bounds for the SharedSymbolTable name=${this.name}, version=${this.version}`
@@ -40,7 +40,7 @@ export class SubstituteSymbolTable extends SharedSymbolTable {
         return undefined;
     }
 
-    getSymbolId(text: string): number {
+    getSymbolId(text: string): number | undefined {
         return undefined;
     }
 }

--- a/src/IonSymbols.ts
+++ b/src/IonSymbols.ts
@@ -33,9 +33,9 @@ function load_imports(reader: Reader, catalog: Catalog): Import {
     while (reader.next()) {
         reader.stepIn(); // into the struct of 1 import
 
-        let name: string;
-        let version: number = 1;
-        let maxId: number;
+        let name: string | null = null;
+        let version: number | null = 1;
+        let maxId: number | null = null;
 
         while (reader.next()) {
             switch (reader.fieldName()) {
@@ -50,12 +50,12 @@ function load_imports(reader: Reader, catalog: Catalog): Import {
             }
         }
 
-        if (version < 1) {
+        if (version === null || version < 1) {
             version = 1;
         }
 
         if (name && name !== "$ion") {
-            let symbolTable: SharedSymbolTable = catalog.getVersion(name, version);
+            let symbolTable: SharedSymbolTable | null = catalog.getVersion(name, version!);
             if (!symbolTable) {
                 if (maxId === undefined) {
                     throw new Error(`No exact match found when trying to import symbol table ${name} version ${version}`);
@@ -65,10 +65,10 @@ function load_imports(reader: Reader, catalog: Catalog): Import {
             }
 
             if (!symbolTable) {
-                symbolTable = new SubstituteSymbolTable(maxId);
+                symbolTable = new SubstituteSymbolTable(maxId!);
             }
 
-            import_ = new Import(import_, symbolTable, maxId);
+            import_ = new Import(import_, symbolTable!, maxId);
         }
 
         reader.stepOut(); // out of one import struct
@@ -78,8 +78,8 @@ function load_imports(reader: Reader, catalog: Catalog): Import {
     return import_;
 }
 
-function load_symbols(reader: Reader): string[] {
-    let symbols: string[] = [];
+function load_symbols(reader: Reader): (string | null)[] {
+    let symbols: (string | null)[] = [];
 
     reader.stepIn();
     while (reader.next()) {
@@ -97,9 +97,8 @@ function load_symbols(reader: Reader): string[] {
  * @param reader The Ion {Reader} over the local symbol table in its serialized form.
  */
 export function makeSymbolTable(catalog: Catalog, reader: Reader): LocalSymbolTable {
-    let import_: Import;
-    let symbols: string[];
-    let maxId: number;
+    let import_: Import | null = null;
+    let symbols: (string | null)[] = [];
     let foundSymbols: boolean = false;
     let foundImports: boolean = false;
 

--- a/src/IonText.ts
+++ b/src/IonText.ts
@@ -90,7 +90,7 @@ export function needsEscape(c: number): boolean {
 }
 
 export function escapeString(s: string, pos: number): string {
-    let fixes = [], c, old_len, new_len, ii, s2;
+    let fixes: number[][] = [], c, ii, s2;
     while (pos >= 0) {
         c = s.charCodeAt(pos);
         if (!needsEscape(c)) break;

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -45,9 +45,9 @@ export enum State {
 export class Context {
     state: State;
     clean: boolean;
-    containerType: IonType;
+    containerType: IonType | null;
 
-    constructor(myType: IonType) {
+    constructor(myType: IonType | null) {
         this.state = myType === IonTypes.STRUCT ? State.STRUCT_FIELD : State.VALUE;
         this.clean = true;
         this.containerType = myType;
@@ -60,7 +60,7 @@ export class TextWriter extends AbstractWriter {
 
     constructor(protected readonly writeable: Writeable) {
         super();
-        this.containerContext = [new Context(undefined)];
+        this.containerContext = [new Context(null)];
     }
 
     get isTopLevel(): boolean {
@@ -257,7 +257,9 @@ export class TextWriter extends AbstractWriter {
 
     stepIn(type: IonType): void {
         if (this.currentContainer.state === State.STRUCT_FIELD) {
-            throw new Error(`Started writing a ${this.currentContainer.containerType.name} inside a struct without writing the field name first. Call writeFieldName(string) with the desired name before calling stepIn(${this.currentContainer.containerType.name}).`);
+            throw new Error(`Started writing a ${this.currentContainer.containerType!.name} inside a struct"
+                + " without writing the field name first. Call writeFieldName(string) with the desired name"
+                + " before calling stepIn(${this.currentContainer.containerType!.name}).`);
         }
         switch (type) {
             case IonTypes.LIST:

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -30,7 +30,7 @@ export enum TimestampPrecision {
  */
 export class Timestamp {
     private static _MIN_SECONDS = Decimal.ZERO;
-    private static _MAX_SECONDS = Decimal.parse('60');
+    private static _MAX_SECONDS = Decimal.parse('60')!;
     private static _MIN_MINUTE = 0;
     private static _MAX_MINUTE = 59;
     private static _MIN_HOUR = 0;
@@ -72,11 +72,11 @@ export class Timestamp {
      */
     constructor(localOffset: number,
                 year: number,
-                month?: number,
-                day?: number,
-                hour?: number,
-                minutes?: number,
-                seconds?: number | Decimal) {
+                month: number | null = null,
+                day: number | null = null,
+                hour: number | null = null,
+                minutes: number | null = null,
+                seconds: number | Decimal | null = null) {
 
         this._localOffset = localOffset;
         this._year = year;
@@ -95,7 +95,9 @@ export class Timestamp {
             }
             this._secondsDecimal = new Decimal(seconds, 0);
         } else {
-            this._secondsDecimal = seconds;
+            if (seconds !== null) {
+                this._secondsDecimal = seconds;
+            }
         }
         if (this._secondsDecimal === null || this._secondsDecimal === undefined) {
             this._secondsDecimal = Decimal.ZERO;
@@ -137,7 +139,7 @@ export class Timestamp {
      *
      * @see https://amzn.github.io/ion-docs/docs/spec.html#timestamp
      */
-    static parse(str: string): Timestamp {
+    static parse(str: string): Timestamp | null {
         return _TimestampParser._parse(str);
     }
 
@@ -200,9 +202,9 @@ export class Timestamp {
         let secondsDecimal: Decimal;
         if (fractionalSeconds != null) {
             let [_, fractionStr] = Timestamp._splitSecondsDecimal(fractionalSeconds);
-            secondsDecimal = Decimal.parse(date.getUTCSeconds() + '.' + fractionStr);
+            secondsDecimal = Decimal.parse(date.getUTCSeconds() + '.' + fractionStr)!;
         } else {
-            secondsDecimal = Decimal.parse(date.getUTCSeconds() + '.' + date.getUTCMilliseconds());
+            secondsDecimal = Decimal.parse(date.getUTCSeconds() + '.' + date.getUTCMilliseconds())!;
         }
 
         switch (precision) {
@@ -252,13 +254,13 @@ export class Timestamp {
      * of the instant in UTC.
      */
     getDate(): Date {
-        let ms = null;
+        let ms = 0;
         if (this._precision === TimestampPrecision.SECONDS) {
             ms = Math.round((this._secondsDecimal.numberValue() - this.getSecondsInt()) * 1000);
         }
 
         let msSinceEpoch = Date.UTC(
-            this._year, (this._precision === TimestampPrecision.YEAR ? 0 : this._month - 1), this._day,
+            this._year, (this._precision === TimestampPrecision.YEAR ? 0 : this._month! - 1), this._day,
             this._hour, this._minutes, this.getSecondsInt(), ms);
 
         msSinceEpoch = Timestamp._adjustMsSinceEpochIfNeeded(this._year, msSinceEpoch);
@@ -290,7 +292,7 @@ export class Timestamp {
         if (fractionStr === '') {
             return Decimal.ZERO;
         }
-        return Decimal.parse(fractionStr + 'd-' + fractionStr.length);
+        return Decimal.parse(fractionStr + 'd-' + fractionStr.length)!;
     }
 
     /**
@@ -347,12 +349,12 @@ export class Timestamp {
                     strVal += '.' + fractionStr;
                 }
             case TimestampPrecision.HOUR_AND_MINUTE:
-                strVal = this._lpadZeros(this._minutes, 2) + (strVal ? ":" + strVal : "");
-                strVal = this._lpadZeros(this._hour, 2) + (strVal ? ":" + strVal : "");
+                strVal = this._lpadZeros(this._minutes!, 2) + (strVal ? ":" + strVal : "");
+                strVal = this._lpadZeros(this._hour!, 2) + (strVal ? ":" + strVal : "");
             case TimestampPrecision.DAY:
-                strVal = this._lpadZeros(this._day, 2) + (strVal ? "T" + strVal : "T");
+                strVal = this._lpadZeros(this._day!, 2) + (strVal ? "T" + strVal : "T");
             case TimestampPrecision.MONTH:
-                strVal = this._lpadZeros(this._month, 2) + (strVal ? "-" + strVal : "");
+                strVal = this._lpadZeros(this._month!, 2) + (strVal ? "-" + strVal : "");
             case TimestampPrecision.YEAR:
                 if (this._precision === TimestampPrecision.YEAR) {
                     strVal = this._lpadZeros(this._year, 4) + "T";
@@ -385,15 +387,15 @@ export class Timestamp {
         this._checkFieldRange(fieldName, value, min, max);
     }
 
-    private _checkOptionalField(fieldName: string, value: number,
+    private _checkOptionalField(fieldName: string, value: number | null,
                                 min: number, max: number, defaultValue: number,
                                 precision: TimestampPrecision): number {
         if (!_hasValue(value)) {
             return defaultValue;
         }
-        this._checkFieldRange(fieldName, value, min, max);
+        this._checkFieldRange(fieldName, value!, min, max);
         this._precision = precision;
-        return value;
+        return value!;
     }
 
     private _checkFieldRange(fieldName: string, value: number | Decimal, min: number | Decimal, max: number | Decimal) {
@@ -467,8 +469,8 @@ interface _StateMap {
 class _TimeParserState {
     constructor(
         public readonly f: _States,
-        public readonly len: number,
-        public readonly t: _TransitionMap
+        public readonly len: number | null,
+        public readonly t: _TransitionMap | null = null
     ) {
     }
 }
@@ -498,7 +500,7 @@ class _TimestampParser {
                 "Z": _States.OFFSET_ZULU
             }),
         [_States.FRACTIONAL_SECONDS]:
-            new _TimeParserState(_States.FRACTIONAL_SECONDS, undefined, {
+            new _TimeParserState(_States.FRACTIONAL_SECONDS, null, {
                 "+": _States.OFFSET_POSITIVE,
                 "-": _States.OFFSET_NEGATIVE,
                 "Z": _States.OFFSET_ZULU
@@ -508,14 +510,14 @@ class _TimestampParser {
         [_States.OFFSET_NEGATIVE]:
             new _TimeParserState(_States.OFFSET_NEGATIVE, 2, {":": _States.OFFSET_MINUTES}),
         [_States.OFFSET_MINUTES]:
-            new _TimeParserState(_States.OFFSET_MINUTES, 2, undefined),
+            new _TimeParserState(_States.OFFSET_MINUTES, 2),
         [_States.OFFSET_ZULU]:
-            new _TimeParserState(_States.OFFSET_ZULU, 0, undefined),
+            new _TimeParserState(_States.OFFSET_ZULU, 0),
         [_States.OFFSET_UNKNOWN]:
-            new _TimeParserState(_States.OFFSET_UNKNOWN, 0, undefined),
+            new _TimeParserState(_States.OFFSET_UNKNOWN, 0),
     };
 
-    static _parse(str: string): Timestamp {
+    static _parse(str: string): Timestamp | null {
         if (str.length < 1) {
             return null;
         }
@@ -527,13 +529,13 @@ class _TimestampParser {
         }
 
         let offsetSign: number;
-        let offset: number;
+        let offset: number | null = null;
         let year: number = 0;
-        let month: number;
-        let day: number;
-        let hour: number;
-        let minute: number;
-        let secondsInt: number;
+        let month: number | null = null;
+        let day: number | null = null;
+        let hour: number | null = null;
+        let minute: number | null = null;
+        let secondsInt: number | null = null;
         let fractionStr = '';
 
         let pos: number = 0;
@@ -543,16 +545,17 @@ class _TimestampParser {
         let v: number;
 
         while (pos < limit) {
-            if (state.len === undefined) {
+            if (state.len === null) {
                 let digits: string = _TimestampParser._readUnknownDigits(str, pos);
                 if (digits.length === 0) throw new Error("No digits found at pos: " + pos);
                 v = parseInt(digits, 10);
                 pos += digits.length;
             } else if (state.len > 0) {
                 v = _TimestampParser._readDigits(str, pos, state.len);
-                if (v < 0) throw new Error("Non digit value found at pos " + pos);
+                if (v < 0) throw new Error("Non-digit value found at pos " + pos);
                 pos = pos + state.len;
             }
+            v = v!;
             switch (state.f) {
                 case _States.YEAR:
                     year = v;
@@ -584,7 +587,7 @@ class _TimestampParser {
                     offset = v * 60;
                     break;
                 case _States.OFFSET_MINUTES:
-                    offset += v;
+                    offset! += v;
                     if (v >= 60) throw new Error("Minute offset " + String(v) + " above maximum or equal to : 60");
                     break;
                 case _States.OFFSET_ZULU:
@@ -600,7 +603,7 @@ class _TimestampParser {
             if (pos >= limit) {
                 break;
             }
-            if (state.t !== undefined) {
+            if (state.t !== null) {
                 let c: string = String.fromCharCode(str.charCodeAt(pos));
                 state = _TimestampParser._timeParserStates[state.t[c]];
                 if (state === undefined) throw new Error("State was not set pos:" + pos);
@@ -612,18 +615,18 @@ class _TimestampParser {
             pos++;
         }
 
-        if (offset === undefined) {
-            if (minute !== undefined) {
+        if (offset === null) {
+            if (minute !== null) {
                 throw new Error('invalid timestamp, missing local offset: "' + str + '"');
             }
             offset = -0;
         } else {
-            offset = offsetSign * offset;
+            offset = offsetSign! * offset!;
         }
 
-        let seconds: Decimal;
+        let seconds: Decimal | undefined = undefined;
         if ((secondsInt !== undefined && secondsInt !== null) || fractionStr) {
-            seconds = Decimal.parse(secondsInt + '.' + (fractionStr ? fractionStr : ''));
+            seconds = Decimal.parse(secondsInt! + '.' + (fractionStr ? fractionStr : ''))!;
         }
         return new Timestamp(offset, year, month, day, hour, minute, seconds);
     }

--- a/test/IonBinaryTimestamp.ts
+++ b/test/IonBinaryTimestamp.ts
@@ -34,6 +34,6 @@ describe('Binary Timestamp', () => {
         let reader = ion.makeReader(writer.getBytes());
         reader.next();
         let timestampValue = reader.value();
-        assert.equal(timestamp.toString(), timestampValue.toString());
+        assert.equal(timestamp.toString(), timestampValue!.toString());
     });
 });

--- a/test/IonBinaryWriter.ts
+++ b/test/IonBinaryWriter.ts
@@ -16,10 +16,23 @@
 import {assert} from 'chai';
 import * as ion from '../src/IonTests';
 import JSBI from 'jsbi';
+import {Decimal, Writer} from "../src/IonTests";
 
 const ivm = [0xe0, 0x01, 0x00, 0xea];
 
-let writerTest = function (name, instructions, expected) {
+interface Test {
+    name: string;
+    instructions: (writer: Writer) => void;
+    expected: number[];
+    skip?: boolean;
+}
+interface BadTest {
+    name: string;
+    instructions: (writer: Writer) => void;
+    skip?: boolean;
+}
+
+let writerTest = function (name: string, instructions: (writer: Writer) => void, expected: number[]) {
     it(name, () => {
         let symbolTable = new ion.LocalSymbolTable(ion.getSystemSymbolTableImport());
         let writeable = new ion.Writeable();
@@ -31,7 +44,7 @@ let writerTest = function (name, instructions, expected) {
     });
 };
 
-let badWriterTest = function (name, instructions) {
+let badWriterTest = function (name: string, instructions: (writer: Writer) => void) {
     let test = () => {
         let symbolTable = new ion.LocalSymbolTable(ion.getSystemSymbolTableImport());
         let writeable = new ion.Writeable();
@@ -42,7 +55,7 @@ let badWriterTest = function (name, instructions) {
     it(name, () => assert.throws(test, Error));
 };
 
-let blobWriterTests = [
+let blobWriterTests: Test[] = [
     {
         name: "Writes blob",
         instructions: (writer) => writer.writeBlob(new Uint8Array([1, 2, 3])),
@@ -94,7 +107,7 @@ let blobWriterTests = [
     },
 ];
 
-let booleanWriterTests = [
+let booleanWriterTests: Test[] = [
     {
         name: "Writes boolean true",
         instructions: (writer) => writer.writeBoolean(true),
@@ -149,7 +162,7 @@ let booleanWriterTests = [
     },
 ];
 
-let clobWriterTests = [
+let clobWriterTests: Test[] = [
     {
         name: "Writes clob",
         instructions: (writer) => writer.writeClob(new Uint8Array([1, 2, 3])),
@@ -201,7 +214,7 @@ let clobWriterTests = [
     },
 ];
 
-let decimalWriterTests = [
+let decimalWriterTests: Test[] = [
     {
         name: "Writes null decimal by detecting null",
         instructions: (writer) => writer.writeDecimal(null),
@@ -265,7 +278,7 @@ let decimalWriterTests = [
     },
 ];
 
-let floatWriterTests = [
+let floatWriterTests: Test[] = [
     {
         name: "Writes null float by direct call",
         instructions: (writer) => writer.writeNull(ion.IonTypes.FLOAT),
@@ -345,7 +358,7 @@ let floatWriterTests = [
     },
 ];
 
-let intWriterTests = [
+let intWriterTests: Test[] = [
     {
         name: "Writes null int by detecting null",
         instructions: (writer) => writer.writeInt(null),
@@ -394,7 +407,7 @@ let intWriterTests = [
     },
 ];
 
-let listWriterTests = [
+let listWriterTests: Test[] = [
     {
         name: "Writes null list by direct call",
         instructions: (writer) => writer.writeNull(ion.IonTypes.LIST),
@@ -528,20 +541,15 @@ let listWriterTests = [
     },
 ];
 
-let nullWriterTests = [
+let nullWriterTests: Test[] = [
     {
         name: "Writes explicit null",
         instructions: (writer) => writer.writeNull(ion.IonTypes.NULL),
         expected: [0x0f]
     },
-    {
-        name: "Writes implicit null",
-        instructions: (writer) => writer.writeNull(),
-        expected: [0x0f]
-    },
 ];
 
-let sexpWriterTests = [
+let sexpWriterTests: Test[] = [
     {
         name: "Writes null sexp by direct call",
         instructions: (writer) => writer.writeNull(ion.IonTypes.SEXP),
@@ -584,7 +592,7 @@ let sexpWriterTests = [
     },
 ];
 
-let stringWriterTests = [
+let stringWriterTests: Test[] = [
     {
         name: "Writes null string by detecting null",
         instructions: (writer) => {
@@ -634,7 +642,7 @@ let stringWriterTests = [
     },
 ];
 
-let structWriterTests = [
+let structWriterTests: Test[] = [
     {
         name: "Writes null struct by direct call",
         instructions: (writer) => {
@@ -697,7 +705,7 @@ let structWriterTests = [
             writer.writeFieldName('c');
             writer.writeClob(ion.encodeUtf8('bar'));
             writer.writeFieldName('d');
-            writer.writeDecimal("123.456");
+            writer.writeDecimal(Decimal.parse("123.456"));
             writer.writeFieldName('f');
             writer.writeFloat32(8.125);
             writer.writeFieldName('f');
@@ -831,7 +839,7 @@ let structWriterTests = [
     },
 ];
 
-let symbolWriterTests = [
+let symbolWriterTests: Test[] = [
     {
         name: "Writes null symbol by detecting null",
         instructions: (writer) => {
@@ -874,7 +882,7 @@ let symbolWriterTests = [
     },
 ];
 
-let timestampWriterTests = [
+let timestampWriterTests: Test[] = [
     {
         name: "Writes null timestamp by detecting null",
         instructions: (writer) => {
@@ -1008,7 +1016,7 @@ let timestampWriterTests = [
     },
 ];
 
-let badWriterTests = [
+let badWriterTests: BadTest[] = [
     {
         name: "Cannot step into struct with missing field value",
         instructions: (writer) => {
@@ -1059,7 +1067,7 @@ let badWriterTests = [
     },
 ];
 
-function runWriterTests(tests) {
+function runWriterTests(tests: Test[]) {
     tests.forEach(({name, instructions, expected, skip}) => {
         if (skip) {
             it.skip(name, () => {});
@@ -1069,7 +1077,7 @@ function runWriterTests(tests) {
     });
 }
 
-function runBadWriterTests(tests) {
+function runBadWriterTests(tests: BadTest[]) {
     tests.forEach(({name, instructions, skip}) => {
         if (skip) {
             it.skip(name, () => {});

--- a/test/IonCatalog.ts
+++ b/test/IonCatalog.ts
@@ -54,7 +54,8 @@ describe('Catalog', () => {
         catalog.add(version3);
         catalog.add(version4);
         let match = catalog.getTable('foo');
-        assert.strictEqual(4, match.version);
+        assert.isNotNull(match);
+        assert.strictEqual(4, match!.version);
     });
 
     it('Find latest version returns null if no version exists', () => {

--- a/test/IonLocalSymbolTable.ts
+++ b/test/IonLocalSymbolTable.ts
@@ -15,6 +15,7 @@
 
 import {assert} from 'chai';
 import * as ion from '../src/IonTests';
+import {LocalSymbolTable} from "../src/IonTests";
 
 let defaultCatalog = function () {
     let catalog = new ion.Catalog();
@@ -24,7 +25,7 @@ let defaultCatalog = function () {
 };
 
 
-let assertSystemSymbols = function (symbolTable) {
+let assertSystemSymbols = function (symbolTable: LocalSymbolTable) {
     assert.equal(symbolTable.getSymbolId('$ion'), 1);
     assert.equal(symbolTable.getSymbolId('$ion_1_0'), 2);
     assert.equal(symbolTable.getSymbolId('$ion_symbol_table'), 3);
@@ -45,8 +46,8 @@ describe('Local symbol table', () => {
 
     it('Imports are added in order', () => {
         let catalog = defaultCatalog();
-        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1));
-        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1));
+        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1)!);
+        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1)!);
         let symbolTable = new ion.LocalSymbolTable(import2);
 
         assert.isDefined(symbolTable.getSymbolText(13));
@@ -60,8 +61,8 @@ describe('Local symbol table', () => {
 
     it('Local symbols are added last', () => {
         let catalog = defaultCatalog();
-        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1));
-        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1));
+        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1)!);
+        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1)!);
         let symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
         assertSystemSymbols(symbolTable);
@@ -76,8 +77,8 @@ describe('Local symbol table', () => {
 
     it('MaxId less than symbol table length restricts imports', () => {
         let catalog = defaultCatalog();
-        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1), 1);
-        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1), 1);
+        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1)!, 1);
+        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1)!, 1);
         let symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
         assert.isDefined(symbolTable.getSymbolText(13));
@@ -94,8 +95,8 @@ describe('Local symbol table', () => {
 
     it('Maxid greater than symbol table length extends imports', () => {
         let catalog = defaultCatalog();
-        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1), 3);
-        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1), 3);
+        let import1 = new ion.Import(ion.getSystemSymbolTableImport(), catalog.getVersion('foo', 1)!, 3);
+        let import2 = new ion.Import(import1, catalog.getVersion('bar', 1)!, 3);
         let symbolTable = new ion.LocalSymbolTable(import2, ['e', 'f']);
 
         assert.isDefined(symbolTable.getSymbolText(17));

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -24,26 +24,26 @@ import SignAndMagnitudeInt from "../src/SignAndMagnitudeInt";
  */
 
 // Returns the largest unsigned integer value that can be stored in `numberOfBits` bits.
-let maxValueForBits = function (numberOfBits) {
+let maxValueForBits = function (numberOfBits: number) {
     return Math.pow(2, numberOfBits) - 1;
 };
 
 // Returns the largest unsigned integer value that can be stored in `numberOfBytes` bytes.
-let maxValueForBytes = function (numberOfBytes) {
+let maxValueForBytes = function (numberOfBytes: number) {
     return maxValueForBits(numberOfBytes * 8);
 };
 
 // Returns an array containing `numberOfBytes` bytes with value of 0xFF.
-let maxValueByteArray = function (numberOfBytes) {
-    let data = [];
+let maxValueByteArray = function (numberOfBytes: number) {
+    let data: number[] = [];
     for (let m = 0; m < numberOfBytes; m++) {
         data.push(0xFF);
     }
     return data;
 };
 
-let unsignedIntBytesMatchValue = (bytes,
-                                  expected,
+let unsignedIntBytesMatchValue = (bytes: number[],
+                                  expected: number,
                                   readFrom: (input: ion.BinarySpan, numberOfBytes: number) => any =
                                       ion.ParserBinaryRaw._readUnsignedIntAsBigIntFrom) => {
     let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
@@ -130,7 +130,7 @@ describe('Reading unsigned ints', () => {
  * Spec: http://amzn.github.io/ion-docs/docs/binary.html#uint-and-int-fields
  */
 
-let signedIntBytesMatch = function (bytes, expected: SignAndMagnitudeInt) {
+let signedIntBytesMatch = function (bytes: number[], expected: SignAndMagnitudeInt) {
     let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
     let actual = ion.ParserBinaryRaw._readSignedIntFrom(binarySpan, bytes.length);
     assert.isTrue(actual.equals(expected));
@@ -174,7 +174,7 @@ describe('Reading signed ints', () => {
  * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
  */
 
-let varUnsignedIntBytesMatchValue = function (bytes, expected) {
+let varUnsignedIntBytesMatchValue = function (bytes: number[], expected: number) {
     let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
     let actual = ion.ParserBinaryRaw._readVarUnsignedIntFrom(binarySpan);
     assert.equal(actual, expected);
@@ -227,7 +227,7 @@ describe('Reading variable unsigned ints', () => {
  * Spec: http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
  */
 
-let varSignedIntBytesMatchValue = function (bytes, expected) {
+let varSignedIntBytesMatchValue = function (bytes: number[], expected: number) {
     let binarySpan = new ion.BinarySpan(new Uint8Array(bytes));
     let actual = ion.ParserBinaryRaw._readVarSignedIntFrom(binarySpan);
     assert.equal(actual, expected)
@@ -293,7 +293,7 @@ describe('Reading variable signed ints', () => {
  * Spec: http://amzn.github.io/ion-docs/docs/binary.html#4-float
  */
 
-let serializeFloat = function (value, viewType, numberOfBytes) {
+let serializeFloat = function (value: number, viewType: Float32ArrayConstructor | Float64ArrayConstructor, numberOfBytes: number) {
     let buffer = new ArrayBuffer(numberOfBytes);
     let view = new viewType(buffer);
     view[0] = value;
@@ -302,18 +302,18 @@ let serializeFloat = function (value, viewType, numberOfBytes) {
     return bytes;
 };
 
-let serializeFloat32 = function (value) {
+let serializeFloat32 = function (value: number) {
     return serializeFloat(value, Float32Array, 4);
 };
 
-let serializeFloat64 = function (value) {
+let serializeFloat64 = function (value: number) {
     return serializeFloat(value, Float64Array, 8);
 };
 
-let floatBytesMatchValue = function (bytes, expected, comparison = (x, y) => assert.equal(x, y)) {
+let floatBytesMatchValue = function (bytes: Uint8Array, expected: number, comparison = (x: number, y: number) => assert.equal(x, y)) {
     let binarySpan = new ion.BinarySpan(bytes);
     let actual = ion.ParserBinaryRaw._readFloatFrom(binarySpan, binarySpan.getRemaining());
-    comparison(actual, expected);
+    comparison(actual!, expected);
 };
 
 let float32TestValues = [

--- a/test/IonReaderConsistency.ts
+++ b/test/IonReaderConsistency.ts
@@ -72,7 +72,7 @@ describe('IonReaderConsistency', () => {
                         reader.stepIn();
                         while (type = reader.next()) {
                             if (reader.fieldName() === 'quantity') {
-                                sum += reader.numberValue();
+                                sum += reader.numberValue()!;
                                 break;
                             }
                         }

--- a/test/IonTimestamp.ts
+++ b/test/IonTimestamp.ts
@@ -16,10 +16,20 @@
 import {assert} from 'chai';
 import * as ion from '../src/Ion';
 import * as util from '../src/util';
+import {TimestampPrecision} from "../src/Ion";
 
-function testParsing(str, precision, localOffset, year, month = null, day = null, hour = null, minutes = null, seconds = null): void {
+function testParsing(str: string,
+                     precision: TimestampPrecision,
+                     localOffset: number,
+                     year: number,
+                     month: number | null = null,
+                     day: number | null = null,
+                     hour: number | null = null,
+                     minutes: number | null = null,
+                     seconds: string | null = null): void {
+
     // verify Timestamp members are set as expected:
-    let ts = ion.Timestamp.parse(str);
+    let ts = ion.Timestamp.parse(str)!;
     assert.equal(ts.getPrecision(), precision, 'precision');
     assert.equal(ts.getLocalOffset(), localOffset, 'local offset');
     assert.equal(util._sign(ts.getLocalOffset()), util._sign(localOffset), 'local offset sign');
@@ -54,16 +64,16 @@ function testParsing(str, precision, localOffset, year, month = null, day = null
     assert.deepEqual(ts3, ts);
 }
 
-function testCompareTo(s1, s2, expected) {
-    let ts1 = ion.Timestamp.parse(s1);
-    let ts2 = ion.Timestamp.parse(s2);
+function testCompareTo(s1: string, s2: string, expected: number) {
+    let ts1 = ion.Timestamp.parse(s1)!;
+    let ts2 = ion.Timestamp.parse(s2)!;
     assert.equal(ts1.compareTo(ts2), expected);
     assert.equal(ts2.compareTo(ts1), -expected);
 }
 
-function testEquals(s1, s2, expected) {
-    let ts1 = ion.Timestamp.parse(s1);
-    let ts2 = ion.Timestamp.parse(s2);
+function testEquals(s1: string, s2: string, expected: boolean) {
+    let ts1 = ion.Timestamp.parse(s1)!;
+    let ts2 = ion.Timestamp.parse(s2)!;
     assert.equal(ts1.equals(ts2), expected);
 }
 
@@ -210,8 +220,8 @@ describe("Timestamp", () => {
         for (let timestamp1 of equivalentTimestamps) {
             for (let timestamp2 of equivalentTimestamps) {
                 it(timestamp1 + " is equivalent to " + timestamp2, () => {
-                    assert.equal(timestamp1.compareTo(timestamp2), 0);     // instant equivalence
-                    assert.equal(timestamp1.equals(timestamp2), timestamp1 === timestamp2);  // data model equivalence
+                    assert.equal(timestamp1!.compareTo(timestamp2!), 0);     // instant equivalence
+                    assert.equal(timestamp1!.equals(timestamp2!), timestamp1 === timestamp2);  // data model equivalence
                 });
             }
         }

--- a/test/IonWriterUndefinedParameters.ts
+++ b/test/IonWriterUndefinedParameters.ts
@@ -24,7 +24,7 @@ class NoopWriter implements Writer {
     addAnnotation(annotation: string): void { }
     close(): void { }
     depth(): number { return 0; }
-    getBytes(): Uint8Array { return undefined; }
+    getBytes(): Uint8Array { return new Uint8Array(); }
     setAnnotations(annotations: string[]): void { }
     stepIn(type: IonType): void { }
     stepOut(): void { }
@@ -63,19 +63,6 @@ describe('IonWriterUndefinedParameters', () => {
                 it(method + '(undefined) throws', function() {
                     assert.throws(() => writer[method](undefined));
                 });
-            });
-
-            it('writeFieldName(undefined) within a struct throws', function() {
-                writer.stepIn(IonTypes.STRUCT);
-                assert.throws(() => writer.writeFieldName(undefined));
-                writer.stepOut();
-            });
-
-            it("writeNull(undefined) doesn't throw", function() {
-                writer.writeNull(undefined);
-            });
-            it("writeNull(null) doesn't throw", function() {
-                writer.writeNull(null);
             });
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "sourceMap": true,
     // TODO enable this to have stricter checking
     "strict": false,
+    "strictNullChecks": true,
     "rootDir": "src",
     "outDir": "dist/es6/es6",
     "experimentalDecorators": true


### PR DESCRIPTION
Resolves #234 

* in `tsconfig.json`, sets `strictNullChecks` to `true`
* aligns method signatures with those of the implemented interface
* adds a number of not-null (!) assertions
* removes tests that can no longer compile (e.g., attempts to call `writeNull()` or `writeNull(undefined)`)
* removes logic that supported `writeDecimal('123.456')` in the binary writer
* does not attempt to remove `undefined` (to be done as part of #90 / #130)
* misc. cleanup when I noticed IDE suggestions, including:
  * addition of `readonly` to properties
  * removal of unused artifacts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
