### PR TITLE
writeValues() works when writers/readers at depth>0

### DIFF
--- a/src/IonBinaryWriter.ts
+++ b/src/IonBinaryWriter.ts
@@ -320,6 +320,10 @@ export class BinaryWriter extends AbstractWriter {
         }
     }
 
+    protected _isInStruct(): boolean {
+        return this.getCurrentContainer() instanceof StructNode;
+    }
+
     writeFieldName(fieldName: string): void {
         _assertDefined(fieldName);
         if (this.state !== States.STRUCT_FIELD) {

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -174,6 +174,10 @@ export class TextWriter extends AbstractWriter {
         });
     }
 
+    protected _isInStruct(): boolean {
+        return this.currentContainer.containerType === IonTypes.STRUCT;
+    }
+
     /*
     Another way to handle this is simply to store the field name here, and actually write it in _serializeValue.
     This is how the other implementations I know of handle it.

--- a/src/IonWriter.ts
+++ b/src/IonWriter.ts
@@ -101,15 +101,27 @@ export interface Writer {
     writeClob(value: Uint8Array | null): void;
 
     /**
-     * Writes a reader's current value.  If there's no current value, this method
-     * does nothing.
+     * Writes a reader's current value.
+     *
+     * If there's no current value, this method does nothing.
+     * If the current value is a container, this method will stepIn() recursively,
+     * writing each nested value that it encounters.
+     *
+     * It is illegal to call this method if this Writer is positioned within a Struct
+     * while the Reader is not.
      */
     writeValue(reader: Reader): void;
 
     /**
      * Writes a reader's current value and all following values until the end
-     * of the current container.  If there's no current value then this method
-     * calls {@link next()} to get started.
+     * of the current container.
+     *
+     * If there's no current value then this method calls {@link next()} to get started.
+     * This method will stepIn() to containers recursively, writing each nested value that it
+     * encounters.
+     *
+     * It is illegal to call this method if this Writer is positioned within a Struct
+     * while the Reader is not.
      */
     writeValues(reader: Reader): void;
 

--- a/test/IonAnnotations.ts
+++ b/test/IonAnnotations.ts
@@ -71,8 +71,7 @@ describe('Annotations', () => {
         reader.stepIn();
         reader.next();
 
-        //FIXME: https://github.com/amzn/ion-js/issues/454
-        writer['_writeValues'](reader, 1);
+        writer.writeValues(reader);
 
         reader.stepOut();
 


### PR DESCRIPTION
*Issue #, if available:* #454 

*Description of changes:*

This PR makes it legal to call `IonWriter#writeValues()` when the `Writer` and `Reader` are at depths greater than zero. It does not change the public-facing API.

* Added a protected abstract method `_isInStruct: boolean` to `AbstractWriter`. Subclasses (`BinaryWriter`, `TextWriter`) each provide their own implementations.
* Added docs to the `IonWriter` interface explaining the behavior of `IonWriter#writeValues()`.
* Removed `IonAnnotationsTest`'s sneaky call to `writer['_writeValues']`.
* Added unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
