### PR TITLE
fixes incorrect escape sequences within symbols, strings, and tripleq…

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -396,6 +396,10 @@ export class ParserTextRaw {
                         if (isEscaped) {
                             s += String.fromCodePoint(ch);
                         } else {
+                            if(t === T_STRING3 && ch === ESC_nl3 && this._in.valueAt(index + 1) === ESC_nl2) {
+                                ch = ESC_nl2;
+                                index++;
+                            }
                             s += String.fromCharCode(ch);
                         }
                     }
@@ -1245,7 +1249,7 @@ export class ParserTextRaw {
             case ESC_nl2:
                 return -1; // =  10, //  values['\n'] = ESCAPE_REMOVES_NEWLINE;  // slash-new line the new line eater
             case ESC_nl3: // =  13, //  values['\r'] = ESCAPE_REMOVES_NEWLINE2;  // slash-new line the new line eater
-                if (ii + 3 < end && this._in.valueAt(ii + 3) == CH_NL) {
+                if (ii + 2 < end && this._in.valueAt(ii + 2) == CH_NL) {
                     this._esc_len = 2;
                 }
                 return IonText.ESCAPED_NEWLINE;
@@ -1284,7 +1288,7 @@ export class ParserTextRaw {
             case ESC_fs:  return 47; // =  47, //  values['/']  = '/';     //    \u002F  \/  forward slash nothing  \NL  escaped NL expands to nothing
             case ESC_nl2: return -1; // =  10, //  values['\n'] = ESCAPE_REMOVES_NEWLINE;  // slash-new line the new line eater
             case ESC_nl3: // =  13, //  values['\r'] = ESCAPE_REMOVES_NEWLINE2;  // slash-new line the new line eater
-                if (ii + 3 < end && this._in.valueAt(ii + 3) == CH_NL) {
+                if (ii + 2 < end && this._in.valueAt(ii + 2) == CH_NL) {
                     this._esc_len = 2;
                 }
                 return IonText.ESCAPED_NEWLINE;

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -225,7 +225,12 @@ class IonTextReaderTests {
         IonTextReaderTests.first_value_equal("'''abc\\'''' '''''' taco", "abc'");
         IonTextReaderTests.first_value_equal('"abc\\""', 'abc"');
         IonTextReaderTests.first_value_equal('"abc\\"" taco', 'abc"');
+        IonTextReaderTests.first_value_equal("'\\\n'", "");
+        IonTextReaderTests.first_value_equal("'''short1\\\n'''\n\n'''\\\nmulti-line string\nwith embedded\\nnew line\ncharacters\\\n'''", "short1multi-line string\nwith embedded\nnew line\ncharacters");
+
     };
+
+
 
     @test "text IVM"() {
         let textReader = ion.makeReader("");


### PR DESCRIPTION
…uoted strings.

*Issue #, if available:*
Fixes #515
*Description of changes:*
-correctly adjusts indexes by 2 instead of 3 within the text parser when escaped \r\n pairs are found
-removes \r from unescaped \r\n pairs within triple quotes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.