### PR TITLE
Fixed unicode escape issue.

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -393,7 +393,11 @@ export class ParserTextRaw {
                     } else if (t === T_STRING3 && ch === CH_SQ && !isEscaped && this.verifyTriple(index)) {
                         index = this._skip_triple_quote_gap(index, this._end, /*acceptComments*/ true);
                     } else if (ch >= 0) {
-                        s += String.fromCharCode(ch);
+                        if (isEscaped) {
+                            s += String.fromCodePoint(ch);
+                        } else {
+                            s += String.fromCharCode(ch);
+                        }
                     }
                 }
                 break;

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -387,8 +387,6 @@ let equivsSkipList = toSkipList([
     'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
     'ion-tests/iontestdata/good/equivs/systemSymbolsAsAnnotations.ion',
     'ion-tests/iontestdata/good/equivs/textNewlines.ion',
-    'ion-tests/iontestdata/good/equivs/utf8/stringU0001D11E.ion',
-    'ion-tests/iontestdata/good/equivs/utf8/stringUtf8.ion',
 ]);
 
 let nonEquivsSkipList = toSkipList([
@@ -413,7 +411,6 @@ let nonEquivsSkipList = toSkipList([
     'good/symbolZero.ion', //no symboltoken support as of yet.
     'good/testfile12.ion',
     'good/non-equivs/nonNulls.ion',
-    'good/equivs/utf8/stringU0001D11E.ion',
     'good/equivs/structComments.ion',
     'good/equivs/sexps.ion',
     'good/equivs/lists.ion',


### PR DESCRIPTION
*Issue #, if available:* #165 

*Description of changes:*

When reading unicode [escapes](http://amzn.github.io/ion-docs/docs/spec.html#escapes) (e.g. `\U0001D11E`), the parser would sometimes treat code points as character codes, causing errors. This PR fixes that, removing the following skip list entries:

**Equivs**
* `utf8/stringU0001D11E.ion`
* `utf8/stringUtf8.ion`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
