### PR TITLE
load() and DOM APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "source-map-support": "^0.5.13",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.1",
-    "typedoc": "github:zslayton/typedoc#7f58d79b0a445434e487d6b61bb14933fbe0c329",
+    "typedoc": "^0.16.10",
     "typescript": "^3.6.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "source-map-support": "^0.5.13",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.1",
-    "typedoc": "^0.15.0",
+    "typedoc": "github:zslayton/typedoc#7f58d79b0a445434e487d6b61bb14933fbe0c329",
     "typescript": "^3.6.2"
   },
   "dependencies": {

--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -99,3 +99,9 @@ export {SharedSymbolTable} from "./IonSharedSymbolTable";
 export {TimestampPrecision, Timestamp} from "./IonTimestamp";
 export {toBase64} from "./IonText";
 export {decodeUtf8} from "./IonUnicode";
+
+import * as dom from "./dom";
+export {dom};
+
+// Re-export dom convenience methods for easy access via 'ion'
+export {load, loadAll} from "./dom";

--- a/src/dom/Blob.ts
+++ b/src/dom/Blob.ts
@@ -11,7 +11,7 @@ export class Blob extends DomValue(Uint8Array, IonTypes.BLOB) {
     /**
      * Constructor.
      * @param data          Raw, unsigned bytes to represent as a blob.
-     * @param annotations   An optional array of strings to associate with `bytes`.
+     * @param annotations   An optional array of strings to associate with `data`.
      */
     constructor(data: Uint8Array, annotations: string[] = []) {
         super(data);

--- a/src/dom/Blob.ts
+++ b/src/dom/Blob.ts
@@ -1,0 +1,24 @@
+import {DomValue} from "./DomValue";
+import {IonTypes} from "../Ion";
+
+/**
+ * Represents a blob[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#blob
+ */
+export class Blob extends DomValue(Uint8Array, IonTypes.BLOB) {
+
+    /**
+     * Constructor.
+     * @param data          Raw, unsigned bytes to represent as a blob.
+     * @param annotations   An optional array of strings to associate with `bytes`.
+     */
+    constructor(data: Uint8Array, annotations: string[] = []) {
+        super(data);
+        this._setAnnotations(annotations);
+    }
+
+    uInt8ArrayValue(): Uint8Array {
+        return this;
+    }
+}

--- a/src/dom/Boolean.ts
+++ b/src/dom/Boolean.ts
@@ -22,7 +22,6 @@ import {DomValue} from "./DomValue";
  *          // this code WILL be executed
  *      }
  *
- *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#bool
  * [2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
  */

--- a/src/dom/Boolean.ts
+++ b/src/dom/Boolean.ts
@@ -1,0 +1,44 @@
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents a boolean[1] value in an Ion stream.
+ *
+ * Because this class extends Javascript's (big-B) Boolean data type, it is subject to the same
+ * surprising behavior when used for control flow.
+ *
+ * From the Mozilla Developer Network documentation[2]:
+ *
+ * > Any object of which the value is not undefined or null, including a Boolean object
+ *   whose value is false, evaluates to true when passed to a conditional statement.
+ *
+ *      var b = false;
+ *      if (b) {
+ *          // this code will NOT be executed
+ *      }
+ *
+ *      b = new Boolean(false);
+ *      if (b) {
+ *          // this code WILL be executed
+ *      }
+ *
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#bool
+ * [2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
+ */
+export class Boolean extends DomValue(global.Boolean, IonTypes.BOOL) {
+
+    /**
+     * Constructor.
+     * @param value         The boolean value of the new instance.
+     * @param annotations   An optional array of strings to associate with `value`.
+     */
+    constructor(value: boolean, annotations: string[] = []) {
+        super(value);
+        this._setAnnotations(annotations);
+    }
+
+    booleanValue(): boolean {
+        return this.valueOf() as boolean;
+    }
+}

--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -12,12 +12,12 @@ export class Clob extends DomValue(Uint8Array, IonTypes.CLOB) {
      * @param bytes         Raw, unsigned bytes to represent as a clob.
      * @param annotations   An optional array of strings to associate with `bytes`.
      */
-    constructor(protected readonly bytes: Uint8Array, annotations: string[] = []) {
+    constructor(bytes: Uint8Array, annotations: string[] = []) {
         super(bytes);
         this._setAnnotations(annotations);
     }
 
     uInt8ArrayValue(): Uint8Array {
-        return this.bytes;
+        return this;
     }
 }

--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -1,0 +1,23 @@
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents a clob[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#clob
+ */
+export class Clob extends DomValue(Uint8Array, IonTypes.CLOB) {
+    /**
+     * Constructor.
+     * @param bytes         Raw, unsigned bytes to represent as a clob.
+     * @param annotations   An optional array of strings to associate with `bytes`.
+     */
+    constructor(protected readonly bytes: Uint8Array, annotations: string[] = []) {
+        super(bytes);
+        this._setAnnotations(annotations);
+    }
+
+    uInt8ArrayValue(): Uint8Array {
+        return this.bytes;
+    }
+}

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -1,0 +1,43 @@
+import {DomValue} from "./DomValue";
+import {IonTypes} from "../Ion";
+import * as ion from "../Ion";
+
+/**
+ * Represents a decimal[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#decimal
+ */
+export class Decimal extends DomValue(Number, IonTypes.DECIMAL) {
+    private readonly _decimalValue: ion.Decimal;
+    private readonly _numberValue: number;
+
+    /**
+     * Constructor.
+     * @param value         The numeric value to represent as a decimal.
+     * @param annotations   An optional array of strings to associate with `value`.
+     */
+    constructor(value: ion.Decimal, annotations: string[] = []) {
+        super(...[value.getCoefficient(), value.getExponent(), value.isNegative()]);
+        this._decimalValue = value;
+        this._numberValue = value.numberValue();
+        this._setAnnotations(annotations);
+    }
+
+    numberValue(): number {
+        return this._numberValue;
+    }
+
+    decimalValue(): ion.Decimal {
+        return this._decimalValue;
+    }
+
+    toString(): string {
+        return this._decimalValue.toString();
+    }
+
+    // Required to produce sensible output for toString().
+    // Without it, toString() relies on the underlying Decimal value's coefficient.
+    valueOf(): number {
+        return this._numberValue;
+    }
+}

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -35,8 +35,6 @@ export class Decimal extends DomValue(Number, IonTypes.DECIMAL) {
         return this._decimalValue.toString();
     }
 
-    // Required to produce sensible output for toString().
-    // Without it, toString() relies on the underlying Decimal value's coefficient.
     valueOf(): number {
         return this._numberValue;
     }

--- a/src/dom/DomValue.ts
+++ b/src/dom/DomValue.ts
@@ -11,8 +11,8 @@ export type Constructor<T = {}> = new (...args: any[]) => T;
  * A mixin[1] that allows each DOM class to effectively extend two different parent classes:
  *   1. The corresponding native JS data type (dom.String extends String, dom.Integer extends Number, etc.)
  *   2. A new class constructed by the DomValue method which provides functionality common to all
- *      DOM elements. This includes storing/accessing an ion data type and annotations, as well as
- *      convenience methods for converting from ion data types to JS data types.
+ *      DOM elements. This includes storing/accessing an Ion data type and annotations, as well as
+ *      convenience methods for converting from Ion data types to JS data types.
  *
  * [1] https://www.typescriptlang.org/docs/handbook/mixins.html
  *

--- a/src/dom/DomValue.ts
+++ b/src/dom/DomValue.ts
@@ -1,0 +1,127 @@
+import {Decimal, IonType} from "../Ion";
+import {Value, PathElement} from "./Value";
+import JSBI from "jsbi";
+
+/**
+ * A type alias for the constructor signature required for mixins.
+ */
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * A mixin[1] that allows each DOM class to effectively extend two different parent classes:
+ *   1. The corresponding native JS data type (dom.String extends String, dom.Integer extends Number, etc.)
+ *   2. A new class constructed by the DomValue method which provides functionality common to all
+ *      DOM elements. This includes storing/accessing an ion data type and annotations, as well as
+ *      convenience methods for converting from ion data types to JS data types.
+ *
+ * [1] https://www.typescriptlang.org/docs/handbook/mixins.html
+ *
+ * @param BaseClass     A parent type for the newly constructed class to extend.
+ * @param ionType       The Ion data type that will be associated with new instances of the constructed class.
+ * @constructor
+ */
+export function DomValue<Clazz extends Constructor>(BaseClass: Clazz, ionType: IonType) {
+    return class extends BaseClass implements Value {
+        _ionType: IonType;
+        _annotations: string[];
+
+        /* TODO:
+         *  Ideally, this mixin's constructor would require subclasses to specify the desired annotations list
+         *  for the value being created as an argument. Something like:
+         *     constructor(annotations: string[], ...args: any[]) {
+         *         super(args);
+         *         this._setAnnotations(annotations);
+         *     }
+         *  Unfortunately, Typescript requires[1] that mixins have a single constructor which accepts a
+         *  single spread parameter. This means that we can't statically enforce this; callers would need
+         *  to "just know" to pass an annotations list as the first element of an arguments array.
+         *  For now, subclasses are expected to call `this._setAnnotations(...)` after the constructor completes.
+         *  This avoids the runtime costs that would be associated with the constant slicing/inspection of
+         *  values in the `...args` list to detect annotations.
+         *
+         *  [1] https://github.com/Microsoft/TypeScript/issues/14126
+         */
+        constructor(...args: any[]) {
+            super(...args);
+            this._ionType = ionType;
+            this._annotations = [];
+            // Setting the 'enumerable' attribute of these properties to `false` prevents them
+            // from appearing in the iterators returned by Object.keys(), Object.entries(), etc.
+            // This guarantees that users iterating over the fields of a struct or values in a list
+            // will see only Values from the source data or that they have created themselves.
+            Object.defineProperty(this, "_ionType", {enumerable: false});
+            Object.defineProperty(this, "_annotations", {enumerable: false});
+        }
+
+        getType(): IonType {
+            return this._ionType;
+        }
+
+        // Class expressions (like this mixin) cannot have private or protected methods.
+        _setAnnotations(annotations: string[]) {
+            this._annotations = annotations;
+        }
+
+        getAnnotations(): string[] {
+            if (this._annotations === null) {
+                return [];
+            }
+            return this._annotations;
+        }
+
+        isNull(): boolean {
+            return false;
+        }
+
+        booleanValue(): boolean | null {
+            return null;
+        }
+
+        numberValue(): number | null {
+            return null;
+        }
+
+        bigIntValue(): JSBI | null {
+            return null;
+        }
+
+        decimalValue(): Decimal | null {
+            return null;
+        }
+
+        stringValue(): string | null {
+            return null;
+        }
+
+        dateValue(): Date | null {
+            return null;
+        }
+
+        uInt8ArrayValue(): Uint8Array | null {
+            return null;
+        }
+
+        fieldNames(): IterableIterator<string> | null {
+            return null;
+        }
+
+        fields(): IterableIterator<[string, Value]> | null {
+            return null;
+        }
+
+        values(): IterableIterator<Value> | null {
+            return null;
+        }
+
+        get(...pathElements: PathElement[]): Value | null {
+            return null;
+        }
+
+        as<T extends Value>(ionValueType: Constructor<T>): T | null {
+            if (this instanceof ionValueType) {
+                return this as unknown as T;
+            }
+            return null;
+        }
+    };
+}

--- a/src/dom/DomValue.ts
+++ b/src/dom/DomValue.ts
@@ -122,7 +122,7 @@ export function DomValue<Clazz extends Constructor>(BaseClass: Clazz, ionType: I
         }
 
         get(...pathElements: PathElement[]): Value | null {
-            return null;
+            this._unsupportedOperation('get');
         }
 
         as<T extends Value>(ionValueType: Constructor<T>): T {

--- a/src/dom/Float.ts
+++ b/src/dom/Float.ts
@@ -13,12 +13,12 @@ export class Float extends DomValue(Number, IonTypes.FLOAT) {
      * @param value         The numeric value to represent as a float.
      * @param annotations   An optional array of strings to associate with `value`.
      */
-    constructor(protected readonly value: number, annotations: string[] = []) {
+    constructor(value: number, annotations: string[] = []) {
         super(value);
         this._setAnnotations(annotations);
     }
 
     public numberValue(): number {
-        return this.valueOf() as number;
+        return +this.valueOf();
     }
 }

--- a/src/dom/Float.ts
+++ b/src/dom/Float.ts
@@ -1,0 +1,24 @@
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents a float[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#float
+ */
+export class Float extends DomValue(Number, IonTypes.FLOAT) {
+
+    /**
+     * Constructor.
+     * @param value         The numeric value to represent as a float.
+     * @param annotations   An optional array of strings to associate with `value`.
+     */
+    constructor(protected readonly value: number, annotations: string[] = []) {
+        super(value);
+        this._setAnnotations(annotations);
+    }
+
+    public numberValue(): number {
+        return this.valueOf() as number;
+    }
+}

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -1,0 +1,56 @@
+import JSBI from "jsbi";
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents an integer value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#int
+ */
+export class Integer extends DomValue(Number, IonTypes.INT) {
+    private _bigIntValue: JSBI | null;
+    private _numberValue: number;
+
+    /**
+     * Constructor.
+     * @param value         The numeric value to represent as an integer.
+     * @param annotations   An optional array of strings to associate with `value`.
+     */
+    constructor(value: JSBI | number, annotations: string[] = []) {
+        // If the provided value is a JS number, we will defer constructing a BigInt representation
+        // of it until it requested later by a call to bigIntValue().
+        if (typeof value === "number") {
+            super(value);
+            this._numberValue = value;
+            this._bigIntValue = null;
+        } else {
+            let numberValue: number = JSBI.toNumber(value);
+            super(numberValue);
+            this._bigIntValue = value;
+            this._numberValue = numberValue;
+        }
+        this._setAnnotations(annotations);
+    }
+
+    bigIntValue(): JSBI {
+        if(this._bigIntValue === null) {
+            this._bigIntValue = JSBI.BigInt(this.numberValue());
+        }
+        return this._bigIntValue;
+    }
+
+    numberValue(): number {
+        return this._numberValue;
+    }
+
+    toString(): string {
+        if (this._bigIntValue === null) {
+            return this._numberValue.toString();
+        }
+        return this._bigIntValue.toString();
+    }
+
+    valueOf() {
+        return this.numberValue();
+    }
+}

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -18,7 +18,7 @@ export class Integer extends DomValue(Number, IonTypes.INT) {
      */
     constructor(value: JSBI | number, annotations: string[] = []) {
         // If the provided value is a JS number, we will defer constructing a BigInt representation
-        // of it until it requested later by a call to bigIntValue().
+        // of it until it's requested later by a call to bigIntValue().
         if (typeof value === "number") {
             super(value);
             this._numberValue = value;
@@ -33,7 +33,7 @@ export class Integer extends DomValue(Number, IonTypes.INT) {
     }
 
     bigIntValue(): JSBI {
-        if(this._bigIntValue === null) {
+        if (this._bigIntValue === null) {
             this._bigIntValue = JSBI.BigInt(this.numberValue());
         }
         return this._bigIntValue;

--- a/src/dom/List.ts
+++ b/src/dom/List.ts
@@ -1,0 +1,19 @@
+import {Value} from "./Value";
+import {IonTypes} from "../Ion";
+import {Sequence} from "./Sequence";
+
+/**
+ * Represents a list value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#list
+ */
+export class List extends Sequence(IonTypes.LIST) {
+    /**
+     * Constructor.
+     * @param children      Values that will be contained in the new list.
+     * @param annotations   An optional array of strings to associate with the items in `children`.
+     */
+    constructor(children: Value[], annotations: string[] = []) {
+        super(children, annotations);
+    }
+}

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -1,0 +1,50 @@
+import {DomValue} from "./DomValue";
+import {IonType, IonTypes} from "../Ion";
+
+/**
+ * Represents a null[1] value in an Ion stream.
+ *
+ * An Ion null differs from a Javascript null in that an instance of an Ion null may have data associated with it.
+ *
+ * In particular, Ion nulls have an Ion data type:
+ *
+ *      text encoding | Ion data type
+ *  ======================================
+ *      null          | IonType.NULL (implicit)
+ *      null.null     | IonType.NULL (explicit)
+ *      null.string   | IonType.STRING
+ *      null.int      | IonType.INT
+ *      null.struct   | IonType.STRUCT
+ *      ...
+ *
+ * They can also be annotated:
+ *
+ *      customerName::null.string
+ *      dollars::null.decimal
+ *      meters::null.float
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#null
+ */
+export class Null extends DomValue(Object, IonTypes.NULL) {
+    /**
+     * Constructor.
+     * @param ionType       The ion data type associated with this null value.
+     * @param annotations   An optional array of strings to associate with this null value.
+     */
+    constructor(ionType: IonType = IonTypes.NULL, annotations: string[] = []) {
+        super();
+        this._ionType = ionType;
+        this._setAnnotations(annotations);
+    }
+
+    isNull(): boolean {
+        return true;
+    }
+
+    toString(): string {
+        if (this.getType() == IonTypes.NULL) {
+            return 'null';
+        }
+        return 'null.' + this._ionType;
+    }
+}

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -67,7 +67,7 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
         if (Null._operationIsSupported(this.getType(), operation)) {
             return null;
         }
-        throw new Error(`${operation} is not supported by Ion type ${this.getType().name}`);
+        throw new Error(`${operation}() is not supported by Ion type ${this.getType().name}`);
     }
 
     // If this Null's Ion type supports the requested operation, throw an Error indicating this was a null dereference.
@@ -76,7 +76,7 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
         if (Null._operationIsSupported(this.getType(), operation)) {
             throw new Error(`${operation}() called on a null ${this.getType().name}.`);
         }
-        throw new Error(`${operation} is not supported by Ion type ${this.getType().name}`);
+        throw new Error(`${operation}() is not supported by Ion type ${this.getType().name}`);
     }
 
     booleanValue(): boolean | null {

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -67,16 +67,16 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
         if (Null._operationIsSupported(this.getType(), operation)) {
             return null;
         }
-        throw new Error(`'${operation}' is not supported by Ion type ${this.getType().name}`);
+        throw new Error(`${operation} is not supported by Ion type ${this.getType().name}`);
     }
 
     // If this Null's Ion type supports the requested operation, throw an Error indicating this was a null dereference.
     // Otherwise, throw an Error indicating that the requested operation is not supported.
-    private _unsupportedOperationOrNullDerefence(operation: string): never {
+    private _unsupportedOperationOrNullDereference(operation: string): never {
         if (Null._operationIsSupported(this.getType(), operation)) {
-            throw new Error(`${operation} called on a null ${this.getType().name}.`);
+            throw new Error(`${operation}() called on a null ${this.getType().name}.`);
         }
-        throw new Error(`'${operation}' is not supported by Ion type ${this.getType().name}`);
+        throw new Error(`${operation} is not supported by Ion type ${this.getType().name}`);
     }
 
     booleanValue(): boolean | null {
@@ -108,15 +108,15 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
     }
 
     fieldNames(): string[] {
-        this._unsupportedOperationOrNullDerefence('fieldNames');
+        this._unsupportedOperationOrNullDereference('fieldNames');
     }
 
     fields(): [string, Value][] {
-        this._unsupportedOperationOrNullDerefence('fields');
+        this._unsupportedOperationOrNullDereference('fields');
     }
 
     elements(): Value[] {
-        this._unsupportedOperationOrNullDerefence('elements');
+        this._unsupportedOperationOrNullDereference('elements');
     }
 
     get(...pathElements: PathElement[]): Value | null {

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -1,5 +1,7 @@
 import {DomValue} from "./DomValue";
-import {IonType, IonTypes} from "../Ion";
+import {Decimal, IonType, IonTypes} from "../Ion";
+import JSBI from "jsbi";
+import {PathElement, Value} from "./Value";
 
 /**
  * Represents a null[1] value in an Ion stream.
@@ -10,8 +12,8 @@ import {IonType, IonTypes} from "../Ion";
  *
  *      text encoding | Ion data type
  *  ======================================
- *      null          | IonType.NULL (implicit)
- *      null.null     | IonType.NULL (explicit)
+ *      null          | IonType.NULL
+ *      null.null     | IonType.NULL
  *      null.string   | IonType.STRING
  *      null.int      | IonType.INT
  *      null.struct   | IonType.STRUCT
@@ -26,6 +28,24 @@ import {IonType, IonTypes} from "../Ion";
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#null
  */
 export class Null extends DomValue(Object, IonTypes.NULL) {
+    private static _supportedIonTypesByOperation = new Map<string, Set<IonType>>([
+        ['booleanValue', new Set([IonTypes.BOOL])],
+        ['numberValue', new Set([IonTypes.INT, IonTypes.FLOAT, IonTypes.DECIMAL])],
+        ['bigIntValue', new Set([IonTypes.INT])],
+        ['decimalValue', new Set([IonTypes.DECIMAL])],
+        ['stringValue', new Set([IonTypes.STRING, IonTypes.SYMBOL])],
+        ['dateValue', new Set([IonTypes.TIMESTAMP])],
+        ['timestampValue', new Set([IonTypes.TIMESTAMP])],
+        ['uInt8ArrayValue', new Set([IonTypes.BLOB, IonTypes.CLOB])],
+        ['fields', new Set([IonTypes.STRUCT])],
+        ['fieldNames', new Set([IonTypes.STRUCT])],
+        ['elements', new Set([IonTypes.LIST, IonTypes.SEXP, IonTypes.STRUCT])]
+    ]);
+
+    private static _operationIsSupported(ionType: IonType, operation: string): boolean {
+        return Null._supportedIonTypesByOperation.get(operation)!.has(ionType);
+    }
+
     /**
      * Constructor.
      * @param ionType       The ion data type associated with this null value.
@@ -41,10 +61,72 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
         return true;
     }
 
+    // If a [type]Value() operation was called on this Null value, we need to see whether the associated Ion type
+    // supports that conversion. If it does, we'll return a JS null. If it doesn't, we'll throw an Error.
+    private _convertToJsNull(operation: string): null | never {
+        if (Null._operationIsSupported(this.getType(), operation)) {
+            return null;
+        }
+        throw new Error(`'${operation}' is not supported by Ion type ${this.getType().name}`);
+    }
+
+    // If this Null's Ion type supports the requested operation, throw an Error indicating this was a null dereference.
+    // Otherwise, throw an Error indicating that the requested operation is not supported.
+    private _unsupportedOperationOrNullDerefence(operation: string): never {
+        if (Null._operationIsSupported(this.getType(), operation)) {
+            throw new Error(`${operation} called on a null ${this.getType().name}.`);
+        }
+        throw new Error(`'${operation}' is not supported by Ion type ${this.getType().name}`);
+    }
+
+    booleanValue(): boolean | null {
+        return this._convertToJsNull('booleanValue');
+    }
+
+    numberValue(): number | null {
+        return this._convertToJsNull('numberValue');
+    }
+
+    bigIntValue(): JSBI | null {
+        return this._convertToJsNull('bigIntValue');
+    }
+
+    decimalValue(): Decimal | null {
+        return this._convertToJsNull('decimalValue');
+    }
+
+    stringValue(): string | null {
+        return this._convertToJsNull('stringValue');
+    }
+
+    dateValue(): Date | null {
+        return this._convertToJsNull('dateValue');
+    }
+
+    uInt8ArrayValue(): Uint8Array | null {
+        return this._convertToJsNull('uInt8ArrayValue');
+    }
+
+    fieldNames(): string[] {
+        this._unsupportedOperationOrNullDerefence('fieldNames');
+    }
+
+    fields(): [string, Value][] {
+        this._unsupportedOperationOrNullDerefence('fields');
+    }
+
+    elements(): Value[] {
+        this._unsupportedOperationOrNullDerefence('elements');
+    }
+
+    get(...pathElements: PathElement[]): Value | null {
+        return null;
+    }
+
     toString(): string {
         if (this.getType() == IonTypes.NULL) {
             return 'null';
         }
-        return 'null.' + this._ionType;
+        return 'null.' + this._ionType.name;
     }
 }

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -48,7 +48,7 @@ export class Null extends DomValue(Object, IonTypes.NULL) {
 
     /**
      * Constructor.
-     * @param ionType       The ion data type associated with this null value.
+     * @param ionType       The Ion data type associated with this null value.
      * @param annotations   An optional array of strings to associate with this null value.
      */
     constructor(ionType: IonType = IonTypes.NULL, annotations: string[] = []) {

--- a/src/dom/SExpression.ts
+++ b/src/dom/SExpression.ts
@@ -1,0 +1,19 @@
+import {Value} from "./Value";
+import {IonTypes} from "../Ion";
+import {Sequence} from "./Sequence";
+
+/**
+ * Represents an s-expression[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#sexp
+ */
+export class SExpression extends Sequence(IonTypes.SEXP) {
+    /**
+     * Constructor.
+     * @param children      Values that will be contained in the new s-expression.
+     * @param annotations   An optional array of strings to associate with the items in `children`.
+     */
+    constructor(children: Value[], annotations: string[] = []) {
+        super(children, annotations);
+    }
+}

--- a/src/dom/SExpression.ts
+++ b/src/dom/SExpression.ts
@@ -16,4 +16,8 @@ export class SExpression extends Sequence(IonTypes.SEXP) {
     constructor(children: Value[], annotations: string[] = []) {
         super(children, annotations);
     }
+
+    toString(): string {
+        return '(' + this.join(' ') + ')';
+    }
 }

--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -28,7 +28,7 @@ export function Sequence(ionType: IonType) {
             }
             let [pathHead, ...pathTail] = pathElements;
             if (typeof (pathHead) !== "number") {
-                return null;
+                throw new Error(`Cannot index into a ${this.getType().name} with a ${typeof(pathHead)}.`);
             }
 
             let children = this as Value[];

--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -1,0 +1,51 @@
+import {Value, PathElement} from "./Value";
+import {DomValue} from "./DomValue";
+import {IonType} from "../Ion";
+
+/**
+ * This mixin constructs a new class that:
+ * - Extends `DomValue`
+ * - Extends `Array`
+ * - Has the specified `IonType`.
+ *
+ * In practice, serves as a common base class for `List` and `SExpression`.
+ *
+ * @param ionType   The IonType to associate with the new DomValue subclass.
+ * @constructor
+ * @private
+ */
+export function Sequence(ionType: IonType) {
+    return class extends DomValue(Array, ionType) implements Value, Array<Value> {
+        protected constructor(children: Value[], annotations: string[] = []) {
+            super();
+            this.push(...children);
+            this._setAnnotations(annotations);
+        }
+
+        get(...pathElements: PathElement[]): Value | null {
+            if (pathElements.length === 0) {
+                throw new Error('Value#get requires at least one parameter.');
+            }
+            let [pathHead, ...pathTail] = pathElements;
+            if (typeof (pathHead) !== "number") {
+                return null;
+            }
+
+            let children = this as Value[];
+            let maybeChild: Value | undefined = children[pathHead];
+            let child: Value | null = maybeChild === undefined ? null : maybeChild;
+            if (pathTail.length === 0 || child === null) {
+                return child;
+            }
+            return child.get(...pathTail);
+        }
+
+        values(): IterableIterator<Value> {
+            return Object.values(this)[Symbol.iterator]();
+        }
+
+        toString(): string {
+            return '[' + this.join(', ') + ']';
+        }
+    }
+}

--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -40,8 +40,8 @@ export function Sequence(ionType: IonType) {
             return child.get(...pathTail);
         }
 
-        values(): IterableIterator<Value> {
-            return Object.values(this)[Symbol.iterator]();
+        elements(): Value[] {
+            return Object.values(this);
         }
 
         toString(): string {

--- a/src/dom/String.ts
+++ b/src/dom/String.ts
@@ -1,0 +1,27 @@
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents a string[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#string
+ */
+export class String extends DomValue(global.String, IonTypes.STRING) {
+    /**
+     * Constructor.
+     * @param _text          The text value to represent as a string.
+     * @param annotations   An optional array of strings to associate with the provided text.
+     */
+    constructor(protected readonly _text: string, annotations: string[] = []) {
+        super(_text);
+        this._setAnnotations(annotations);
+    }
+
+    stringValue(): string {
+        return this._text;
+    }
+
+    toString(): string {
+        return this._text;
+    }
+}

--- a/src/dom/String.ts
+++ b/src/dom/String.ts
@@ -9,19 +9,15 @@ import {DomValue} from "./DomValue";
 export class String extends DomValue(global.String, IonTypes.STRING) {
     /**
      * Constructor.
-     * @param _text          The text value to represent as a string.
+     * @param text          The text value to represent as a string.
      * @param annotations   An optional array of strings to associate with the provided text.
      */
-    constructor(protected readonly _text: string, annotations: string[] = []) {
-        super(_text);
+    constructor(text: string, annotations: string[] = []) {
+        super(text);
         this._setAnnotations(annotations);
     }
 
     stringValue(): string {
-        return this._text;
-    }
-
-    toString(): string {
-        return this._text;
+        return this.toString();
     }
 }

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -37,7 +37,7 @@ export class Struct extends DomValue(Object, IonTypes.STRUCT) implements Value {
         }
         let [pathHead, ...pathTail] = pathElements;
         if (typeof(pathHead) !== "string") {
-            return null;
+            throw new Error(`Cannot index into a struct with a ${typeof(pathHead)}.`);
         }
         let child: Value | null = this._getField(pathHead);
         if (pathTail.length === 0 || child === null) {

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -5,6 +5,11 @@ import {DomValue} from "./DomValue";
 /**
  * Represents a struct[1] value in an Ion stream.
  *
+ * Struct fields can be accessed as properties on this object. For example:
+ *
+ *    let s: any = ion.load('{foo: 1, bar: 2, baz: qux::3}');
+ *    assert.equal(6, s.foo + s['bar'] + s.baz);
+ *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#struct
  */
 export class Struct extends DomValue(Object, IonTypes.STRUCT) implements Value {
@@ -13,15 +18,15 @@ export class Struct extends DomValue(Object, IonTypes.STRUCT) implements Value {
      * @param fields        An iterator of field name/value pairs to represent as a struct.
      * @param annotations   An optional array of strings to associate with this null value.
      */
-    constructor(fields: IterableIterator<[string, Value]>, annotations: string[] = []) {
+    constructor(fields: Iterable<[string, Value]>, annotations: string[] = []) {
         super();
-        for(let [fieldName, value] of fields) {
-            Object.defineProperty(this, ''+fieldName, {
+        for (let [fieldName, value] of fields) {
+            Object.defineProperty(this, fieldName, {
                 configurable: true,
                 enumerable: true,
                 value: value,
                 writable: true
-            })
+            });
         }
         this._setAnnotations(annotations);
     }
@@ -41,20 +46,20 @@ export class Struct extends DomValue(Object, IonTypes.STRUCT) implements Value {
         return child.get(...pathTail);
     }
 
-    fieldNames(): IterableIterator<string> {
-        return Object.keys(this)[Symbol.iterator]();
+    fieldNames(): string[] {
+        return Object.keys(this);
     }
 
-    fields(): IterableIterator<[string, Value]> {
-        return Object.entries(this)[Symbol.iterator]();
+    fields(): [string, Value][] {
+        return Object.entries(this);
     }
 
-    values(): IterableIterator<Value> {
-        return Object.values(this)[Symbol.iterator]();
+    elements(): Value[] {
+        return Object.values(this);
     }
 
     [Symbol.iterator](): IterableIterator<[string, Value]> {
-        return this.fields();
+        return this.fields()[Symbol.iterator]();
     }
 
     _getField(fieldName: string): Value | null {

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -1,0 +1,96 @@
+import {Value, PathElement} from "./Value";
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+/**
+ * Represents a struct[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#struct
+ */
+export class Struct extends DomValue(Object, IonTypes.STRUCT) implements Value {
+    /**
+     * Constructor.
+     * @param fields        An iterator of field name/value pairs to represent as a struct.
+     * @param annotations   An optional array of strings to associate with this null value.
+     */
+    constructor(fields: IterableIterator<[string, Value]>, annotations: string[] = []) {
+        super();
+        for(let [fieldName, value] of fields) {
+            Object.defineProperty(this, ''+fieldName, {
+                configurable: true,
+                enumerable: true,
+                value: value,
+                writable: true
+            })
+        }
+        this._setAnnotations(annotations);
+    }
+
+    get(...pathElements: PathElement[]): Value | null {
+        if (pathElements.length === 0) {
+            throw new Error('Value#get requires at least one parameter.');
+        }
+        let [pathHead, ...pathTail] = pathElements;
+        if (typeof(pathHead) !== "string") {
+            return null;
+        }
+        let child: Value | null = this._getField(pathHead);
+        if (pathTail.length === 0 || child === null) {
+            return child;
+        }
+        return child.get(...pathTail);
+    }
+
+    fieldNames(): IterableIterator<string> {
+        return Object.keys(this)[Symbol.iterator]();
+    }
+
+    fields(): IterableIterator<[string, Value]> {
+        return Object.entries(this)[Symbol.iterator]();
+    }
+
+    values(): IterableIterator<Value> {
+        return Object.values(this)[Symbol.iterator]();
+    }
+
+    [Symbol.iterator](): IterableIterator<[string, Value]> {
+        return this.fields();
+    }
+
+    _getField(fieldName: string): Value | null {
+        /* Typescript requires some convincing to retrieve
+         * properties that may have been stored on an Object
+         * via common Javascript idioms like:
+         *
+         *   obj['foo'] = ...;
+         *   obj.foo = ...;
+         *   Object.defineProperty(obj, 'foo', ...);
+         *
+         * Here we cast `this` from a Struct to the
+         * `unknown` type to disable static type analysis.
+         * Then we cast it to a vanilla JS object with string
+         * keys and Value values. This casting has no runtime
+         * overhead. It's a bit ugly, but allows us to access data
+         * in Structs via any of:
+         *
+         *   let value = struct.get('foo'); // Typescript + JS
+         *   let value = struct['foo']; // JS
+         *   let value = struct.foo;    // JS
+         */
+        let obj = this as unknown as {[key: string]: Value};
+        let field: Value | undefined = obj[fieldName];
+        if (field === undefined) {
+            return null;
+        }
+
+        return field;
+    }
+
+    toString(): string {
+        return '{'
+            + [...this.fields()]
+                .map(([name, value]) => name + ': ' + value)
+                .join(', ')
+        + '}';
+    }
+}

--- a/src/dom/Symbol.ts
+++ b/src/dom/Symbol.ts
@@ -1,0 +1,27 @@
+import {IonTypes} from "../Ion";
+import {DomValue} from "./DomValue";
+
+// TODO:
+//   This extends 'String' because ion-js does not yet have a SymbolToken construct.
+//   It is not possible to access the raw Symbol ID via the Reader API, so it cannot be accessed from this class.
+
+/**
+ * Represents a symbol[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#symbol
+ */
+export class Symbol extends DomValue(String, IonTypes.SYMBOL) {
+    /**
+     * Constructor.
+     * @param symbolText    The text to represent as a symbol.
+     * @param annotations   An optional array of strings to associate with this null value.
+     */
+    constructor(protected readonly symbolText: string, annotations: string[] = []) {
+        super(symbolText);
+        this._setAnnotations(annotations);
+    }
+
+    stringValue(): string {
+        return this.valueOf() as string;
+    }
+}

--- a/src/dom/Symbol.ts
+++ b/src/dom/Symbol.ts
@@ -14,14 +14,14 @@ export class Symbol extends DomValue(String, IonTypes.SYMBOL) {
     /**
      * Constructor.
      * @param symbolText    The text to represent as a symbol.
-     * @param annotations   An optional array of strings to associate with this null value.
+     * @param annotations   An optional array of strings to associate with this symbol.
      */
-    constructor(protected readonly symbolText: string, annotations: string[] = []) {
+    constructor(symbolText: string, annotations: string[] = []) {
         super(symbolText);
         this._setAnnotations(annotations);
     }
 
     stringValue(): string {
-        return this.valueOf() as string;
+        return this.toString();
     }
 }

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -14,7 +14,7 @@ export class Timestamp extends DomValue(Date, IonTypes.TIMESTAMP) {
     /**
      * Constructor.
      * @param dateOrTimestamp   A `Date` or `Timestamp` to represent as a timestamp.
-     * @param annotations       An optional array of strings to associate with this null value.
+     * @param annotations       An optional array of strings to associate with this timestamp.
      */
     constructor(dateOrTimestamp: Date | ion.Timestamp, annotations: string[] = []) {
         let date: Date;
@@ -25,7 +25,6 @@ export class Timestamp extends DomValue(Date, IonTypes.TIMESTAMP) {
         } else {
             timestamp = dateOrTimestamp;
             date = timestamp.getDate();
-
         }
         super(date);
         this._date = date;
@@ -45,7 +44,7 @@ export class Timestamp extends DomValue(Date, IonTypes.TIMESTAMP) {
         );
     }
 
-    timestampValue():ion.Timestamp {
+    timestampValue(): ion.Timestamp {
         return this._timestamp;
     }
 

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -1,0 +1,55 @@
+import {DomValue} from "./DomValue";
+import * as ion from "../Ion";
+import {IonTypes} from "../Ion";
+
+/**
+ * Represents a timestamp[1] value in an Ion stream.
+ *
+ * [1] http://amzn.github.io/ion-docs/docs/spec.html#timestamp
+ */
+export class Timestamp extends DomValue(Date, IonTypes.TIMESTAMP) {
+    protected _timestamp: ion.Timestamp;
+    protected _date: Date;
+
+    /**
+     * Constructor.
+     * @param dateOrTimestamp   A `Date` or `Timestamp` to represent as a timestamp.
+     * @param annotations       An optional array of strings to associate with this null value.
+     */
+    constructor(dateOrTimestamp: Date | ion.Timestamp, annotations: string[] = []) {
+        let date: Date;
+        let timestamp: ion.Timestamp;
+        if (dateOrTimestamp instanceof Date) {
+            date = dateOrTimestamp;
+            timestamp = Timestamp._timestampFromDate(date);
+        } else {
+            timestamp = dateOrTimestamp;
+            date = timestamp.getDate();
+
+        }
+        super(date);
+        this._date = date;
+        this._timestamp = timestamp;
+        this._setAnnotations(annotations);
+    }
+
+    private static _timestampFromDate(date: Date): ion.Timestamp {
+        return new ion.Timestamp(
+            date.getTimezoneOffset(),
+            date.getUTCFullYear(),
+            date.getUTCMonth(),
+            date.getUTCDate(),
+            date.getUTCHours(),
+            date.getUTCMinutes(),
+            date.getUTCSeconds() + (date.getUTCMilliseconds()/1000)
+        );
+    }
+
+    timestampValue():ion.Timestamp {
+        return this._timestamp;
+    }
+
+    dateValue(): Date {
+        return this._date;
+    }
+}

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -60,6 +60,9 @@ export interface Value {
     /**
      * For the Timestamp type, returns a JS Date representation of the Value; otherwise throws
      * an Error.
+     *
+     * Note that the conversion from an ion.Timestamp to a Date can involve a loss of precision.
+     * See timestampValue() for a lossless alternative.
      */
     dateValue(): Date | null;
 

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -1,0 +1,119 @@
+import {Decimal, IonType} from "../Ion";
+import JSBI from "jsbi";
+import {Constructor} from "./DomValue";
+
+/**
+ * Provides a common interface to work with DOM elements of any Ion type.
+ *
+ * Implementors should return `null` for any method that cannot provide the requested value.
+ */
+export interface Value {
+    /**
+     * Returns the Ion type of this value.
+     */
+    getType(): IonType;
+
+    /**
+     * Returns an array containing any annotations associated with this value.
+     * If this value does not have any annotations, an empty array will be returned.
+     */
+    getAnnotations(): string[];
+
+    /**
+     * Returns true if this Value is a Null and false otherwise.
+     */
+    isNull(): boolean;
+
+    /**
+     * Returns null if the Value is not a Boolean.
+     * Otherwise, returns the boolean value of the Boolean.
+     */
+    booleanValue(): boolean | null;
+
+    /**
+     * Returns null if the Value is not an Integer, Float, or Decimal.
+     * Otherwise, returns the JS number representation of the Value.
+     * In some cases, this method will perform conversions that inherently involve loss of
+     * precision. See bigIntValue() and decimalValue() for lossless alternatives.
+     */
+    numberValue(): number | null;
+
+    /**
+     * Returns null if the Value is not an Integer.
+     * Otherwise, returns a lossless BigInt representation of the Value.
+     */
+    bigIntValue(): JSBI | null;
+
+    /**
+     * Returns null if the Value is not a Decimal.
+     * Otherwise, returns a lossless Decimal representation of the Value.
+     */
+    decimalValue(): Decimal | null;
+
+    /**
+     * Returns null if the Value is not a String or Symbol.
+     * Otherwise, returns a string representation of the Value's text.
+     */
+    stringValue(): string | null;
+
+    /**
+     * Returns null if the Value is not a Timestamp.
+     * Otherwise, returns a Date representation of the Value.
+     */
+    dateValue(): Date | null;
+
+    /**
+     * Returns null if the Value is not a Blob or Clob.
+     * Otherwise, returns a Uint8Array representation of the Value's bytes.
+     */
+    uInt8ArrayValue(): Uint8Array | null;
+
+    /**
+     * Returns null if the Value is not a Struct, List, or SExpression.
+     * Otherwise, will attempt to index into the Value with each pathElement in turn
+     * until:
+     *  - A value is found that cannot use the current PathElement as an index.
+     *    (e.g. The current Value is a List but the current PathElement is a number.)
+     *  - An undefined value is encountered.
+     *    (e.g. The current Value is a Struct and the current PathElement is a string,
+     *          but the current PathElement is not a fieldName that exists in the Struct.)
+     *  - The pathElements are exhausted and the requested Value is discovered.
+     *
+     * @param pathElements  One or more values to be used to index into the Value.
+     * @returns null if no value is found at the specified path. Otherwise, returns the discovered Value.
+     */
+    get(...pathElements: PathElement[]): Value | null;
+
+    /**
+     * Returns null if the Value is not a Struct.
+     * Otherwise, returns an iterator over the names of the fields in the Struct.
+     */
+    fieldNames(): IterableIterator<string> | null;
+
+    /**
+     * Returns null if the Value is not a Struct.
+     * Otherwise, returns an iterator over the field name/value pairs in the Struct.
+     */
+    fields(): IterableIterator<[string, Value]> | null;
+
+    /**
+     * Returns null if the Value is not a Struct, List, or SExpression.
+     * Otherwise, returns an iterator over the container's children.
+     */
+    values(): IterableIterator<Value> | null;
+
+    /**
+     * Allows for easy type casting from Value to a particular implementation of Value.
+     *
+     * Returns null if the Value is not an instance of the class type represented by the provided
+     * constructor. Otherwise, casts the Value as type 'T' and returns it.
+     */
+    as<T extends Value>(ionValueType: Constructor<T>): T | null;
+}
+
+/**
+ * Represents data types that may be used to index into a Value.
+ *
+ * See: Value#get
+ */
+export type PathElement = string | number;

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -1,4 +1,4 @@
-import {Decimal, IonType} from "../Ion";
+import {Decimal, Timestamp, IonType} from "../Ion";
 import JSBI from "jsbi";
 import {Constructor} from "./DomValue";
 
@@ -25,55 +25,62 @@ export interface Value {
     isNull(): boolean;
 
     /**
-     * Returns null if the Value is not a Boolean.
-     * Otherwise, returns the boolean value of the Boolean.
+     * For the Boolean type, returns a JS boolean representation of the Value; otherwise
+     * throws an Error.
      */
     booleanValue(): boolean | null;
 
     /**
-     * Returns null if the Value is not an Integer, Float, or Decimal.
-     * Otherwise, returns the JS number representation of the Value.
+     * For the Integer, Float, and Decimal types, returns a JS number representation of the
+     * Value; otherwise throws an Error.
+     *
      * In some cases, this method will perform conversions that inherently involve loss of
      * precision. See bigIntValue() and decimalValue() for lossless alternatives.
      */
     numberValue(): number | null;
 
     /**
-     * Returns null if the Value is not an Integer.
-     * Otherwise, returns a lossless BigInt representation of the Value.
+     * For the Integer type, returns a BigInt representation of the Value; otherwise throws
+     * an Error.
      */
     bigIntValue(): JSBI | null;
 
     /**
-     * Returns null if the Value is not a Decimal.
-     * Otherwise, returns a lossless Decimal representation of the Value.
+     * For the Decimal type, returns an ion.Decimal representation of the Value; otherwise
+     * throws an Error.
      */
     decimalValue(): Decimal | null;
 
     /**
-     * Returns null if the Value is not a String or Symbol.
-     * Otherwise, returns a string representation of the Value's text.
+     * For the String and Symbol types, returns a JS string representation of the Value's
+     * text; otherwise throws an Error.
      */
     stringValue(): string | null;
 
     /**
-     * Returns null if the Value is not a Timestamp.
-     * Otherwise, returns a Date representation of the Value.
+     * For the Timestamp type, returns a JS Date representation of the Value; otherwise throws
+     * an Error.
      */
     dateValue(): Date | null;
 
     /**
-     * Returns null if the Value is not a Blob or Clob.
-     * Otherwise, returns a Uint8Array representation of the Value's bytes.
+     * For the Timestamp type, returns an ion.Timestamp representation of the Value; otherwise throws
+     * an Error.
+     */
+    timestampValue(): Timestamp | null;
+
+    /**
+     * For the Blob and Clob types, returns a Uint8Array representation of the Value's bytes;
+     * otherwise throws an Error.
      */
     uInt8ArrayValue(): Uint8Array | null;
 
     /**
-     * Returns null if the Value is not a Struct, List, or SExpression.
-     * Otherwise, will attempt to index into the Value with each pathElement in turn
-     * until:
+     * Attempts to index into the Value with each pathElement in turn until:
+     *  - The current Value is of a type that cannot be indexed into.
+     *    (e.g. The current value is an Integer or Timestamp.)
      *  - A value is found that cannot use the current PathElement as an index.
-     *    (e.g. The current Value is a List but the current PathElement is a number.)
+     *    (e.g. The current Value is a List but the current PathElement is a string.)
      *  - An undefined value is encountered.
      *    (e.g. The current Value is a Struct and the current PathElement is a string,
      *          but the current PathElement is not a fieldName that exists in the Struct.)
@@ -85,30 +92,30 @@ export interface Value {
     get(...pathElements: PathElement[]): Value | null;
 
     /**
-     * Returns null if the Value is not a Struct.
-     * Otherwise, returns an iterator over the names of the fields in the Struct.
+     * For the Struct type, returns an array containing the names of the fields in the Struct;
+     * otherwise throws an Error.
      */
-    fieldNames(): IterableIterator<string> | null;
+    fieldNames(): string[];
 
     /**
-     * Returns null if the Value is not a Struct.
-     * Otherwise, returns an iterator over the field name/value pairs in the Struct.
+     * For the Struct type, returns an array containing the field name/value pairs in the Struct;
+     * otherwise throws an Error.
      */
-    fields(): IterableIterator<[string, Value]> | null;
+    fields(): [string, Value][];
 
     /**
-     * Returns null if the Value is not a Struct, List, or SExpression.
-     * Otherwise, returns an iterator over the container's children.
+     * For the Struct, List, and SExpression types, returns an array containing the container's
+     * nested values; otherwise throws an Error.
      */
-    values(): IterableIterator<Value> | null;
+    elements(): Value[];
 
     /**
      * Allows for easy type casting from Value to a particular implementation of Value.
      *
-     * Returns null if the Value is not an instance of the class type represented by the provided
-     * constructor. Otherwise, casts the Value as type 'T' and returns it.
+     * If the Value is an instance of the type `T` represented by the provided constructor, this
+     * function will cast it as type `T` and return it; otherwise throws an Error.
      */
-    as<T extends Value>(ionValueType: Constructor<T>): T | null;
+    as<T extends Value>(ionValueType: Constructor<T>): T;
 }
 
 /**

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,0 +1,154 @@
+import {IntSize, IonType, IonTypes, makeReader, Reader, ReaderBuffer} from "../Ion";
+import * as ion from "../Ion";
+import {Value} from "./Value";
+import {Struct} from "./Struct";
+import {List} from "./List";
+import {SExpression} from "./SExpression";
+import {Null} from "./Null";
+import {Boolean} from "./Boolean";
+import {Integer} from "./Integer";
+import {Float} from "./Float";
+import {Decimal} from "./Decimal";
+import {Timestamp} from "./Timestamp";
+import {Symbol} from "./Symbol";
+import {String} from "./String";
+import {Clob} from "./Clob";
+import {Blob} from "./Blob";
+import {TextReader} from "../IonTextReader";
+import {BinaryReader} from "../IonBinaryReader";
+
+/**
+ * Reads the provided ion data source into memory, constructing Value objects to represent
+ * each value found in the stream.
+ *
+ * This approach to reading is less efficient at runtime than using the streaming Reader API
+ * (next(), stepIn(), stepOut(), etc), but is often much simpler to use.
+ *
+ * If `ionData` is a ReaderBuffer, a new Reader will be created to process it.
+ * If it is already a Reader, it will be consumed fully.
+ *
+ * @param ionData   A source of Ion data (text or binary) to load into memory.
+ * @returns         An array of Value objects representing the values found in the stream.
+ */
+export function loadAll(ionData: ReaderBuffer | Reader): Value[] {
+    let reader = createReader(ionData);
+    let ionValues: Value[] = [];
+    let ionType: IonType | null = reader.next();
+    while (ionType !== null) {
+        ionValues.push(loadValue(reader));
+        ionType = reader.next();
+    }
+    return ionValues;
+}
+
+/**
+ * Reads the first value from the provided ion data source into memory, constructing
+ * an Value object to represent it.
+ *
+ * This approach to reading is less efficient at runtime than using the streaming Reader API
+ * (next(), stepIn(), stepOut(), etc), but is often much simpler to use.
+ *
+ * If `ionData` is a ReaderBuffer, a new Reader will be created to process it.
+ * If it is already a Reader, next() will be called once at the top level to consume the
+ * first value found in the data.
+ *
+ * @param ionData   A source of Ion data (text or binary) to load into memory.
+ * @returns         An array of Value objects representing the values found in the stream.
+ */
+export function load(ionData: ReaderBuffer | Reader): Value | null {
+    let reader = createReader(ionData);
+    let ionType: IonType | null = reader.next();
+    return ionType === null ? null : loadValue(reader);
+}
+
+function createReader(ionData: ReaderBuffer | Reader): Reader {
+    // If the provided parameter is already a reader, no new work is required.
+    // However, we cannot simply test `ionData instanceof Reader` because `Reader`
+    // is an interface.
+    if (ionData instanceof TextReader || ionData instanceof BinaryReader) {
+        return ionData as Reader;
+    }
+    return makeReader(ionData as ReaderBuffer);
+}
+
+// Loads the Reader's current value, returning it as a DOM Value
+function loadValue(reader: Reader): Value {
+    let ionType = reader.type();
+    if (ionType === null) {
+        throw new Error("loadValue() called when no further values were available to read.");
+    }
+    let annotations: string[] = reader.annotations();
+    if (reader.isNull()) {
+        return new Null(reader.type()!, annotations);
+    }
+    switch (ionType) {
+        case IonTypes.NULL: return new Null(IonTypes.NULL, annotations);
+        case IonTypes.BOOL: return new ion.dom.Boolean(reader.booleanValue()!, annotations);
+        case IonTypes.INT:
+            return reader.intSize() == IntSize.Number
+                ? new Integer(reader.numberValue()!, annotations)
+                :  new Integer(reader.bigIntValue()!, annotations);
+        case IonTypes.FLOAT: return new Float(reader.numberValue()!, annotations);
+        case IonTypes.DECIMAL: return new Decimal(reader.decimalValue()!, annotations);
+        case IonTypes.TIMESTAMP: return new Timestamp(reader.timestampValue()!, annotations);
+        case IonTypes.SYMBOL: return new Symbol(reader.stringValue()!, annotations);
+        case IonTypes.STRING: return new ion.dom.String(reader.stringValue()!, annotations);
+        case IonTypes.CLOB: return new Clob(reader.byteValue()!, annotations);
+        case IonTypes.BLOB: return new Blob(reader.byteValue()!, annotations);
+        // Containers
+        case IonTypes.LIST: return loadList(reader);
+        case IonTypes.SEXP: return loadSExpression(reader);
+        case IonTypes.STRUCT: return loadStruct(reader);
+        default: throw new Error(`Unrecognized IonType '${ionType}' found.`);
+    }
+}
+
+function loadStruct(reader: Reader): Struct {
+    let children: Map<string, Value> = new Map();
+    let annotations: string[] = reader.annotations();
+    reader.stepIn();
+    let ionType: IonType | null = reader.next();
+    while (ionType !== null) {
+        children.set(reader.fieldName()!, loadValue(reader));
+        ionType = reader.next();
+    }
+    reader.stepOut();
+    return new Struct(children.entries(), annotations);
+}
+
+function loadList(reader: Reader): List {
+    let annotations = reader.annotations();
+    return new List(loadSequence(reader), annotations);
+}
+
+function loadSExpression(reader: Reader): SExpression {
+    let annotations = reader.annotations();
+    return new SExpression(loadSequence(reader), annotations);
+}
+
+function loadSequence(reader: Reader): Value[] {
+    let children: Value[] = [];
+    reader.stepIn();
+    let ionType: IonType | null = reader.next();
+    while (ionType !== null) {
+        children.push(loadValue(reader));
+        ionType = reader.next();
+    }
+    reader.stepOut();
+    return children;
+}
+
+export {Value, PathElement} from "./Value";
+export {Null} from "./Null";
+export {Boolean} from "./Boolean";
+export {Integer} from "./Integer";
+export {Float} from "./Float";
+export {Decimal} from "./Decimal";
+export {Timestamp} from "./Timestamp";
+export {String} from "./String";
+export {Symbol} from "./Symbol";
+export {Blob} from "./Blob";
+export {Clob} from "./Clob";
+export {Struct} from "./Struct";
+export {List} from "./List";
+export {SExpression} from "./SExpression";

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -18,7 +18,7 @@ import {TextReader} from "../IonTextReader";
 import {BinaryReader} from "../IonBinaryReader";
 
 /**
- * Reads the provided ion data source into memory, constructing Value objects to represent
+ * Reads the provided Ion data source into memory, constructing Value objects to represent
  * each value found in the stream.
  *
  * This approach to reading is less efficient at runtime than using the streaming Reader API
@@ -44,8 +44,8 @@ export function loadAll(ionData: ReaderBuffer | Reader): Value[] {
 }
 
 /**
- * Reads the first value from the provided ion data source into memory, constructing
- * an Value object to represent it.
+ * Reads the first value from the provided Ion data source into memory, constructing
+ * a Value object to represent it.
  *
  * This approach to reading is less efficient at runtime than using the streaming Reader API
  * (next(), stepIn(), stepOut(), etc), but is often much simpler to use.
@@ -96,7 +96,7 @@ function _loadValue(reader: Reader): Value {
         case IonTypes.INT:
             return reader.intSize() == IntSize.Number
                 ? new Integer(reader.numberValue()!, annotations)
-                :  new Integer(reader.bigIntValue()!, annotations);
+                : new Integer(reader.bigIntValue()!, annotations);
         case IonTypes.FLOAT: return new Float(reader.numberValue()!, annotations);
         case IonTypes.DECIMAL: return new Decimal(reader.decimalValue()!, annotations);
         case IonTypes.TIMESTAMP: return new Timestamp(reader.timestampValue()!, annotations);

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -35,10 +35,8 @@ import {BinaryReader} from "../IonBinaryReader";
 export function loadAll(ionData: ReaderBuffer | Reader): Value[] {
     let reader = _createReader(ionData);
     let ionValues: Value[] = [];
-    let ionType: IonType | null = reader.next();
-    while (ionType !== null) {
+    while (reader.next()) {
         ionValues.push(_loadValue(reader));
-        ionType = reader.next();
     }
     return ionValues;
 }

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -1,0 +1,493 @@
+import {assert} from "chai";
+import JSBI from "jsbi";
+import * as ion from "../../src/Ion";
+import {IonTypes} from "../../src/Ion";
+import {Value} from "../../src/dom";
+import {encodeUtf8} from "../../src/IonUnicode";
+
+/**
+ * This file contains two tests for each Ion data type:
+ *   1.  'load() _______ as Value'
+ *       Demonstrates interacting with DOM nodes via the strongly-typed 'Value' interface.
+ *   2.  'load() _______ as any'
+ *       Demonstrates interacting with DOM nodes without type information (by casting them as 'any').
+ *
+ * A 'kitchen sink' example that loads a multi-value, heterogeneous Ion stream is also provided.
+ */
+
+describe('DOM', () => {
+   it('load() kitchen sink as Value[]', () => {
+      let values: Value[] = ion.loadAll(
+            ' 7' +
+            ' greeting::"Hello"' +
+            ' [\'moose\', null.string]' +
+            ' 5e1' +
+            ' {a: 2.1, b: 4, c: [foo, (bar baz), "qux"]}' +
+            ' 1970-01-01T00:00:00.000Z'
+      )!;
+
+      // 7
+      assert.equal(7, values[0].numberValue());
+
+      // greeting::"Hello"
+      assert.equal('Hello', values[1].stringValue());
+      assert.deepEqual(['greeting'], values[1].getAnnotations());
+
+      // ['moose', null.string]
+      assert.equal('moose', values[2].get(0)!.stringValue());
+      assert.isTrue(values[2].get(1)!.isNull());
+      assert.equal(IonTypes.STRING, values[2].get(1)!.getType());
+
+      // 5e1
+      assert.equal(50, values[3].numberValue());
+
+      // {a: 2.1, b: 4, c: [foo, (bar baz), "qux"]}
+      assert.equal(2.1, +values[4].get('a')!);
+      assert.equal(4, +values[4].get('b')!);
+      assert.equal('foo', ''+values[4].get('c')!.get(0));
+      assert.equal('bar', ''+values[4].get('c', 1, 0));
+      assert.equal('baz', ''+values[4].get('c', 1, 1));
+      assert.equal('qux', ''+values[4].get('c', 2));
+
+      // 1970-01-01T00:00:00.000Z
+      assert.equal(new Date(0).getTime(), values[5].dateValue()!.getTime());
+   });
+
+   it('load() kitchen sink as any[]', () => {
+      // This test casts each Ion value as an `any`, allowing each to be interacted with as a plain JS value.
+      let values: any[] = ion.loadAll(
+          ' 7' +
+          ' greeting::"Hello"' +
+          ' [\'moose\', null.string]' +
+          ' 5e1' +
+          ' {a: 2.1, b: 4, c: [foo, (bar baz), "qux"]}' +
+          ' 1970-01-01T00:00:00.000Z'
+      )!;
+
+      // 7
+      assert.equal(7, values[0]);
+
+      // greeting::"Hello"
+      assert.equal('Hello', values[1]);
+      assert.deepEqual(['greeting'], values[1].getAnnotations());
+
+      // ['moose', null.string]
+      assert.equal('moose', values[2][0]);
+      assert.isTrue(values[2][1].isNull());
+      assert.equal(IonTypes.STRING, values[2][1].getType());
+
+      // 5e1
+      assert.equal(50, values[3]);
+
+      // {a: 2.1, b: 4, c: [foo, (bar baz), "qux"]}
+      assert.equal(2.1, values[4].a);
+      assert.equal(4, values[4]['b']);
+      assert.equal('foo', values[4].c[0]);
+      assert.equal('bar', values[4].c[1][0]);
+      assert.equal('baz', values[4].c[1][1]);
+      assert.equal('qux', values[4].c[2]);
+
+      // 1970-01-01T00:00:00.000Z
+      assert.equal(new Date(0).getTime(), values[5].getTime());
+   });
+
+   it('load() Null as Value', () => {
+      let n = ion.load('null.blob')!;
+
+      assert.isTrue(n.isNull());
+      assert.equal(IonTypes.BLOB, n.getType());
+      assert.isNull(n.booleanValue());
+      assert.isNull(n.numberValue());
+      assert.isNull(n.bigIntValue());
+      assert.isNull(n.decimalValue());
+      assert.isNull(n.stringValue());
+      assert.isNull(n.dateValue());
+      assert.isNull(n.uInt8ArrayValue());
+      assert.isNull(n.fieldNames());
+      assert.isNull(n.fields());
+      assert.isNull(n.values());
+   });
+
+   // load() `Null` as `any` would be identical to the above.
+
+   it('load() Boolean as Value', () => {
+      let b: Value = ion.load('false')!;
+
+      assert.equal(false, b.booleanValue()!);
+      assert.equal(false, b.valueOf());
+      // Because ion.dom.Boolean is a class representation of a boolean, it does not behave like the
+      // primitive boolean type in some cases. See the class-level documentation for details.
+      assert.equal(true, !!b);
+   });
+
+   it('load() Boolean as any', () => {
+      let b: any = ion.load('false')!;
+
+      assert.equal(false, b.booleanValue()!);
+      assert.equal(false, b.valueOf());
+      // Because ion.dom.Boolean is a class representation of a boolean, it does not behave like the
+      // primitive boolean type in some cases. See the class-level documentation for details.
+      assert.equal(true, !!b);
+      assert.isTrue(b !== false);
+      assert.isTrue(b == false);
+      assert.isTrue(!!b);
+
+      if (b === false) {
+         assert.fail(null, null, 'Unreachable. b === false is not considered true.');
+      }
+
+      if (!b) {
+         assert.fail(null, null, 'Unreachable. !b is not considered true.');
+      }
+   });
+
+   it('load() Integer as Value', () => {
+      let i: Value = ion.load('foo::bar::7')!;
+
+      assert.equal(IonTypes.INT, i.getType());
+      assert.deepEqual(['foo', 'bar'], i.getAnnotations());
+
+      assert.equal(7, +i);
+      assert.equal(7, i.numberValue());
+
+      assert.isTrue(7 == +i);
+      assert.isTrue(7 === +i);
+      assert.isTrue(7 == i.numberValue());
+      assert.isTrue(7 === i.numberValue());
+
+      assert.isTrue(
+          JSBI.equal(
+              JSBI.BigInt(7),
+              i.bigIntValue()!
+          )
+      );
+   });
+
+   it('load() Integer as any', () => {
+      let i: any = ion.load('foo::bar::7')!;
+
+      assert.equal(IonTypes.INT, i.getType());
+      assert.deepEqual(['foo', 'bar'], i.getAnnotations());
+
+      assert.equal(8, i + 1);
+      assert.equal(49, i ** 2);
+      assert.equal(1, i / 7);
+      assert.equal(1, i / i);
+      assert.equal(14, i + i);
+      assert.equal(128, Math.pow(2, i));
+
+      assert.isTrue(
+          JSBI.equal(
+              JSBI.BigInt(7),
+              i.bigIntValue()
+          )
+      );
+   });
+
+   it('load() Float as Value', () => {
+      let f: Value = ion.load('baz::qux::15e-1')!;
+
+      assert.equal(IonTypes.FLOAT, f.getType());
+      assert.deepEqual(['baz', 'qux'], f.getAnnotations());
+
+      assert.equal(1.5, +f);
+      assert.equal(1.5, f.numberValue());
+
+      assert.isTrue(1.5 == +f);
+      assert.isTrue(1.5 === +f);
+      assert.isTrue(1.5 == f.numberValue());
+      assert.isTrue(1.5 === f.numberValue());
+   });
+
+   it('load() Float as any', () => {
+      let f: any = ion.load('baz::qux::15e-1')!;
+
+      assert.equal(IonTypes.FLOAT, f.getType());
+      assert.deepEqual(['baz', 'qux'], f.getAnnotations());
+
+      assert.equal(2.5, f + 1);
+      assert.equal(2.25, f ** 2);
+      assert.equal(1, f / 1.5);
+      assert.equal(1, f / f);
+      assert.equal(3, f + f);
+      assert.equal(2 ** 1.5, Math.pow(2, f));
+   });
+
+   it('load() Decimal as Value', () => {
+      let d: Value = ion.load('101.5')!;
+
+      assert.equal(IonTypes.DECIMAL, d.getType());
+
+      assert.equal(101.5, +d);
+      assert.equal(101.5, d.numberValue());
+      assert.isTrue(new ion.Decimal('101.5').equals(d.decimalValue()!));
+      assert.equal(1015, +d.decimalValue()!.getCoefficient());
+   });
+
+   it('load() Decimal as any', () => {
+      let d: any = ion.load('101.5')!;
+
+      assert.equal(IonTypes.DECIMAL, d.getType());
+
+      assert.equal(101.5, d);
+      assert.equal(101.5, +d);
+      assert.isTrue(new ion.Decimal('101.5').equals(d.decimalValue()));
+      assert.equal(1015, +d.decimalValue().getCoefficient());
+   });
+
+   it('load() Timestamp as Value', () => {
+      let t: Value = ion.load('DOB::2020-01-16T20:15:54.066Z')!;
+
+      assert.equal(IonTypes.TIMESTAMP, t.getType());
+      assert.deepEqual(['DOB'], t.getAnnotations());
+
+      assert.equal(
+          new Date('2020-01-16T20:15:54.066Z').getTime(),
+          t.dateValue()!.getTime()
+      );
+   });
+
+   it('load() Timestamp as any', () => {
+      let t: any = ion.load('DOB::2020-01-16T20:15:54.066Z')!;
+
+      assert.equal(IonTypes.TIMESTAMP, t.getType());
+      assert.deepEqual(['DOB'], t.getAnnotations());
+
+      assert.equal(
+          new Date('2020-01-16T20:15:54.066Z').getTime(),
+          t.getTime()
+      );
+   });
+
+   it('load() Symbol as Value', () => {
+      let s: Value = ion.load('foo::bar::"Saturn"')!;
+
+      assert.equal(IonTypes.STRING, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      assert.equal('Saturn', ''+s);
+      assert.equal('Saturn', s+'');
+      assert.equal('Saturn' + ', Jupiter', s + ', Jupiter');
+      assert.equal('Saturn'.substr(4), (''+s).substr(4));
+      assert.equal('Saturn'.substr(4), s.stringValue()!.substr(4));
+   });
+
+   it('load() Symbol as any', () => {
+      let s: any = ion.load('foo::bar::"Saturn"')!;
+
+      assert.equal(IonTypes.STRING, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      assert.equal('Saturn', s);
+      assert.equal('Saturn' + ', Jupiter', s + ', Jupiter');
+      assert.equal('Saturn'.substr(4), s.substr(4));
+   });
+
+   it('load() String as Value', () => {
+      let s: Value = ion.load('foo::bar::"Saturn"')!;
+
+      assert.equal(IonTypes.STRING, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      assert.equal('Saturn', ''+s);
+      assert.equal('Saturn', s+'');
+      assert.equal('Saturn' + ', Jupiter', s + ', Jupiter');
+      assert.equal('Saturn'.substr(4), (''+s).substr(4));
+      assert.equal('Saturn'.substr(4), s.stringValue()!.substr(4));
+   });
+
+   it('load() String as any', () => {
+      let s: any = ion.load('foo::bar::"Saturn"')!;
+
+      assert.equal(IonTypes.STRING, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      assert.equal('Saturn', s);
+      assert.equal('Saturn' + ', Jupiter', s + ', Jupiter');
+      assert.equal('Saturn'.substr(4), s.substr(4));
+   });
+
+   it('load() Clob as Value', () => {
+      let c: Value = ion.load('month::{{"February"}}')!;
+
+      assert.equal(IonTypes.CLOB, c.getType());
+      assert.deepEqual(['month'], c.getAnnotations());
+
+      assert.deepEqual(encodeUtf8("February"), c.uInt8ArrayValue()!);
+   });
+
+   it('load() Clob as any', () => {
+      let c: any = ion.load('month::{{"February"}}')!;
+
+      assert.equal(IonTypes.CLOB, c.getType());
+      assert.deepEqual(['month'], c.getAnnotations());
+
+      assert.deepEqual(encodeUtf8("February"), c);
+   });
+
+   it('load() Blob as Value', () => {
+      let b: Value = ion.load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
+
+      assert.equal(IonTypes.BLOB, b.getType());
+      assert.deepEqual(['quote'], b.getAnnotations());
+
+      assert.deepEqual(encodeUtf8("To infinity... and beyond!"), b.uInt8ArrayValue());
+   });
+
+   it('load() Blob as any', () => {
+      let b: any = ion.load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
+
+      assert.equal(IonTypes.BLOB, b.getType());
+      assert.deepEqual(['quote'], b.getAnnotations());
+
+      assert.deepEqual(encodeUtf8("To infinity... and beyond!"), b);
+   });
+
+   it('load() List as Value', () => {
+      let l: Value = ion.load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
+
+      assert.equal(IonTypes.LIST, l.getType());
+      assert.deepEqual(['planets'], l.getAnnotations());
+
+      // Iteration
+      for (let planet of l.values()!) {
+         assert.isNotNull(planet.stringValue());
+      }
+
+      // Indexing
+      assert.equal("Mercury", l.get(0)!.stringValue());
+      assert.equal("Venus", l.get(1)!.stringValue());
+      assert.equal("Earth",l.get(2)!.stringValue());
+      assert.equal("Mars", l.get(3)!.stringValue());
+
+      let planets: string[] = [...l.values()!].map(s => s.stringValue()!);
+      assert.equal(4, planets.length);
+   });
+
+   it('load() List as any', () => {
+      let l: any = ion.load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
+
+      assert.equal(IonTypes.LIST, l.getType());
+      assert.deepEqual(['planets'], l.getAnnotations());
+
+      // Iteration
+      for (let planet of l) {
+         assert.isTrue(planet instanceof String);
+      }
+
+      // Indexing
+      assert.equal("Mercury", l[0]);
+      assert.equal("Venus", l[1]);
+      assert.equal("Earth", l[2]);
+      assert.equal("Mars", l[3]);
+
+      assert.equal(4, l.length);
+
+      // Directly use Array methods
+      assert.isTrue(l.findIndex(s => s == "Earth") > 0);
+      assert.isNotNull(l.find(s => s == "Earth"));
+   });
+
+   it('load() SExpression as Value', () => {
+      let s: Value = ion.load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
+
+      assert.equal(IonTypes.SEXP, s.getType());
+      assert.deepEqual(['planets'], s.getAnnotations());
+
+      // Iteration
+      for (let planet of s.values()!) {
+         assert.isNotNull(planet.stringValue());
+      }
+
+      // Indexing
+      assert.equal("Mercury", s.get(0)!.stringValue());
+      assert.equal("Venus", s.get(1)!.stringValue());
+      assert.equal("Earth",s.get(2)!.stringValue());
+      assert.equal("Mars", s.get(3)!.stringValue());
+
+      let planets: string[] = [...s.values()!].map(s => s.stringValue()!);
+      assert.equal(4, planets.length);
+   });
+
+   it('load() SExpression as any', () => {
+      let s: any = ion.load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
+
+      assert.equal(IonTypes.SEXP, s.getType());
+      assert.deepEqual(['planets'], s.getAnnotations());
+
+      // Iteration
+      for (let planet of s) {
+         assert.isTrue(planet instanceof String);
+      }
+
+      // Indexing
+      assert.equal("Mercury", s[0]);
+      assert.equal("Venus", s[1]);
+      assert.equal("Earth", s[2]);
+      assert.equal("Mars", s[3]);
+
+      assert.equal(4, s.length);
+
+      // Directly use Array methods
+      assert.isTrue(s.findIndex(s => s == "Earth") > 0);
+      assert.isNotNull(s.find(s => s == "Earth"));
+   });
+
+   it('load() Struct as Value', () => {
+      let s: Value = ion.load(
+          'foo::bar::{' +
+            'name: {' +
+               'first: "John", ' +
+               'middle: "Jacob", ' +
+               'last: "Jingleheimer-Schmidt",' +
+            '},' +
+            'age: 41' +
+          '}'
+      )!;
+
+      assert.equal(IonTypes.STRUCT, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      // Field access
+      assert.equal("Jacob", s.get("name")!.get("middle")!.stringValue());
+      assert.equal("Jacob", s.get("name", "middle")!.stringValue());
+
+      // Iteration
+      for (let [fieldName, value] of s.fields()!) {
+         assert.isTrue(typeof fieldName === "string");
+         assert.isTrue(fieldName.length > 0);
+         assert.isFalse(value.isNull());
+      }
+
+      assert.equal(2, [...s.fields()!].length)
+   });
+
+   it('load() Struct as any', () => {
+      let s: any = ion.load(
+          'foo::bar::{' +
+          'name: {' +
+          'first: "John", ' +
+          'middle: "Jacob", ' +
+          'last: "Jingleheimer-Schmidt",' +
+          '},' +
+          'age: 41' +
+          '}'
+      )!;
+
+      assert.equal(IonTypes.STRUCT, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      // Field access
+      assert.equal("Jacob", s.name.middle);
+      assert.equal("Jacob", s["name"]["middle"]);
+
+      // Iteration
+      for (let [fieldName, value] of s.fields()!) {
+         assert.isTrue(typeof fieldName === "string");
+         assert.isTrue(fieldName.length > 0);
+         assert.isFalse(value.isNull());
+      }
+
+      assert.equal(2, [...s.fields()!].length)
+   });
+});

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -95,17 +95,19 @@ describe('DOM', () => {
       let n = ion.load('null.blob')!;
 
       assert.isTrue(n.isNull());
-      assert.equal(IonTypes.BLOB, n.getType());
-      assert.isNull(n.booleanValue());
-      assert.isNull(n.numberValue());
-      assert.isNull(n.bigIntValue());
-      assert.isNull(n.decimalValue());
-      assert.isNull(n.stringValue());
-      assert.isNull(n.dateValue());
       assert.isNull(n.uInt8ArrayValue());
-      assert.isNull(n.fieldNames());
-      assert.isNull(n.fields());
-      assert.isNull(n.values());
+      assert.equal(IonTypes.BLOB, n.getType());
+      assert.isTrue(n instanceof ion.dom.Null);
+
+      assert.throws(() => n.booleanValue());
+      assert.throws(() => n.numberValue());
+      assert.throws(() => n.bigIntValue());
+      assert.throws(() => n.decimalValue());
+      assert.throws(() => n.stringValue());
+      assert.throws(() => n.dateValue());
+      assert.throws(() => n.fieldNames());
+      assert.throws(() => n.fields());
+      assert.throws(() => n.elements());
    });
 
    // load() `Null` as `any` would be identical to the above.
@@ -232,7 +234,7 @@ describe('DOM', () => {
       assert.equal(101.5, d);
       assert.equal(101.5, +d);
       assert.isTrue(new ion.Decimal('101.5').equals(d.decimalValue()));
-      assert.equal(1015, +d.decimalValue().getCoefficient());
+      assert.equal(1015, +d.decimalValue()!.getCoefficient());
    });
 
    it('load() Timestamp as Value', () => {
@@ -350,17 +352,17 @@ describe('DOM', () => {
       assert.deepEqual(['planets'], l.getAnnotations());
 
       // Iteration
-      for (let planet of l.values()!) {
+      for (let planet of l.elements()!) {
          assert.isNotNull(planet.stringValue());
       }
 
       // Indexing
-      assert.equal("Mercury", l.get(0)!.stringValue());
-      assert.equal("Venus", l.get(1)!.stringValue());
-      assert.equal("Earth",l.get(2)!.stringValue());
-      assert.equal("Mars", l.get(3)!.stringValue());
+      assert.equal("Mercury", l.get(0)?.stringValue());
+      assert.equal("Venus", l.get(1)?.stringValue());
+      assert.equal("Earth",l.get(2)?.stringValue());
+      assert.equal("Mars", l.get(3)?.stringValue());
 
-      let planets: string[] = [...l.values()!].map(s => s.stringValue()!);
+      let planets: string[] = l.elements().map(s => s.stringValue()!);
       assert.equal(4, planets.length);
    });
 
@@ -395,17 +397,17 @@ describe('DOM', () => {
       assert.deepEqual(['planets'], s.getAnnotations());
 
       // Iteration
-      for (let planet of s.values()!) {
+      for (let planet of s.elements()!) {
          assert.isNotNull(planet.stringValue());
       }
 
       // Indexing
-      assert.equal("Mercury", s.get(0)!.stringValue());
-      assert.equal("Venus", s.get(1)!.stringValue());
-      assert.equal("Earth",s.get(2)!.stringValue());
-      assert.equal("Mars", s.get(3)!.stringValue());
+      assert.equal("Mercury", s.get(0)?.stringValue());
+      assert.equal("Venus", s.get(1)?.stringValue());
+      assert.equal("Earth",s.get(2)?.stringValue());
+      assert.equal("Mars", s.get(3)?.stringValue());
 
-      let planets: string[] = [...s.values()!].map(s => s.stringValue()!);
+      let planets: string[] = s.elements().map(s => s.stringValue()!);
       assert.equal(4, planets.length);
    });
 
@@ -453,13 +455,13 @@ describe('DOM', () => {
       assert.equal("Jacob", s.get("name", "middle")!.stringValue());
 
       // Iteration
-      for (let [fieldName, value] of s.fields()!) {
+      for (let [fieldName, value] of s.fields()) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
          assert.isFalse(value.isNull());
       }
 
-      assert.equal(2, [...s.fields()!].length)
+      assert.equal(2, s.fields().length);
    });
 
    it('load() Struct as any', () => {
@@ -482,12 +484,12 @@ describe('DOM', () => {
       assert.equal("Jacob", s["name"]["middle"]);
 
       // Iteration
-      for (let [fieldName, value] of s.fields()!) {
+      for (let [fieldName, value] of s) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
          assert.isFalse(value.isNull());
       }
 
-      assert.equal(2, [...s.fields()!].length)
+      assert.equal(2, s.fields().length)
    });
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,3 +3,4 @@
 --require source-map-support/register
 
 test/*.ts
+test/dom/*.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "lib": ["es6"],
+    "lib": ["es6", "es2017.object"],
     "declaration": true,
     "inlineSources": true,
     "sourceMap": true,


### PR DESCRIPTION
*Issue #, if available:* #531 

*Description of changes:*

Currently, `ion-js` only provides a streaming `Reader` API to access values in an Ion stream. This API is efficient, but has a rather steep learning curve and can often require verbose code. This PR creates a DOM-style API for loading values from an Ion stream into memory, allowing users to interact with them as they would any other JS value/Array/Object.

### `load()` and `loadAll()`

Two new top-level functions have been introduced:

```typescript
// Loads the first value from the provided data source (if present) and returns it
load(ionData: ReaderBuffer | Reader): Value | null

// Loads all of the values found in the provided data source and returns them
loadAll(ionData: ReaderBuffer | Reader): Value[]
```

### Javascript (`any`) interface

Each Ion data type is represented by a new class that extends an existing Javascript type:
* `dom.List` extends `Array`
* `dom.Integer` extends `Number`
* `dom.Timestamp` extends `Date`
* ....

This means that in most cases, you can treat values returned by `load()` the same way you would treat a standard Javascript equivalent.

```typescript
// Ion integer
let i: any = ion.load('7');
assert.equal(7, i);
assert.equal(8, i + 1);
assert.equal(49, i ** 2);
assert.equal(1, i / 7);
```

```typescript
// Ion string
let s: any = ion.load('"Saturn"');
assert.equal('Saturn', s);
assert.equal('Saturn' + ', Jupiter', s + ', Jupiter');
assert.equal('Saturn'.substr(4), s.substr(4));
assert.isNotNull(s.match(/atu/));
```

```typescript
// Ion list
let l: any = ion.load('[0, 2, 4, 6, 8, 10]');
assert.equal(4, l[2]);
assert.equal(6, l.length);
// iteration example
for (let value of l) {
    assert.isTrue(value % 2 == 0);
}
// Direct access to Array methods
assert.equal(30, l.reduce((sum, value) => sum + value, 0));
```

```typescript
// Ion struct
let person: any = ion.load(
  'person::{' +
      'name: {' +
          'first: "John", ' +
          'middle: "Jacob", ' +
          'last: "Jingleheimer-Schmidt",' +
     '},' +
     'age: 41' +
  '}'
);
assert.equal(41, person.age);
assert.equal(41, person['age']);
assert.equal('Jacob', person.name.middle);
for (let [key, value] of person) { // Iteration
    console.log(name + ': ' + value);
}
```

### Typescript (`Value`) interface

The Javascript API above is concise and convenient, but does not offer any static type safety. Each of the new classes in this PR also implements a new interface called `dom.Value`, which provides methods for indexing into Ion values as well as converting them to JS representations.

```typescript
// Ion integer
// `i` is an implementation of the Value interface. To use it, we'll need to
// be explicit about our coercions to JS types in order to satisfy 
// the Typescript compiler.
let i: Value = ion.load('7');

// The unary '+' operator will coerce our dom.Integer into a JS number
assert.equal(7, +i);
// We can explicitly convert this value to a JS number
assert.equal(7, i.numberValue()); 

// dom.Integer is not a text value, so there is no string value associated with it.
assert.isNull(i.stringValue());
```

```typescript
// Ion list
let l: Value = ion.load('[0, 2, 4, 6, 8, 10]');

// We can use the `get()` method to index into the Value
assert.equal(4, l.get(2));

// iteration example using the `values()` method
for (let value of l.values()!) {
    assert.isTrue(value % 2 == 0);
}
```

```typescript
// Ion struct
let person: Value = ion.load(
  'person::{' +
      'name: {' +
          'first: "John", ' +
          'middle: "Jacob", ' +
          'last: "Jingleheimer-Schmidt",' +
     '},' +
     'age: 41' +
  '}'
)!;
assert.equal(41, person.get('age'));
assert.equal('Jacob', person.get('name', 'middle'));

// Iteration example using the `fields()` method
for (let [key, value] of person.fields()) {
    console.log(name + ': ' + value);
}
```

### Recommended reading order

I suggest reading the following files first:
1. `src/dom/Value.ts`: All of the new classes introduced in this PR implement this interface.
2. `src/dom/DomValue.ts`: Serves as a common default implementation for the `Value` interface.
3. `src/dom/index.ts`: Defines the `load()` and `loadAll()` methods. 
4. `test/dom/dom.ts`: Demonstrates how to work with each data type after `load()`ing some Ion data.

The rest of the files contain class definitions for each Ion type and are pretty straightforward.

### Notes
1. I tested out a few different naming conventions before settling on using the plain Ion type names themselves grouped under the `dom` module. There are some name collisions that are easily remedied via package qualifiers or custom import aliases:
  * `ion.dom.String` vs `global.String`
  * `ion.dom.Boolean` vs `global.Boolean`
  * `ion.dom.Decimal` vs `ion.Decimal`
  * `ion.dom.Timestamp` vs `ion.Timestamp`
1. The provided implementation of `toString()` does not attempt to produce valid Ion. Overriding `toString()` in classes that extend `String` (i.e. `dom.String`, `dom.Symbol`) causes some `String` functionality (e.g. the `match` method) to break.

### Follow-on work
1. We still need to provide an `ion.dump(...)` method to perform the inverse of `ion.load()`. I held off on this to confirm that the API proposed in this PR is acceptable.
1. There are some `TODO`s in this code that will be turned into `ion-js` issues after the PR gets merged. Another PR will add the issue links to the comments.
1. There are some constructors that could/should take a wider variety of data types. For example, it should be possible to create a `dom.Decimal` from a `number`. However, this is not required for use of the `load()` API.
1. Once an `ion.dump()` method is available, we should design a formal integration with `ion-tests`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
