### PR TITLE
JSBI to Number conversions lose precision instead of clamping.

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -446,7 +446,7 @@ export class ParserBinaryRaw {
                 }
                 this.load_value();
                 let bigInt: JSBI = this._curr!;
-                return JsbiSupport.clampToSafeIntegerRange(bigInt);
+                return JSBI.toNumber(bigInt);
             case IonBinary.TB_FLOAT:
                 if (this.isNull()) {
                     return null;

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -311,7 +311,7 @@ export class ParserTextRaw {
         switch (this._curr) {
             case T_INT:
             case T_HEXINT:
-                return JsbiSupport.clampToSafeIntegerRange(JsbiSupport.bigIntFromString(s));
+                return JSBI.toNumber(JsbiSupport.bigIntFromString(s));
             case T_FLOAT:
                 return Number(s);
             case T_FLOAT_SPECIAL:


### PR DESCRIPTION
*Issue #, if available:* #353 

*Description of changes:*

When a `Reader` is positioned over an integer that is too large to safely fit in a JS `Number`, calling `reader.numberValue()` will "[clamp](https://en.wikipedia.org/wiki/Clamping_(graphics))" the integer to [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). This behavior is often surprising, as that value appears to be random to the user.

This PR modifies the text and binary `Reader`s to return a JS `Number` that approximates the one being read in as closely as possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
