### PR TITLE
dom.Value.from(jsValue) API

### DIFF
--- a/src/dom/Blob.ts
+++ b/src/dom/Blob.ts
@@ -1,12 +1,12 @@
-import {Value} from "./Value";
 import {IonTypes} from "../Ion";
+import {Lob} from "./Lob";
 
 /**
  * Represents a blob[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#blob
  */
-export class Blob extends Value(Uint8Array, IonTypes.BLOB) {
+export class Blob extends Lob(IonTypes.BLOB) {
 
     /**
      * Constructor.
@@ -14,11 +14,6 @@ export class Blob extends Value(Uint8Array, IonTypes.BLOB) {
      * @param annotations   An optional array of strings to associate with `data`.
      */
     constructor(data: Uint8Array, annotations: string[] = []) {
-        super(data);
-        this._setAnnotations(annotations);
-    }
-
-    uInt8ArrayValue(): Uint8Array {
-        return this;
+        super(data, annotations);
     }
 }

--- a/src/dom/Boolean.ts
+++ b/src/dom/Boolean.ts
@@ -1,5 +1,11 @@
 import {IonTypes} from "../Ion";
 import {Value} from "./Value";
+import {FromJsConstructor, FromJsConstructorBuilder, Primitives} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withPrimitives(Primitives.Boolean)
+    .withClassesToUnbox(global.Boolean)
+    .build();
 
 /**
  * Represents a boolean[1] value in an Ion stream.
@@ -25,7 +31,7 @@ import {Value} from "./Value";
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#bool
  * [2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
  */
-export class Boolean extends Value(global.Boolean, IonTypes.BOOL) {
+export class Boolean extends Value(global.Boolean, IonTypes.BOOL, _fromJsConstructor) {
 
     /**
      * Constructor.

--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -1,23 +1,18 @@
 import {IonTypes} from "../Ion";
-import {Value} from "./Value";
+import {Lob} from "./Lob";
 
 /**
  * Represents a clob[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#clob
  */
-export class Clob extends Value(Uint8Array, IonTypes.CLOB) {
+export class Clob extends Lob(IonTypes.CLOB) {
     /**
      * Constructor.
      * @param bytes         Raw, unsigned bytes to represent as a clob.
      * @param annotations   An optional array of strings to associate with `bytes`.
      */
     constructor(bytes: Uint8Array, annotations: string[] = []) {
-        super(bytes);
-        this._setAnnotations(annotations);
-    }
-
-    uInt8ArrayValue(): Uint8Array {
-        return this;
+        super(bytes, annotations);
     }
 }

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -1,13 +1,18 @@
 import {Value} from "./Value";
-import {IonTypes} from "../Ion";
 import * as ion from "../Ion";
+import {IonTypes} from "../Ion";
+import {FromJsConstructor, FromJsConstructorBuilder} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withClasses(ion.Decimal)
+    .build();
 
 /**
  * Represents a decimal[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#decimal
  */
-export class Decimal extends Value(Number, IonTypes.DECIMAL) {
+export class Decimal extends Value(Number, IonTypes.DECIMAL, _fromJsConstructor) {
     private readonly _decimalValue: ion.Decimal;
     private readonly _numberValue: number;
 

--- a/src/dom/Float.ts
+++ b/src/dom/Float.ts
@@ -1,12 +1,18 @@
 import {IonTypes} from "../Ion";
 import {Value} from "./Value";
+import {FromJsConstructor, FromJsConstructorBuilder, Primitives} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withPrimitives(Primitives.Number)
+    .withClassesToUnbox(Number)
+    .build();
 
 /**
  * Represents a float[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#float
  */
-export class Float extends Value(Number, IonTypes.FLOAT) {
+export class Float extends Value(Number, IonTypes.FLOAT, _fromJsConstructor) {
 
     /**
      * Constructor.

--- a/src/dom/FromJsConstructor.ts
+++ b/src/dom/FromJsConstructor.ts
@@ -1,0 +1,140 @@
+import {Constructor, Value} from "./Value";
+import {dom, IonTypes} from "../Ion";
+import {_hasValue} from "../util";
+
+// Converts the provided Iterable into a Set. If no iterable is provided, returns an empty set.
+function _newSet<T>(values?: Iterable<T>): Set<T> {
+    if (_hasValue(values)) {
+        return new Set<T>(values);
+    }
+    return new Set<T>();
+}
+
+/**
+ * Builder to configure and instantiate FromJsConstructor objects. See the documentation for
+ * the FromJsConstructor class for a description of each field.
+ *
+ * Package-visible for use in dom.Value subclass definitions.
+ * @private
+ */
+export class FromJsConstructorBuilder {
+    private _primitives: Set<string>;
+    private _classesToUnbox: Set<Constructor>;
+    private _classes: Set<Constructor>;
+
+    constructor() {
+        this._primitives = _newSet();
+        this._classesToUnbox = _newSet();
+        this._classes = _newSet();
+    }
+
+    withPrimitives(...primitives: string[]): FromJsConstructorBuilder {
+        this._primitives = _newSet(primitives);
+        return this;
+    }
+
+    withClasses(...classes: Constructor[]): FromJsConstructorBuilder {
+        this._classes = _newSet(classes);
+        return this;
+    }
+
+    withClassesToUnbox(...classes: Constructor[]): FromJsConstructorBuilder {
+        this._classesToUnbox = _newSet(classes);
+        return this;
+    }
+
+    build(): FromJsConstructor {
+        return new FromJsConstructor(this._primitives, this._classesToUnbox, this._classes);
+    }
+}
+
+/**
+ * Provides common conversion and validation logic needed to instantiate subclasses of dom.Value
+ * from a given Javascript value of unknown type (`any`) and an optional annotations array.
+ *
+ * Given a Javascript value, will test its type to see whether it is:
+ * 1. A primitive that is supported by the specified constructor.
+ * 2. A boxed primitive that is supported by the specified constructor if unboxed via `valueOf()`.
+ * 3. A class that is supported by the specified constructor as-is, including boxed primitives.
+ *
+ * If the value matches any of the above descriptions, the provided constructor will be invoked
+ * with the value; otherwise, throws an Error.
+ *
+ * Constructors are expected to be compatible with the signature:
+ *
+ *      constructor(value, annotations: string[]): ClassName
+ *
+ * See also: Value._fromJsValue()
+ */
+export class FromJsConstructor {
+    // Useful for dom.Value subclasses that do not use a FromJsConstructor (e.g. Struct, List)
+    // Because it has no supported types, any attempt to use this instance will throw an Error.
+    public static NONE: FromJsConstructor = new FromJsConstructorBuilder().build();
+
+    /**
+     * Constructor.
+     *
+     * @param _primitives       Primitive types that will be passed through as-is.
+     * @param _classesToUnbox   Boxed primitive types that will be converted to primitives via
+     *                          `valueOf()` and then passed through.
+     * @param _classes          Classes that will be passed through as-is.
+     */
+    constructor(
+        private readonly _primitives: Set<string>,
+        private readonly _classesToUnbox: Set<Constructor>,
+        private readonly _classes: Set<Constructor>
+    ) {}
+
+    /**
+     * Invokes the provided constructor if `jsValue` is of a supported data type; otherwise
+     * throws an Error.
+     *
+     * @param constructor   A dom.Value subclass's constructor to call.
+     * @param jsValue       A Javascript value to validate/unbox before passing through to
+     *                      the constructor.
+     * @param annotations   An optional array of strings to associate with the newly constructed
+     *                      dom.Value.
+     */
+    construct(constructor: any, jsValue: any, annotations: string[] = []): Value {
+        if (jsValue === null) {
+            return new dom.Null(IonTypes.NULL, annotations);
+        }
+
+        let jsValueType = typeof(jsValue);
+        if (jsValueType === "object") {
+            // jsValue is an unsupported boxed primitive, but we can use it if we convert it to a primitive first
+            if (this._classesToUnbox.has(jsValue.constructor)) {
+                return new constructor(jsValue.valueOf(), annotations);
+            }
+
+            // jsValue is an Object of a supported type, including boxed primitives
+            if (this._classes.has(jsValue.constructor)) {
+                return new constructor(jsValue, annotations);
+            }
+
+            throw new Error(`Unable to construct a(n) ${constructor.name} from a ${jsValue.constructor.name}.`);
+        }
+
+        if (this._primitives.has(jsValueType)) {
+            return new constructor(jsValue, annotations);
+        }
+
+        throw new Error(`Unable to construct a(n) ${constructor.name} from a ${jsValueType}.`);
+    }
+}
+
+/**
+ * A mapping of primitive types to the corresponding string that will be returned by
+ * the `typeof` operator.
+ */
+export const Primitives = {
+    /*
+     * Some possible values are not included because they are unsupported. In particular:
+     *   - "object" indicates that a value is not a primitive.
+     *   - The mapping from Javascript's "symbol" to Ion's type system is not yet clear.
+     *   - No constructors accept "undefined" as a parameter.
+     */
+    Boolean: "boolean",
+    Number: "number",
+    String: "string"
+};

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -1,13 +1,26 @@
 import JSBI from "jsbi";
 import {IonTypes} from "../Ion";
-import {Value} from "./Value";
+import {Constructor, Value} from "./Value";
+import {FromJsConstructor, FromJsConstructorBuilder, Primitives} from "./FromJsConstructor";
+
+// JSBI is an irregular class type in that it provides no constructor, only static
+// constructor methods. This means that while it is a class type and `instanceof JSBI`
+// works as expected, the JSBI class does not conform to the typical Constructor
+// interface of new(...args) => any. Because FromJsConstructor will only use it for
+// instanceof tests, we can safely cast it as a Constructor to satisfy the compiler.
+let _jsbiConstructor: Constructor = JSBI as unknown as Constructor;
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withPrimitives(Primitives.Number)
+    .withClassesToUnbox(Number)
+    .withClasses(_jsbiConstructor)
+    .build();
 
 /**
  * Represents an integer value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#int
  */
-export class Integer extends Value(Number, IonTypes.INT) {
+export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
     private _bigIntValue: JSBI | null;
     private _numberValue: number;
 

--- a/src/dom/JsValueConversion.ts
+++ b/src/dom/JsValueConversion.ts
@@ -1,0 +1,142 @@
+import {IonType} from "../IonType";
+import {IonTypes} from "../IonTypes";
+import {Decimal, dom, Timestamp} from "../Ion";
+import {Constructor, Value} from "./Value";
+import JSBI from "jsbi";
+import {_hasValue} from "../util";
+
+
+// When Typescript is compiling this code, dom/index.ts depends on Value.ts which in turn
+// depends on this file. This means that 'dom' is still being defined and we cannot yet
+// reference any of the Value subtypes (dom.Integer, dom.String, etc). We can sidestep this
+// issue by lazily initializing this mapping, deferring any reference to those types until
+// they are first used.
+let _domTypesByIonType: Map<IonType, Constructor> | null = null;
+
+// Lazily initializes our IonType -> Dom type constructor mapping.
+function _getDomTypesByIonTypeMap(): Map<IonType, Constructor> {
+    if (_domTypesByIonType === null) {
+        // Clob, SExpression, and Symbol are not included here as _inferType always
+        // favors Blob, List, and String respectively.
+        _domTypesByIonType = new Map<IonType,  Constructor>([
+            [IonTypes.NULL,  dom.Null],
+            [IonTypes.BOOL,  dom.Boolean],
+            [IonTypes.INT,  dom.Integer],
+            [IonTypes.FLOAT, dom.Float],
+            [IonTypes.DECIMAL, dom.Decimal],
+            [IonTypes.TIMESTAMP, dom.Timestamp],
+            [IonTypes.STRING, dom.String],
+            [IonTypes.BLOB,  dom.Blob],
+            [IonTypes.LIST, dom.List],
+            [IonTypes.STRUCT, dom.Struct],
+        ]);
+    }
+    return _domTypesByIonType;
+}
+
+// Returns a dom type constructor for the provided IonType.
+// This function is exported to assist in unit testing but is not visible at the library level.
+export function _domConstructorFor(ionType: IonType): Constructor {
+    let domConstructor = _getDomTypesByIonTypeMap().get(ionType)!;
+    if (!_hasValue(domConstructor)) {
+        throw new Error(`No dom type constructor was found for Ion type ${ionType.name}`);
+    }
+    return domConstructor;
+}
+
+// Examines the provided JS value and returns the IonType best suited to represent it.
+// This function will never return Clob, SExpression, and Symbol; it will always
+// favor Blob, List, and String respectively.
+function _inferType(value: any): IonType {
+    if (value === undefined) {
+        throw new Error("Cannot create an Ion value from `undefined`.");
+    }
+    if (value === null) {
+        return IonTypes.NULL;
+    }
+
+    let valueType: string = typeof(value);
+    switch (valueType) {
+        case "string":
+            return IonTypes.STRING;
+        case "number":
+            return Number.isInteger(value)
+                ? IonTypes.INT
+                : IonTypes.FLOAT;
+        case "boolean":
+            return IonTypes.BOOL;
+        case "object":
+            break;
+        // We `break` here to defer handling native bigints to the 'valueof JSBI' test below,
+        // which will handle native bigints correctly if Babel is being used to convert JSBI
+        // logic to native bigint logic.
+        case "bigint":
+            break;
+
+        //
+        // TODO: Javascript symbols are not a 1:1 match for Ion symbols, but we may wish
+        //       to support them in Value.from() anyway.
+        case "symbol":
+        default:
+            throw new Error(`Value.from() does not support the JS primitive type ${valueType}.`);
+    }
+
+    // If `value` is a native bigint but we're not using Babel for native bigint support, we need to
+    // throw an Error.
+    //
+    // If Babel is being used, this test becomes:
+    //      typeof(value) === 'bigint'
+    // which will return true for native bigints, leading to the creation of an Integer.
+    //
+    // If Babel is not being used, then this remains a JSBI instanceof test, which will
+    // return false for native bigints.
+    if (value instanceof JSBI) {
+        return IonTypes.INT;
+    } else if (typeof(value) === 'bigint') {
+        // If Babel is being used, this check will be identical to the one above it and it will
+        // never be reached. If Babel is not being used, this test will return true for native
+        // bigints (which aren't supported without Babel) while allowing other Object types
+        // to be processed below.
+        throw new Error('bigints are not supported without using Babel for JSBI compilation.');
+    }
+    if (value instanceof String) {
+        return IonTypes.STRING;
+    }
+    if (value instanceof Decimal) {
+        return IonTypes.DECIMAL;
+    }
+    if (value instanceof Date || value instanceof Timestamp) {
+        return IonTypes.TIMESTAMP;
+    }
+    if (value instanceof Uint8Array) {
+        return IonTypes.BLOB;
+    }
+    if (value instanceof Array) {
+        return IonTypes.LIST;
+    }
+    return IonTypes.STRUCT;
+}
+
+// Inspects the provided JS value and constructs a new instance of the appropriate Ion
+// type using that value.
+export function _ionValueFromJsValue(value: any, annotations: string[] = []): Value {
+    let ionType = _inferType(value);
+    switch (ionType) {
+        case IonTypes.NULL:
+            return new dom.Null(IonTypes.NULL, annotations);
+        case IonTypes.LIST:
+            return new dom.List(
+                value.map(child => Value.from(child)),
+                annotations
+            );
+        case IonTypes.STRUCT:
+            return new dom.Struct(
+                Object.entries(value)
+                    .map(([key, value]) => [key, Value.from(value)]),
+                annotations
+            );
+        default:
+            let ionTypeConstructor: Constructor = _domConstructorFor(ionType);
+            return new ionTypeConstructor(value, annotations) as Value;
+    }
+}

--- a/src/dom/JsValueConversion.ts
+++ b/src/dom/JsValueConversion.ts
@@ -1,32 +1,45 @@
 import {IonType} from "../IonType";
 import {IonTypes} from "../IonTypes";
 import {Decimal, dom, Timestamp} from "../Ion";
-import {Constructor, Value} from "./Value";
+import {Value} from "./Value";
 import JSBI from "jsbi";
 import {_hasValue} from "../util";
 
+// Typescript interfaces can be used to describe classes' static methods; this can
+// be a bit surprising as the methods in the interface are not marked 'static' and
+// the class definition does not need to indicate that it implements this interface.
+//
+// This interface describes classes that offer a static constructor that accepts an
+// untyped Javascript value and an optional annotations array as its parameter. Because
+// the dom.Value mixin provides a default implementation of this method, all dom.Value
+// subtypes implicitly implement this interface.
+//
+// Package visible for testing.
+export interface FromJsValue {
+    _fromJsValue(jsValue: any, annotations: string[]): Value;
+}
 
 // When Typescript is compiling this code, dom/index.ts depends on Value.ts which in turn
 // depends on this file. This means that 'dom' is still being defined and we cannot yet
 // reference any of the Value subtypes (dom.Integer, dom.String, etc). We can sidestep this
 // issue by lazily initializing this mapping, deferring any reference to those types until
 // they are first used.
-let _domTypesByIonType: Map<IonType, Constructor> | null = null;
+let _domTypesByIonType: Map<IonType, FromJsValue> | null = null;
 
 // Lazily initializes our IonType -> Dom type constructor mapping.
-function _getDomTypesByIonTypeMap(): Map<IonType, Constructor> {
+function _getDomTypesByIonTypeMap(): Map<IonType, FromJsValue> {
     if (_domTypesByIonType === null) {
         // Clob, SExpression, and Symbol are not included here as _inferType always
         // favors Blob, List, and String respectively.
-        _domTypesByIonType = new Map<IonType,  Constructor>([
-            [IonTypes.NULL,  dom.Null],
-            [IonTypes.BOOL,  dom.Boolean],
-            [IonTypes.INT,  dom.Integer],
+        _domTypesByIonType = new Map<IonType, FromJsValue>([
+            [IonTypes.NULL, dom.Null],
+            [IonTypes.BOOL, dom.Boolean],
+            [IonTypes.INT, dom.Integer],
             [IonTypes.FLOAT, dom.Float],
             [IonTypes.DECIMAL, dom.Decimal],
             [IonTypes.TIMESTAMP, dom.Timestamp],
             [IonTypes.STRING, dom.String],
-            [IonTypes.BLOB,  dom.Blob],
+            [IonTypes.BLOB, dom.Blob],
             [IonTypes.LIST, dom.List],
             [IonTypes.STRUCT, dom.Struct],
         ]);
@@ -36,7 +49,7 @@ function _getDomTypesByIonTypeMap(): Map<IonType, Constructor> {
 
 // Returns a dom type constructor for the provided IonType.
 // This function is exported to assist in unit testing but is not visible at the library level.
-export function _domConstructorFor(ionType: IonType): Constructor {
+export function _domConstructorFor(ionType: IonType): FromJsValue {
     let domConstructor = _getDomTypesByIonTypeMap().get(ionType)!;
     if (!_hasValue(domConstructor)) {
         throw new Error(`No dom type constructor was found for Ion type ${ionType.name}`);
@@ -67,20 +80,19 @@ function _inferType(value: any): IonType {
             return IonTypes.BOOL;
         case "object":
             break;
-        // We `break` here to defer handling native bigints to the 'valueof JSBI' test below,
-        // which will handle native bigints correctly if Babel is being used to convert JSBI
-        // logic to native bigint logic.
         case "bigint":
             break;
-
-        //
+            // ^-- We `break` here to defer handling native bigints to the 'valueof JSBI' test below,
+            // which will handle native bigints correctly if Babel is being used to convert JSBI
+            // logic to native bigint logic.
         // TODO: Javascript symbols are not a 1:1 match for Ion symbols, but we may wish
         //       to support them in Value.from() anyway.
-        case "symbol":
+        // case "symbol":
         default:
             throw new Error(`Value.from() does not support the JS primitive type ${valueType}.`);
     }
 
+    // TODO: Use the code below to create an easy-to-undesrtand _babelIsEnabled() test.
     // If `value` is a native bigint but we're not using Babel for native bigint support, we need to
     // throw an Error.
     //
@@ -98,6 +110,14 @@ function _inferType(value: any): IonType {
         // bigints (which aren't supported without Babel) while allowing other Object types
         // to be processed below.
         throw new Error('bigints are not supported without using Babel for JSBI compilation.');
+    }
+    if (value instanceof Number) {
+        return Number.isInteger(value.valueOf())
+            ? IonTypes.INT
+            : IonTypes.FLOAT;
+    }
+    if (value instanceof Boolean) {
+        return IonTypes.BOOL;
     }
     if (value instanceof String) {
         return IonTypes.STRING;
@@ -121,22 +141,6 @@ function _inferType(value: any): IonType {
 // type using that value.
 export function _ionValueFromJsValue(value: any, annotations: string[] = []): Value {
     let ionType = _inferType(value);
-    switch (ionType) {
-        case IonTypes.NULL:
-            return new dom.Null(IonTypes.NULL, annotations);
-        case IonTypes.LIST:
-            return new dom.List(
-                value.map(child => Value.from(child)),
-                annotations
-            );
-        case IonTypes.STRUCT:
-            return new dom.Struct(
-                Object.entries(value)
-                    .map(([key, value]) => [key, Value.from(value)]),
-                annotations
-            );
-        default:
-            let ionTypeConstructor: Constructor = _domConstructorFor(ionType);
-            return new ionTypeConstructor(value, annotations) as Value;
-    }
+    let ionTypeConstructor: FromJsValue = _domConstructorFor(ionType);
+    return ionTypeConstructor._fromJsValue(value, annotations);
 }

--- a/src/dom/JsValueConversion.ts
+++ b/src/dom/JsValueConversion.ts
@@ -92,7 +92,7 @@ function _inferType(value: any): IonType {
             throw new Error(`Value.from() does not support the JS primitive type ${valueType}.`);
     }
 
-    // TODO: Use the code below to create an easy-to-undesrtand _babelIsEnabled() test.
+    // TODO: Use the code below to create an easy-to-understand _babelJsbiIsEnabled() test.
     // If `value` is a native bigint but we're not using Babel for native bigint support, we need to
     // throw an Error.
     //

--- a/src/dom/Lob.ts
+++ b/src/dom/Lob.ts
@@ -1,0 +1,32 @@
+import {Value} from "./Value";
+import {IonType} from "../Ion";
+import {FromJsConstructor, FromJsConstructorBuilder} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withClasses(Uint8Array)
+    .build();
+
+/**
+ * This mixin constructs a new class that:
+ * - Extends `DomValue`
+ * - Extends `Uint8Array`
+ * - Has the specified `IonType`.
+ *
+ * In practice, serves as a common base class for `Blob` and `Clob`.
+ *
+ * @param ionType   The IonType to associate with the new DomValue subclass.
+ * @constructor
+ * @private
+ */
+export function Lob(ionType: IonType) {
+    return class extends Value(Uint8Array, ionType, _fromJsConstructor) implements Value {
+        protected constructor(data: Uint8Array, annotations: string[] = []) {
+            super(data);
+            this._setAnnotations(annotations);
+        }
+
+        uInt8ArrayValue(): Uint8Array {
+            return this;
+        }
+    }
+}

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -3,8 +3,6 @@ import JSBI from "jsbi";
 import {PathElement, Value} from "./Value";
 import {FromJsConstructor} from "./FromJsConstructor";
 
-const _fromJsConstructor: FromJsConstructor = FromJsConstructor.NONE;
-
 /**
  * Represents a null[1] value in an Ion stream.
  *
@@ -29,7 +27,7 @@ const _fromJsConstructor: FromJsConstructor = FromJsConstructor.NONE;
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#null
  */
-export class Null extends Value(Object, IonTypes.NULL, _fromJsConstructor) {
+export class Null extends Value(Object, IonTypes.NULL, FromJsConstructor.NONE) {
     private static _supportedIonTypesByOperation = new Map<string, Set<IonType>>([
         ['booleanValue', new Set([IonTypes.BOOL])],
         ['numberValue', new Set([IonTypes.INT, IonTypes.FLOAT, IonTypes.DECIMAL])],

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -1,6 +1,9 @@
 import {Decimal, IonType, IonTypes} from "../Ion";
 import JSBI from "jsbi";
 import {PathElement, Value} from "./Value";
+import {FromJsConstructor} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = FromJsConstructor.NONE;
 
 /**
  * Represents a null[1] value in an Ion stream.
@@ -26,7 +29,7 @@ import {PathElement, Value} from "./Value";
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#null
  */
-export class Null extends Value(Object, IonTypes.NULL) {
+export class Null extends Value(Object, IonTypes.NULL, _fromJsConstructor) {
     private static _supportedIonTypesByOperation = new Map<string, Set<IonType>>([
         ['booleanValue', new Set([IonTypes.BOOL])],
         ['numberValue', new Set([IonTypes.INT, IonTypes.FLOAT, IonTypes.DECIMAL])],

--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -1,5 +1,6 @@
-import {Value, PathElement} from "./Value";
+import {PathElement, Value} from "./Value";
 import {IonType} from "../Ion";
+import {FromJsConstructor} from "./FromJsConstructor";
 
 /**
  * This mixin constructs a new class that:
@@ -14,7 +15,7 @@ import {IonType} from "../Ion";
  * @private
  */
 export function Sequence(ionType: IonType) {
-    return class extends Value(Array, ionType) implements Value, Array<Value> {
+    return class extends Value(Array, ionType, FromJsConstructor.NONE) implements Value, Array<Value> {
         protected constructor(children: Value[], annotations: string[] = []) {
             super();
             this.push(...children);
@@ -45,6 +46,14 @@ export function Sequence(ionType: IonType) {
 
         toString(): string {
             return '[' + this.join(', ') + ']';
+        }
+
+        static _fromJsValue(jsValue: any, annotations: string[]): Value {
+            if (!(jsValue instanceof Array)) {
+                throw new Error(`Cannot create a ${this.name} from: ${jsValue.toString()}`);
+            }
+            let children = jsValue.map(child => Value.from(child));
+            return new this(children, annotations);
         }
     }
 }

--- a/src/dom/String.ts
+++ b/src/dom/String.ts
@@ -1,12 +1,18 @@
 import {IonTypes} from "../Ion";
 import {Value} from "./Value";
+import {FromJsConstructor, FromJsConstructorBuilder, Primitives} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withPrimitives(Primitives.String)
+    .withClassesToUnbox(global.String)
+    .build();
 
 /**
  * Represents a string[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#string
  */
-export class String extends Value(global.String, IonTypes.STRING) {
+export class String extends Value(global.String, IonTypes.STRING, _fromJsConstructor) {
     /**
      * Constructor.
      * @param text          The text value to represent as a string.

--- a/src/dom/Symbol.ts
+++ b/src/dom/Symbol.ts
@@ -1,5 +1,11 @@
 import {IonTypes} from "../Ion";
 import {Value} from "./Value";
+import {FromJsConstructor, FromJsConstructorBuilder, Primitives} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withPrimitives(Primitives.String)
+    .withClassesToUnbox(global.String)
+    .build();
 
 // TODO:
 //   This extends 'String' because ion-js does not yet have a SymbolToken construct.
@@ -10,7 +16,7 @@ import {Value} from "./Value";
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#symbol
  */
-export class Symbol extends Value(String, IonTypes.SYMBOL) {
+export class Symbol extends Value(String, IonTypes.SYMBOL, _fromJsConstructor) {
     /**
      * Constructor.
      * @param symbolText    The text to represent as a symbol.

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -36,7 +36,7 @@ export class Timestamp extends Value(Date, IonTypes.TIMESTAMP) {
         return new ion.Timestamp(
             date.getTimezoneOffset(),
             date.getUTCFullYear(),
-            date.getUTCMonth(),
+            date.getUTCMonth() + 1, // Timestamp expects a range of 1-12
             date.getUTCDate(),
             date.getUTCHours(),
             date.getUTCMinutes(),

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -1,13 +1,18 @@
 import {Value} from "./Value";
 import * as ion from "../Ion";
 import {IonTypes} from "../Ion";
+import {FromJsConstructor, FromJsConstructorBuilder} from "./FromJsConstructor";
+
+const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
+    .withClasses(Date, ion.Timestamp)
+    .build();
 
 /**
  * Represents a timestamp[1] value in an Ion stream.
  *
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#timestamp
  */
-export class Timestamp extends Value(Date, IonTypes.TIMESTAMP) {
+export class Timestamp extends Value(Date, IonTypes.TIMESTAMP, _fromJsConstructor) {
     protected _timestamp: ion.Timestamp;
     protected _date: Date;
 

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -1,5 +1,6 @@
-import {Decimal, Timestamp, IonType} from "../Ion";
+import {Decimal, dom, IonType, IonTypes, Timestamp} from "../Ion";
 import JSBI from "jsbi";
+import * as JsValueConversion from "./JsValueConversion";
 
 // This file leverages Typescript's declaration merging feature[1] to create a
 // combined type/value called `Value` that is simultaneously an interface, a mixin constructor,
@@ -7,7 +8,7 @@ import JSBI from "jsbi";
 // * Classes can implement Value
 // * Classes can extend a mixin constructed by Value()
 // * `instanceof Value` returns true for classes that extend a mixin constructed by Value()
-// * TODO: Concrete Value implementations can be constructed by calling Value.from(jsValue)
+// * Concrete Value implementations can be constructed by calling Value.from(jsValue)
 //
 // [1] https://www.typescriptlang.org/docs/handbook/declaration-merging.html
 
@@ -270,6 +271,33 @@ export function Value<Clazz extends Constructor>(BaseClass: Clazz, ionType: IonT
 }
 
 export namespace Value {
-    // TODO: Provide a function to convert from native JS values to ion.dom.Value instances.
-    //       function from(jsValue): Value {...}
+    /**
+     * Constructs a dom.Value from the provided Javascript value using the following type mappings:
+     *
+     * JS Type    | dom.Value subclass
+     * -----------------------------
+     * null       | dom.Null
+     * boolean    | dom.Boolean
+     * number     | dom.Integer or dom.Float
+     * BigInt     | dom.Integer
+     * string     | dom.String
+     * Decimal    | dom.Decimal
+     * Date       | dom.Timestamp
+     * Timestamp  | dom.Timestamp
+     * Uint8Array | dom.Blob
+     * Array      | dom.List
+     * Object     | dom.Struct
+     *
+     * Other input types (including 'undefined') are not supported and will throw an Error.
+     *
+     * If the input type is an Array or Object, this method will also convert each nested javascript
+     * values into a dom.Value.
+     *
+     * @param value         A javascript value to convert into an Ion dom.Value.
+     * @param annotations   An optional array of strings to associate with the newly created dom.Value.
+     *                      These annotations will NOT be associated with any nested dom.Values.
+     */
+    export function from(value: any, annotations: string[] = []): Value {
+        return JsValueConversion._ionValueFromJsValue(value, annotations);
+    }
 }

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,4 +1,4 @@
-import {IntSize, IonType, IonTypes, makeReader, Reader, ReaderBuffer} from "../Ion";
+import {IntSize, IonTypes, makeReader, Reader, ReaderBuffer} from "../Ion";
 import * as ion from "../Ion";
 import {Value} from "./Value";
 import {Struct} from "./Struct";

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,5 +1,5 @@
-import {IntSize, IonTypes, makeReader, Reader, ReaderBuffer} from "../Ion";
 import * as ion from "../Ion";
+import {IntSize, IonTypes, makeReader, Reader, ReaderBuffer} from "../Ion";
 import {Value} from "./Value";
 import {Struct} from "./Struct";
 import {List} from "./List";

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -1,160 +1,178 @@
 import {assert} from "chai";
 import {Value} from "../../src/dom";
-import {Decimal, IonTypes, Timestamp} from "../../src/Ion";
-import {Constructor} from "../../src/dom/Value";
-import {_hasValue} from "../../src/util";
+import {Decimal, dom, IonTypes, Timestamp} from "../../src/Ion";
 import JSBI from "jsbi";
 import * as JsValueConversion from "../../src/dom/JsValueConversion";
+import {_hasValue} from "../../src/util";
+
+// The same test logic performed by assert.equals() but without an assertion.
+function jsEqualsIon(jsValue, ionValue): boolean {
+    return jsValue == ionValue;
+}
 
 /**
  * Tests constructing an Ion value from a JS value. Verifies that the newly constructed
  * value has the expected Ion type, the expected JS type, and the correct value.
  *
+ * Callers may optionally provide a wrapped version of the jsValue that will be used converted to
+ * an Ion dom.Value. This is useful for validating that Value.from() behaves the same with boxed primitives
+ * (Boolean, String, Number) as it does with actual primitives (boolean, string, number).
+ *
  * @param jsValue               A JS value to pass to Value.from() after optionally wrapping it by
  *                              calling `wrapperConstructor` if provided.
- * @param annotations           An array of strings to associate with the newly constructed value.
  * @param expectedIonType       The new dom.Value's expected Ion type.
- * @param wrapperConstructor    A wrapper constructor for (e.g.) boxing primitives.
+ * @param wrappedValue          A boxed version of jsValue.
  * @param equalityTest          A function that tests whether the new DOM value is equal to the provided jsValue
  */
-function domValueTest(jsValue, annotations, expectedIonType, wrapperConstructor?, equalityTest?) {
-    return () => {
-        let sourceValue = jsValue;
-        if (_hasValue(wrapperConstructor)) {
-            sourceValue = wrapperConstructor(jsValue);
-        }
-        let v: any = Value.from(sourceValue, annotations);
-        let expectedDomType: Constructor = JsValueConversion._domConstructorFor(expectedIonType);
-        if (_hasValue(equalityTest)) {
-            assert.isTrue(equalityTest(jsValue, v));
-        } else {
-            assert.equal(jsValue, v);
-        }
+function domValueTest(jsValue,
+                      expectedIonType,
+                      equalityTest: (p1, p2) => boolean = jsEqualsIon,
+                      wrappedValue?) {
+    function validateDomValue(v: any, annotations) {
+        // Verify that the new dom.Value is considered equal to the original (unwrapped) JS value.
+        assert.isTrue(equalityTest(jsValue, v));
         assert.equal(expectedIonType, v.getType());
+        let expectedDomType: any = JsValueConversion._domConstructorFor(expectedIonType);
         assert.isTrue(v instanceof expectedDomType);
         assert.deepEqual(annotations, v.getAnnotations());
+    }
+
+    return () => {
+        // Test Value.from() with and without specifying annotations
+        let annotations = ['foo', 'bar', 'baz'];
+        let sourceValue = _hasValue(wrappedValue) ? wrappedValue : jsValue;
+        it('' + sourceValue, () => {
+            validateDomValue(Value.from(sourceValue), []);
+        });
+        it(annotations.join('::') + '::' + sourceValue, () => {
+            validateDomValue(Value.from(sourceValue, annotations), annotations);
+        });
     };
 }
 
 describe('Value', () => {
     describe('from()', () => {
-        it('null',
+        describe('null',
             domValueTest(
                 null,
-                ['foo'],
                 IonTypes.NULL,
-                null,
                 (_, domValue) => domValue.isNull()
             )
         );
-        it('boolean',
-            domValueTest(true, ['foo'], IonTypes.BOOL)
+        describe('boolean',
+            domValueTest(true, IonTypes.BOOL)
         );
-        it('Boolean',
-            domValueTest(true, ['foo'], IonTypes.BOOL, Boolean)
+        describe('Boolean',
+            domValueTest(true, IonTypes.BOOL, jsEqualsIon, new Boolean(true))
         );
-        it('number (integer)',
-            domValueTest(7, ['foo'], IonTypes.INT)
+        describe('number (integer)',
+            domValueTest(7, IonTypes.INT)
         );
-        it('Number (integer)',
-            domValueTest(7, ['foo'], IonTypes.INT, Number)
+        describe('Number (integer)',
+            domValueTest(7, IonTypes.INT, jsEqualsIon, new Number(7))
         );
-        it('BigInt',
+        describe('BigInt',
             domValueTest(
                 JSBI.BigInt(7),
-                ['foo'],
                 IonTypes.INT,
-                null,
-                (jsValue, domValue) => JSBI.equal(jsValue, domValue.bigIntValue())
+                (jsValue, domValue) => JSBI.equal(jsValue, domValue.bigIntValue()!)
             )
         );
-        it('number (floating point)',
-            domValueTest(7.5, ['foo'], IonTypes.FLOAT)
+        describe('number (floating point)',
+            domValueTest(7.5, IonTypes.FLOAT)
         );
-        it('Number (floating point)',
-            domValueTest(7.5, ['foo'], IonTypes.FLOAT, Number)
+        describe('Number (floating point)',
+            domValueTest(7.5, IonTypes.FLOAT, jsEqualsIon, new Number(7.5))
         );
-        it('Decimal',
+        describe('Decimal',
             domValueTest(
                 new Decimal("7.5"),
-                ['foo'],
                 IonTypes.DECIMAL,
-                null,
                 (jsValue, domValue) => domValue.decimalValue().equals(jsValue)
             )
         );
-        it('Date',
+        describe('Date',
             domValueTest(
                 new Date("1970-01-01T00:00:00Z"),
-                ['foo'],
                 IonTypes.TIMESTAMP,
-                null,
                 (jsValue, domValue) => domValue.dateValue().getTime() === jsValue.getTime()
             )
         );
-        it('Timestamp',
+        describe('Timestamp',
             domValueTest(
                 Timestamp.parse("1970-01-01T00:00:00Z"),
-                ['foo'],
                 IonTypes.TIMESTAMP,
-                null,
                 (jsValue, domValue) => domValue.timestampValue().equals(jsValue)
             )
         );
-        it('string',
+        describe('string',
             domValueTest(
                 'Hello',
-                ['foo'],
                 IonTypes.STRING,
             )
         );
-        it('String',
+        describe('String',
             domValueTest(
                 'Hello',
-                ['foo'],
                 IonTypes.STRING,
-                String
+                jsEqualsIon,
+                new String('Hello')
             )
         );
-
-        const blobData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        it('Blob',
+        describe('Blob',
             domValueTest(
-                blobData,
-                ['foo'],
+                new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                 IonTypes.BLOB,
-                null,
                 (jsValue, domValue) =>
-                    domValue.uInt8ArrayValue().every(
-                        (byte, index) => byte === blobData[index]
+                    jsValue.every(
+                        (byte, index) => byte === domValue[index]
                     )
             )
         );
-
-        const listData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        it('List',
+        describe('List',
             domValueTest(
-                listData,
-                ['foo'],
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                 IonTypes.LIST,
-                null,
                 (jsValue, domValue) =>
-                    domValue.every(
-                        (ionValue, index) => ionValue.numberValue() == jsValue[index]
+                    jsValue.every(
+                        (listItem, index) => listItem === domValue[index].numberValue()
                     )
                 )
         );
-
-        const structData = {foo: 7, bar: true, baz: 98.6, qux: 'Hello'};
-        it('Struct',
+        describe('Struct',
             domValueTest(
-                structData,
-                ['foo'],
+                {foo: 7, bar: true, baz: 98.6, qux: 'Hello'},
                 IonTypes.STRUCT,
-                null,
                 (jsValue, domValue) =>
                     Object.entries(jsValue)
                           .every(([key, value]) => domValue.get(key).valueOf() === value)
+            )
+        );
+        describe('List inside Struct',
+            domValueTest(
+                {foo: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]},
+                IonTypes.STRUCT,
+                (jsValue, domValue) => {
+                    assert.isTrue(domValue instanceof dom.Struct);
+                    assert.isTrue(domValue['foo'] instanceof dom.List);
+                    let domList: dom.List = domValue['foo'];
+                    return jsValue.foo.every(
+                        (arrayNumber, index) => arrayNumber === domList[index].numberValue()
+                    )
+                }
+            )
+        );
+        describe('Struct inside List',
+            domValueTest(
+                [{foo: 7, bar: true, baz: 98.6, qux: 'Hello'}],
+                IonTypes.LIST,
+                (jsValue, domValue) => {
+                    assert.isTrue(domValue instanceof dom.List);
+                    assert.isTrue(domValue[0] instanceof dom.Struct);
+                    let domStruct: dom.Struct = domValue[0];
+                    return Object.entries(jsValue[0])
+                                 .every(([key, value]) => domStruct.get(key)!.valueOf() === value)
+                }
             )
         );
     });

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -1,0 +1,161 @@
+import {assert} from "chai";
+import {Value} from "../../src/dom";
+import {Decimal, IonTypes, Timestamp} from "../../src/Ion";
+import {Constructor} from "../../src/dom/Value";
+import {_hasValue} from "../../src/util";
+import JSBI from "jsbi";
+import * as JsValueConversion from "../../src/dom/JsValueConversion";
+
+/**
+ * Tests constructing an Ion value from a JS value. Verifies that the newly constructed
+ * value has the expected Ion type, the expected JS type, and the correct value.
+ *
+ * @param jsValue               A JS value to pass to Value.from() after optionally wrapping it by
+ *                              calling `wrapperConstructor` if provided.
+ * @param annotations           An array of strings to associate with the newly constructed value.
+ * @param expectedIonType       The new dom.Value's expected Ion type.
+ * @param wrapperConstructor    A wrapper constructor for (e.g.) boxing primitives.
+ * @param equalityTest          A function that tests whether the new DOM value is equal to the provided jsValue
+ */
+function domValueTest(jsValue, annotations, expectedIonType, wrapperConstructor?, equalityTest?) {
+    return () => {
+        let sourceValue = jsValue;
+        if (_hasValue(wrapperConstructor)) {
+            sourceValue = wrapperConstructor(jsValue);
+        }
+        let v: any = Value.from(sourceValue, annotations);
+        let expectedDomType: Constructor = JsValueConversion._domConstructorFor(expectedIonType);
+        if (_hasValue(equalityTest)) {
+            assert.isTrue(equalityTest(jsValue, v));
+        } else {
+            assert.equal(jsValue, v);
+        }
+        assert.equal(expectedIonType, v.getType());
+        assert.isTrue(v instanceof expectedDomType);
+        assert.deepEqual(annotations, v.getAnnotations());
+    };
+}
+
+describe('Value', () => {
+    describe('from()', () => {
+        it('null',
+            domValueTest(
+                null,
+                ['foo'],
+                IonTypes.NULL,
+                null,
+                (_, domValue) => domValue.isNull()
+            )
+        );
+        it('boolean',
+            domValueTest(true, ['foo'], IonTypes.BOOL)
+        );
+        it('Boolean',
+            domValueTest(true, ['foo'], IonTypes.BOOL, Boolean)
+        );
+        it('number (integer)',
+            domValueTest(7, ['foo'], IonTypes.INT)
+        );
+        it('Number (integer)',
+            domValueTest(7, ['foo'], IonTypes.INT, Number)
+        );
+        it('BigInt',
+            domValueTest(
+                JSBI.BigInt(7),
+                ['foo'],
+                IonTypes.INT,
+                null,
+                (jsValue, domValue) => JSBI.equal(jsValue, domValue.bigIntValue())
+            )
+        );
+        it('number (floating point)',
+            domValueTest(7.5, ['foo'], IonTypes.FLOAT)
+        );
+        it('Number (floating point)',
+            domValueTest(7.5, ['foo'], IonTypes.FLOAT, Number)
+        );
+        it('Decimal',
+            domValueTest(
+                new Decimal("7.5"),
+                ['foo'],
+                IonTypes.DECIMAL,
+                null,
+                (jsValue, domValue) => domValue.decimalValue().equals(jsValue)
+            )
+        );
+        it('Date',
+            domValueTest(
+                new Date("1970-01-01T00:00:00Z"),
+                ['foo'],
+                IonTypes.TIMESTAMP,
+                null,
+                (jsValue, domValue) => domValue.dateValue().getTime() === jsValue.getTime()
+            )
+        );
+        it('Timestamp',
+            domValueTest(
+                Timestamp.parse("1970-01-01T00:00:00Z"),
+                ['foo'],
+                IonTypes.TIMESTAMP,
+                null,
+                (jsValue, domValue) => domValue.timestampValue().equals(jsValue)
+            )
+        );
+        it('string',
+            domValueTest(
+                'Hello',
+                ['foo'],
+                IonTypes.STRING,
+            )
+        );
+        it('String',
+            domValueTest(
+                'Hello',
+                ['foo'],
+                IonTypes.STRING,
+                String
+            )
+        );
+
+        const blobData = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        it('Blob',
+            domValueTest(
+                blobData,
+                ['foo'],
+                IonTypes.BLOB,
+                null,
+                (jsValue, domValue) =>
+                    domValue.uInt8ArrayValue().every(
+                        (byte, index) => byte === blobData[index]
+                    )
+            )
+        );
+
+        const listData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        it('List',
+            domValueTest(
+                listData,
+                ['foo'],
+                IonTypes.LIST,
+                null,
+                (jsValue, domValue) =>
+                    domValue.every(
+                        (ionValue, index) => ionValue.numberValue() == jsValue[index]
+                    )
+                )
+        );
+
+        const structData = {foo: 7, bar: true, baz: 98.6, qux: 'Hello'};
+        it('Struct',
+            domValueTest(
+                structData,
+                ['foo'],
+                IonTypes.STRUCT,
+                null,
+                (jsValue, domValue) =>
+                    Object.entries(jsValue)
+                          .every(([key, value]) => domValue.get(key).valueOf() === value)
+            )
+        );
+    });
+});


### PR DESCRIPTION
*Description of changes:*

This PR introduces a `dom.Value.from(jsValue)` method that can convert an arbitrary Javascript object to a newly constructed instance of the appropriate Ion `dom.Value` subclass.

```javascript
Value.from(null); // dom.Null
Value.from(true); // dom.Boolean
Value.from(4); // dom.Integer
Value.from(4.2); // dom.Float
Value.from(new Date(0)); // dom.Timestamp
Value.from(new ion.Decimal("1.5")); // dom.Decimal
Value.from("hello"); // dom.String
Value.from([1, 2, 3]); // dom.List containing dom.Integers
Value.from({foo: "bar", baz: 5}); // dom.Struct containing properties 'foo' => dom.String and 'baz' => dom.Integer
```

**Notes**
* `Value.from()` will call itself recursively on containers' nested values.
* Ambiguous conversions:
  * JS `Array`s will be converted into instances of `dom.List`. Users requiring `dom.SExpression` will need to manually instantiate them. 
  * JS `Uint8Array`s will be converted into instances of `dom.Blob`. Users requiring `dom.Clob` will need to manually instantiate them. 
  * JS `String`s will be converted into instances of `dom.String`. Users requiring `dom.Symbol` will need to manually instantiate them.

**Future work**
  * JS `Symbol`s are not yet supported. Research is needed to understand how their semantics align with Ion's `string` and `symbol` types.
  * We may wish to add a `hint: IonType` parameter to this method in the future, but this needs to be designed. (How would the hint apply to arrays inside of arrays?)

CC @yohanmartin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
