### PR TITLE
JSON.stringify support for non-clobs

### DIFF
--- a/src/IonDecimal.ts
+++ b/src/IonDecimal.ts
@@ -230,6 +230,13 @@ export class Decimal {
     }
 
     /**
+     * Converts this Decimal value to a JSON number when being serialized via `JSON.stringify()`.
+     */
+    toJSON() {
+        return this.numberValue();
+    }
+
+    /**
      * Returns a BigInt representing the coefficient of this Decimal value.
      *
      * Note that the BigInt data type is unable to represent -0 natively. If you wish to check for a -0 coefficient,

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -381,8 +381,8 @@ export class Timestamp {
     }
 
     /**
-     *  Converts this Timestamp to a ISO8601-formatted string when being serialized with
-     *  `JSON.stringify()`.
+     * Converts this Timestamp to a ISO8601-formatted string when being serialized with
+     * `JSON.stringify()`.
      */
     toJSON() {
         return this.getDate().toISOString();

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -381,9 +381,9 @@ export class Timestamp {
     }
 
     /**
-     * Converts this Timestamp to a ISO8601-formatted string when being serialized with
-     * `JSON.stringify()`.
-    */
+     *  Converts this Timestamp to a ISO8601-formatted string when being serialized with
+     *  `JSON.stringify()`.
+     */
     toJSON() {
         return this.getDate().toISOString();
     }

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -380,6 +380,14 @@ export class Timestamp {
         return strVal;
     }
 
+    /**
+     * Converts this Timestamp to a ISO8601-formatted string when being serialized with
+     * `JSON.stringify()`.
+    */
+    toJSON() {
+        return this.getDate().toISOString();
+    }
+
     private _checkRequiredField(fieldName: string, value: number, min: number, max: number) {
         if (!_hasValue(value)) {
             throw new Error(`${fieldName} cannot be ${value}`);

--- a/src/dom/Blob.ts
+++ b/src/dom/Blob.ts
@@ -1,4 +1,4 @@
-import {IonTypes} from "../Ion";
+import {IonTypes, toBase64} from "../Ion";
 import {Lob} from "./Lob";
 
 /**
@@ -15,5 +15,12 @@ export class Blob extends Lob(IonTypes.BLOB) {
      */
     constructor(data: Uint8Array, annotations: string[] = []) {
         super(data, annotations);
+    }
+
+    /**
+     * Converts this Blob to a base64-encoded string when being serialized with `JSON.stringify()`.
+     */
+    toJSON() {
+        return toBase64(this);
     }
 }

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -129,4 +129,11 @@ export class Null extends Value(Object, IonTypes.NULL, FromJsConstructor.NONE) {
         }
         return 'null.' + this._ionType.name;
     }
+
+    /**
+     * Converts this dom.Null to a Javascript null when being serialized with `JSON.stringify()`.
+     */
+    toJSON() {
+        return null;
+    }
 }

--- a/test/dom/json.ts
+++ b/test/dom/json.ts
@@ -1,0 +1,84 @@
+import {assert} from "chai";
+import * as ion from "../../src/Ion";
+import {Value} from "../../src/dom";
+import {Decimal, IonTypes, Timestamp, toBase64} from "../../src/Ion";
+import {encodeUtf8} from "../../src/IonTests";
+
+// Verifies that subtypes of dom.Value down-convert to JSON following the documented process[1].
+// [1] http://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
+
+function jsonStringifyTests(typeName: string, ...jsValues: any[]) {
+    describe(typeName, () => {
+        for (let jsValue of jsValues) {
+            let json: string = JSON.stringify(jsValue);
+            it(json, () => {
+                assert.equal(
+                    json,
+                    JSON.stringify(Value.from(jsValue))
+                );
+            });
+        }
+    });
+}
+
+describe('JSON', () => {
+    describe('stringify()', () => {
+        jsonStringifyTests('Null', null);
+        jsonStringifyTests('Boolean', true, false);
+        jsonStringifyTests('Integer', 24601, 0, 8675309);
+        jsonStringifyTests('Float', 2.4601, 867.5309);
+        jsonStringifyTests('Decimal',
+            new Decimal("0"),
+            new Decimal("1.5"),
+            new Decimal("-1.5"),
+            new Decimal(".00001"),
+            new Decimal("-.00001"),
+        );
+        jsonStringifyTests('Timestamp',
+            new Date('1970-01-01T00:00:00.000Z'),
+            Timestamp.parse('1970-01-01T00:00:00.000Z')
+        );
+        jsonStringifyTests('String', "foo", "bar", "baz", "");
+        jsonStringifyTests(
+            'List',
+            [],
+            [1, 2, 3],
+            ['foo', 'bar', 'baz'],
+            [new Date(0), {qux: 21, grault: false}]
+        );
+        jsonStringifyTests(
+            'Struct',
+            {},
+            {foo: 5, bar: "baz", qux: true},
+            {foo: ['dog', 'cat', 'mouse']}
+        );
+        it('Blob', () => {
+            let helloWorldBase64 = toBase64(encodeUtf8("Hello, world!"));
+            let blob = ion.load('{{' + helloWorldBase64 + '}}')!;
+            assert.equal(IonTypes.BLOB, blob.getType());
+            assert.equal(
+                JSON.stringify(helloWorldBase64),
+                JSON.stringify(blob)
+            );
+        });
+        it('SExpression', () => {
+            assert.equal(
+                JSON.stringify([1, 2, 3]),
+                JSON.stringify(ion.load('(1 2 3)'))
+            );
+            assert.equal(
+                JSON.stringify([]),
+                JSON.stringify(ion.load('()'))
+            );
+        });
+        it('Symbol', () => {
+            assert.equal(
+                JSON.stringify('foo'),
+                JSON.stringify(ion.load('foo'))
+            );
+        });
+        it.skip('Clob', () => {
+            //TODO: JSON.stringify() support for Clobs
+        });
+    });
+});


### PR DESCRIPTION
*Issue #, if available:* #563 

*Description of changes:*

`JSON.stringify()` works on most `dom.Value` subtypes. This PR adds support for the following holdouts: 

- [x] `Null`
- [x] `Timestamp`
- [x] `Decimal`
- [x] `Blob`
- [ ] `Clob`

Support for `Clob` will take rather more effort and will be added in another PR.

CC @yohanmartin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
