### PR TITLE
Added dumpBinary(), dumpText(), dumpPrettyText().

### DIFF
--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -88,7 +88,7 @@ export function makeBinaryWriter(): Writer {
 }
 
 // Used by the dump*() functions to write each of a sequence of values to the provided Writer.
-function writeAllTo(writer: Writer, values: any[]): Uint8Array {
+function _writeAllTo(writer: Writer, values: any[]): Uint8Array {
     for (let value of values) {
         dom.Value.from(value).writeTo(writer);
     }
@@ -101,7 +101,7 @@ function writeAllTo(writer: Writer, values: any[]): Uint8Array {
  * @param values Values to encode in Ion.
  */
 export function dumpBinary(...values: any[]): Uint8Array {
-    return writeAllTo(makeBinaryWriter(), values);
+    return _writeAllTo(makeBinaryWriter(), values);
 }
 
 /**
@@ -109,7 +109,7 @@ export function dumpBinary(...values: any[]): Uint8Array {
  * @param values Values to encode in Ion.
  */
 export function dumpText(...values: any[]): string {
-    return decodeUtf8(writeAllTo(makeTextWriter(), values));
+    return decodeUtf8(_writeAllTo(makeTextWriter(), values));
 }
 
 /**
@@ -118,7 +118,7 @@ export function dumpText(...values: any[]): string {
  * @param values Values to encode in Ion.
  */
 export function dumpPrettyText(...values: any[]): string {
-    return decodeUtf8(writeAllTo(makePrettyWriter(), values));
+    return decodeUtf8(_writeAllTo(makePrettyWriter(), values));
 }
 
 export {Reader, ReaderScalarValue} from "./IonReader";

--- a/src/Ion.ts
+++ b/src/Ion.ts
@@ -87,6 +87,40 @@ export function makeBinaryWriter(): Writer {
     return new BinaryWriter(localSymbolTable, new Writeable());
 }
 
+// Used by the dump*() functions to write each of a sequence of values to the provided Writer.
+function writeAllTo(writer: Writer, values: any[]): Uint8Array {
+    for (let value of values) {
+        dom.Value.from(value).writeTo(writer);
+    }
+    writer.close();
+    return writer.getBytes();
+}
+
+/**
+ * Returns a binary Ion representation of the provided values.
+ * @param values Values to encode in Ion.
+ */
+export function dumpBinary(...values: any[]): Uint8Array {
+    return writeAllTo(makeBinaryWriter(), values);
+}
+
+/**
+ * Returns a compact text Ion representation of the provided values.
+ * @param values Values to encode in Ion.
+ */
+export function dumpText(...values: any[]): string {
+    return decodeUtf8(writeAllTo(makeTextWriter(), values));
+}
+
+/**
+ * Returns a text Ion representation of the provided values that is generously spaced for
+ * easier human readability.
+ * @param values Values to encode in Ion.
+ */
+export function dumpPrettyText(...values: any[]): string {
+    return decodeUtf8(writeAllTo(makePrettyWriter(), values));
+}
+
 export {Reader, ReaderScalarValue} from "./IonReader";
 export {Writer} from "./IonWriter";
 export {Catalog} from "./IonCatalog";

--- a/src/IonTests.ts
+++ b/src/IonTests.ts
@@ -13,9 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import {Timestamp} from "./IonTimestamp";
 import {Decimal} from "./IonDecimal";
-import {load, Value} from "./dom";
 
 export * from './Ion';
 export {Writeable} from './IonWriteable';
@@ -29,55 +27,3 @@ export {BinaryWriter} from "./IonBinaryWriter";
 export {ParserBinaryRaw} from "./IonParserBinaryRaw";
 export {BinarySpan} from "./IonSpan";
 export {Decimal} from "./IonDecimal";
-
-// Generates a mocha-friendly string representation of the provided value that can be used in test names
-export function valueName(value: any): string {
-    if (value === null) {
-        return 'null';
-    }
-    if (typeof value === "object") {
-        return `${value.constructor.name}(${value})`;
-    }
-    return `${typeof value}(${value})`;
-}
-
-// Used as a default filtering predicate in functions below
-function acceptAnyValue(_: any) : boolean {
-    return true;
-}
-
-// A common collection of JS values that can be reduced to a relevant subset using the provided filter function.
-export function exampleJsValuesWhere(filter: (v: any) => boolean = acceptAnyValue): any[] {
-    return [
-        null,
-        true, false,
-        Number.MIN_SAFE_INTEGER, -7.5, -7, 0, 7, 7.5, Number.MAX_SAFE_INTEGER,
-        "", "foo",
-        new Date(0),
-        Timestamp.parse('1970-01-01T00:00:00Z'),
-        new Decimal('1.5'),
-        [], [1, 2, 3], [{foo: "bar"}],
-        {}, {foo: "bar", baz: 5}, {foo: [1, 2, 3]}
-    ].filter(filter);
-}
-
-// A common collection of Ion dom.Value instances that can be reduced to a relevant subset using
-// the provided filter function.
-export function exampleIonValuesWhere(filter: (v: Value) => boolean = acceptAnyValue): Value[] {
-    return [
-        load('null')!, // null
-        load('null.string')!, // typed null
-        load('true')!, // boolean
-        load('1')!, // integer
-        load('15e-1')!, // float
-        load('15d-1')!, // decimal
-        load('1970-01-01T00:00:00.000Z')!, // timestamp
-        load('"Hello"')!, // string
-        load('Hello')!, // symbol
-        load('{{aGVsbG8gd29ybGQ=}}')!, // blob
-        load('{{"February"}}')!, // clob
-        load('[1, 2, 3]')!, // list
-        load('(1 2 3)')!, // s-expression
-        load('{foo: true, bar: "Hello", baz: 5, qux: null}')! // struct
-    ].filter(filter);
-}

--- a/src/IonTests.ts
+++ b/src/IonTests.ts
@@ -13,6 +13,10 @@
  * permissions and limitations under the License.
  */
 
+import {Timestamp} from "./IonTimestamp";
+import {Decimal} from "./IonDecimal";
+import {load, Value} from "./dom";
+
 export * from './Ion';
 export {Writeable} from './IonWriteable';
 export {encodeUtf8} from './IonUnicode';
@@ -25,3 +29,55 @@ export {BinaryWriter} from "./IonBinaryWriter";
 export {ParserBinaryRaw} from "./IonParserBinaryRaw";
 export {BinarySpan} from "./IonSpan";
 export {Decimal} from "./IonDecimal";
+
+// Generates a mocha-friendly string representation of the provided value that can be used in test names
+export function valueName(value: any): string {
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === "object") {
+        return `${value.constructor.name}(${value})`;
+    }
+    return `${typeof value}(${value})`;
+}
+
+// Used as a default filtering predicate in functions below
+function acceptAnyValue(_: any) : boolean {
+    return true;
+}
+
+// A common collection of JS values that can be reduced to a relevant subset using the provided filter function.
+export function exampleJsValuesWhere(filter: (v: any) => boolean = acceptAnyValue): any[] {
+    return [
+        null,
+        true, false,
+        Number.MIN_SAFE_INTEGER, -7.5, -7, 0, 7, 7.5, Number.MAX_SAFE_INTEGER,
+        "", "foo",
+        new Date(0),
+        Timestamp.parse('1970-01-01T00:00:00Z'),
+        new Decimal('1.5'),
+        [], [1, 2, 3], [{foo: "bar"}],
+        {}, {foo: "bar", baz: 5}, {foo: [1, 2, 3]}
+    ].filter(filter);
+}
+
+// A common collection of Ion dom.Value instances that can be reduced to a relevant subset using
+// the provided filter function.
+export function exampleIonValuesWhere(filter: (v: Value) => boolean = acceptAnyValue): Value[] {
+    return [
+        load('null')!, // null
+        load('null.string')!, // typed null
+        load('true')!, // boolean
+        load('1')!, // integer
+        load('15e-1')!, // float
+        load('15d-1')!, // decimal
+        load('1970-01-01T00:00:00.000Z')!, // timestamp
+        load('"Hello"')!, // string
+        load('Hello')!, // symbol
+        load('{{aGVsbG8gd29ybGQ=}}')!, // blob
+        load('{{"February"}}')!, // clob
+        load('[1, 2, 3]')!, // list
+        load('(1 2 3)')!, // s-expression
+        load('{foo: true, bar: "Hello", baz: 5, qux: null}')! // struct
+    ].filter(filter);
+}

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -6,21 +6,11 @@ import JSBI from "jsbi";
 import * as JsValueConversion from "../../src/dom/JsValueConversion";
 import {_hasValue} from "../../src/util";
 import {Constructor} from "../../src/dom/Value";
+import {exampleIonValuesWhere, exampleJsValuesWhere, valueName} from "../../src/IonTests";
 
 // The same test logic performed by assert.equals() but without an assertion.
 function jsEqualsIon(jsValue, ionValue): boolean {
     return jsValue == ionValue;
-}
-
-// Generates a mocha-friendly string representation of the provided value that can be used in test names
-function valueName(value: any): string {
-    if (value === null) {
-        return 'null';
-    }
-    if (typeof value === "object") {
-        return `${value.constructor.name}(${value})`;
-    }
-    return `${typeof value}(${value})`;
 }
 
 // Tests whether each value is or is not an instance of dom.Value
@@ -38,47 +28,6 @@ function instanceOfValueSubclassTest(constructor: Constructor, expected: boolean
             assert.equal(value instanceof constructor, expected);
         });
     }
-}
-
-// Used as a default filter on the `exampleJsValuesWhere` and `exampleIonValuesWhere` functions below.
-function acceptAnyValue(_: any) : boolean {
-    return true;
-}
-
-// A common collection of JS values that can be reduced to a relevant subset using the provided filter function.
-function exampleJsValuesWhere(filter: (v: any) => boolean = acceptAnyValue): any[] {
-    return [
-        null,
-        true, false,
-        Number.MIN_SAFE_INTEGER, -7.5, -7, 0, 7, 7.5, Number.MAX_SAFE_INTEGER,
-        "", "foo",
-        new Date(0),
-        Timestamp.parse('1970-01-01T00:00:00Z'),
-        new Decimal('1.5'),
-        [], [1, 2, 3], [{foo: "bar"}],
-        {}, {foo: "bar", baz: 5}, {foo: [1, 2, 3]}
-    ].filter(filter);
-}
-
-// A common collection of Ion dom.Value instances that can be reduced to a relevant subset using
-// the provided filter function.
-function exampleIonValuesWhere(filter: (v: Value) => boolean = acceptAnyValue): Value[] {
-    return [
-        load('null')!, // null
-        load('null.string')!, // typed null
-        load('true')!, // boolean
-        load('1')!, // integer
-        load('15e-1')!, // float
-        load('15d-1')!, // decimal
-        load('1970-01-01T00:00:00.000Z')!, // timestamp
-        load('"Hello"')!, // string
-        load('Hello')!, // symbol
-        load('{{aGVsbG8gd29ybGQ=}}')!, // blob
-        load('{{"February"}}')!, // clob
-        load('[1, 2, 3]')!, // list
-        load('(1 2 3)')!, // s-expression
-        load('{foo: true, bar: "Hello", baz: 5, qux: null}')! // struct
-    ].filter(filter);
 }
 
 // Describes the static side of dom.Value subclasses

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -6,7 +6,8 @@ import JSBI from "jsbi";
 import * as JsValueConversion from "../../src/dom/JsValueConversion";
 import {_hasValue} from "../../src/util";
 import {Constructor} from "../../src/dom/Value";
-import {exampleIonValuesWhere, exampleJsValuesWhere, valueName} from "../../src/IonTests";
+import {exampleIonValuesWhere, exampleJsValuesWhere} from "../exampleValues";
+import {valueName} from "../mochaSupport";
 
 // The same test logic performed by assert.equals() but without an assertion.
 function jsEqualsIon(jsValue, ionValue): boolean {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -2,7 +2,7 @@ import {assert} from "chai";
 import JSBI from "jsbi";
 import * as ion from "../../src/Ion";
 import {IonTypes} from "../../src/Ion";
-import {Value} from "../../src/dom";
+import {Value, load, loadAll} from "../../src/dom";
 import {encodeUtf8} from "../../src/IonUnicode";
 
 /**
@@ -17,7 +17,7 @@ import {encodeUtf8} from "../../src/IonUnicode";
 
 describe('DOM', () => {
    it('load() kitchen sink as Value[]', () => {
-      let values: Value[] = ion.loadAll(
+      let values: Value[] = loadAll(
             ' 7' +
             ' greeting::"Hello"' +
             ' [\'moose\', null.string]' +
@@ -55,7 +55,7 @@ describe('DOM', () => {
 
    it('load() kitchen sink as any[]', () => {
       // This test casts each Ion value as an `any`, allowing each to be interacted with as a plain JS value.
-      let values: any[] = ion.loadAll(
+      let values: any[] = loadAll(
           ' 7' +
           ' greeting::"Hello"' +
           ' [\'moose\', null.string]' +
@@ -92,7 +92,7 @@ describe('DOM', () => {
    });
 
    it('load() Null as Value', () => {
-      let n = ion.load('null.blob')!;
+      let n = load('null.blob')!;
 
       assert.isTrue(n.isNull());
       assert.isNull(n.uInt8ArrayValue());
@@ -113,7 +113,7 @@ describe('DOM', () => {
    // load() `Null` as `any` would be identical to the above.
 
    it('load() Boolean as Value', () => {
-      let b: Value = ion.load('false')!;
+      let b: Value = load('false')!;
 
       assert.equal(false, b.booleanValue()!);
       assert.equal(false, b.valueOf());
@@ -123,7 +123,7 @@ describe('DOM', () => {
    });
 
    it('load() Boolean as any', () => {
-      let b: any = ion.load('false')!;
+      let b: any = load('false')!;
 
       assert.equal(false, b.booleanValue()!);
       assert.equal(false, b.valueOf());
@@ -144,7 +144,7 @@ describe('DOM', () => {
    });
 
    it('load() Integer as Value', () => {
-      let i: Value = ion.load('foo::bar::7')!;
+      let i: Value = load('foo::bar::7')!;
 
       assert.equal(IonTypes.INT, i.getType());
       assert.deepEqual(['foo', 'bar'], i.getAnnotations());
@@ -166,7 +166,7 @@ describe('DOM', () => {
    });
 
    it('load() Integer as any', () => {
-      let i: any = ion.load('foo::bar::7')!;
+      let i: any = load('foo::bar::7')!;
 
       assert.equal(IonTypes.INT, i.getType());
       assert.deepEqual(['foo', 'bar'], i.getAnnotations());
@@ -187,7 +187,7 @@ describe('DOM', () => {
    });
 
    it('load() Float as Value', () => {
-      let f: Value = ion.load('baz::qux::15e-1')!;
+      let f: Value = load('baz::qux::15e-1')!;
 
       assert.equal(IonTypes.FLOAT, f.getType());
       assert.deepEqual(['baz', 'qux'], f.getAnnotations());
@@ -202,7 +202,7 @@ describe('DOM', () => {
    });
 
    it('load() Float as any', () => {
-      let f: any = ion.load('baz::qux::15e-1')!;
+      let f: any = load('baz::qux::15e-1')!;
 
       assert.equal(IonTypes.FLOAT, f.getType());
       assert.deepEqual(['baz', 'qux'], f.getAnnotations());
@@ -216,7 +216,7 @@ describe('DOM', () => {
    });
 
    it('load() Decimal as Value', () => {
-      let d: Value = ion.load('101.5')!;
+      let d: Value = load('101.5')!;
 
       assert.equal(IonTypes.DECIMAL, d.getType());
 
@@ -227,7 +227,7 @@ describe('DOM', () => {
    });
 
    it('load() Decimal as any', () => {
-      let d: any = ion.load('101.5')!;
+      let d: any = load('101.5')!;
 
       assert.equal(IonTypes.DECIMAL, d.getType());
 
@@ -238,7 +238,7 @@ describe('DOM', () => {
    });
 
    it('load() Timestamp as Value', () => {
-      let t: Value = ion.load('DOB::2020-01-16T20:15:54.066Z')!;
+      let t: Value = load('DOB::2020-01-16T20:15:54.066Z')!;
 
       assert.equal(IonTypes.TIMESTAMP, t.getType());
       assert.deepEqual(['DOB'], t.getAnnotations());
@@ -250,7 +250,7 @@ describe('DOM', () => {
    });
 
    it('load() Timestamp as any', () => {
-      let t: any = ion.load('DOB::2020-01-16T20:15:54.066Z')!;
+      let t: any = load('DOB::2020-01-16T20:15:54.066Z')!;
 
       assert.equal(IonTypes.TIMESTAMP, t.getType());
       assert.deepEqual(['DOB'], t.getAnnotations());
@@ -262,7 +262,7 @@ describe('DOM', () => {
    });
 
    it('load() Symbol as Value', () => {
-      let s: Value = ion.load('foo::bar::"Saturn"')!;
+      let s: Value = load('foo::bar::"Saturn"')!;
 
       assert.equal(IonTypes.STRING, s.getType());
       assert.deepEqual(['foo', 'bar'], s.getAnnotations());
@@ -275,7 +275,7 @@ describe('DOM', () => {
    });
 
    it('load() Symbol as any', () => {
-      let s: any = ion.load('foo::bar::"Saturn"')!;
+      let s: any = load('foo::bar::"Saturn"')!;
 
       assert.equal(IonTypes.STRING, s.getType());
       assert.deepEqual(['foo', 'bar'], s.getAnnotations());
@@ -286,7 +286,7 @@ describe('DOM', () => {
    });
 
    it('load() String as Value', () => {
-      let s: Value = ion.load('foo::bar::"Saturn"')!;
+      let s: Value = load('foo::bar::"Saturn"')!;
 
       assert.equal(IonTypes.STRING, s.getType());
       assert.deepEqual(['foo', 'bar'], s.getAnnotations());
@@ -299,7 +299,7 @@ describe('DOM', () => {
    });
 
    it('load() String as any', () => {
-      let s: any = ion.load('foo::bar::"Saturn"')!;
+      let s: any = load('foo::bar::"Saturn"')!;
 
       assert.equal(IonTypes.STRING, s.getType());
       assert.deepEqual(['foo', 'bar'], s.getAnnotations());
@@ -310,7 +310,7 @@ describe('DOM', () => {
    });
 
    it('load() Clob as Value', () => {
-      let c: Value = ion.load('month::{{"February"}}')!;
+      let c: Value = load('month::{{"February"}}')!;
 
       assert.equal(IonTypes.CLOB, c.getType());
       assert.deepEqual(['month'], c.getAnnotations());
@@ -319,7 +319,7 @@ describe('DOM', () => {
    });
 
    it('load() Clob as any', () => {
-      let c: any = ion.load('month::{{"February"}}')!;
+      let c: any = load('month::{{"February"}}')!;
 
       assert.equal(IonTypes.CLOB, c.getType());
       assert.deepEqual(['month'], c.getAnnotations());
@@ -328,7 +328,7 @@ describe('DOM', () => {
    });
 
    it('load() Blob as Value', () => {
-      let b: Value = ion.load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
+      let b: Value = load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
 
       assert.equal(IonTypes.BLOB, b.getType());
       assert.deepEqual(['quote'], b.getAnnotations());
@@ -337,7 +337,7 @@ describe('DOM', () => {
    });
 
    it('load() Blob as any', () => {
-      let b: any = ion.load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
+      let b: any = load('quote::{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}')!;
 
       assert.equal(IonTypes.BLOB, b.getType());
       assert.deepEqual(['quote'], b.getAnnotations());
@@ -346,7 +346,7 @@ describe('DOM', () => {
    });
 
    it('load() List as Value', () => {
-      let l: Value = ion.load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
+      let l: Value = load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
 
       assert.equal(IonTypes.LIST, l.getType());
       assert.deepEqual(['planets'], l.getAnnotations());
@@ -367,7 +367,7 @@ describe('DOM', () => {
    });
 
    it('load() List as any', () => {
-      let l: any = ion.load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
+      let l: any = load('planets::["Mercury", "Venus", "Earth", "Mars"]')!;
 
       assert.equal(IonTypes.LIST, l.getType());
       assert.deepEqual(['planets'], l.getAnnotations());
@@ -391,7 +391,7 @@ describe('DOM', () => {
    });
 
    it('load() SExpression as Value', () => {
-      let s: Value = ion.load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
+      let s: Value = load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
 
       assert.equal(IonTypes.SEXP, s.getType());
       assert.deepEqual(['planets'], s.getAnnotations());
@@ -412,7 +412,7 @@ describe('DOM', () => {
    });
 
    it('load() SExpression as any', () => {
-      let s: any = ion.load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
+      let s: any = load('planets::("Mercury" "Venus" "Earth" "Mars")')!;
 
       assert.equal(IonTypes.SEXP, s.getType());
       assert.deepEqual(['planets'], s.getAnnotations());
@@ -436,7 +436,7 @@ describe('DOM', () => {
    });
 
    it('load() Struct as Value', () => {
-      let s: Value = ion.load(
+      let s: Value = load(
           'foo::bar::{' +
             'name: {' +
                'first: "John", ' +
@@ -465,7 +465,7 @@ describe('DOM', () => {
    });
 
    it('load() Struct as any', () => {
-      let s: any = ion.load(
+      let s: any = load(
           'foo::bar::{' +
           'name: {' +
           'first: "John", ' +

--- a/test/dump.ts
+++ b/test/dump.ts
@@ -15,7 +15,8 @@
 
 import {assert} from 'chai';
 import * as ion from '../src/IonTests';
-import {dom, exampleIonValuesWhere, exampleJsValuesWhere, IonTypes} from "../src/IonTests";
+import {dom, IonTypes} from '../src/IonTests';
+import {exampleIonValuesWhere, exampleJsValuesWhere} from "./exampleValues";
 
 function roundTripTests(...values: any[]) {
     let expectedValues: dom.Value[] = values.map((jsValue) => dom.Value.from(jsValue));
@@ -30,10 +31,8 @@ function roundTripTest(dumpFn: (...values: any[]) => any,
                        inputValues: any[],
                        expectedValues: dom.Value[]) {
     let actualValues: dom.Value[] = dom.loadAll(dumpFn(inputValues));
-    let testComparisons: [dom.Value, dom.Value][] = actualValues.map(
-        (actualValue, index) => [actualValue, expectedValues[index]]
-    );
-    for (let [actualValue, expectedValue] of testComparisons) {
+    expectedValues.forEach((expectedValue, index) => {
+       let actualValue = actualValues[index];
         //TODO: This tests for a very weak common definition of equality.
         //      We should make this a stronger test when .equals() is added to the Value interface[1].
         //      In the meantime, the core writing/equality logic is more strictly tested by
@@ -43,7 +42,7 @@ function roundTripTest(dumpFn: (...values: any[]) => any,
         assert.deepEqual(actualValue.getAnnotations(), expectedValue.getAnnotations());
         assert.equal(actualValue.isNull(), expectedValue.isNull());
         assert.equal(actualValue.getType(), expectedValue.getType());
-    }
+    });
 }
 
 describe('dump*()', () => {
@@ -73,12 +72,6 @@ describe('dump*()', () => {
         writer.writeInt(3);
         writer.stepOut();
         writer.close();
-        let expectedBytes: Uint8Array = writer.getBytes();
-        let byteComparisons: [number, number][] = Array.from(ionBinary).map(
-            (byte, index) => [byte, expectedBytes[index]]
-        );
-        for (let [actualByte, expectedByte] of byteComparisons) {
-            assert.equal(actualByte, expectedByte);
-        }
+        assert.deepEqual(ionBinary, writer.getBytes());
     });
 });

--- a/test/dump.ts
+++ b/test/dump.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {assert} from 'chai';
+import * as ion from '../src/IonTests';
+import {dom, exampleIonValuesWhere, exampleJsValuesWhere, IonTypes} from "../src/IonTests";
+
+function roundTripTests(...values: any[]) {
+    let expectedValues: dom.Value[] = values.map((jsValue) => dom.Value.from(jsValue));
+    it(`dumpBinary(${values})`, () => roundTripTest(ion.dumpBinary, values, expectedValues));
+    it(`dumpText(${values})`,() => roundTripTest(ion.dumpText, values, expectedValues));
+    it(`dumpPrettyText(${values})`, () => roundTripTest(ion.dumpPrettyText, values, expectedValues));
+}
+
+// Dumps the provided values to Ion using the specified dump*() function, uses loadAll() to read the values
+// back in, then compares the input values to the loaded values.
+function roundTripTest(dumpFn: (...values: any[]) => any,
+                       inputValues: any[],
+                       expectedValues: dom.Value[]) {
+    let actualValues: dom.Value[] = dom.loadAll(dumpFn(inputValues));
+    let testComparisons: [dom.Value, dom.Value][] = actualValues.map(
+        (actualValue, index) => [actualValue, expectedValues[index]]
+    );
+    for (let [actualValue, expectedValue] of testComparisons) {
+        //TODO: This tests for a very weak common definition of equality.
+        //      We should make this a stronger test when .equals() is added to the Value interface[1].
+        //      In the meantime, the core writing/equality logic is more strictly tested by
+        //      test/dom/Value.ts, which evaluates the data produced by the Value.writeTo() function
+        //      at the core of the ion.dump*() methods.
+        //      [1] https://github.com/amzn/ion-js/issues/576
+        assert.deepEqual(actualValue.getAnnotations(), expectedValue.getAnnotations());
+        assert.equal(actualValue.isNull(), expectedValue.isNull());
+        assert.equal(actualValue.getType(), expectedValue.getType());
+    }
+}
+
+describe('dump*()', () => {
+    describe('Round tripping JS values', () => {
+        roundTripTests(exampleJsValuesWhere())
+    });
+    describe('Round tripping Ion values', () => {
+        roundTripTests(exampleIonValuesWhere())
+    });
+    it('Text stream', () => {
+        let ionText = ion.dumpText(null, 7, "Hello", [1, 2, 3]);
+        assert.equal(ionText, 'null\n7\n"Hello"\n[1,2,3]');
+    });
+    it('Pretty text stream', () => {
+        let ionPrettyText = ion.dumpPrettyText(null, 7, "Hello", [1, 2, 3]);
+        assert.equal(ionPrettyText, 'null\n7\n"Hello"\n[\n  1,\n  2,\n  3\n]');
+    });
+    it('Binary stream', () => {
+        let ionBinary: Uint8Array = ion.dumpBinary(null, 7, "Hello", [1, 2, 3]);
+        let writer = ion.makeBinaryWriter();
+        writer.writeNull(IonTypes.NULL);
+        writer.writeInt(7);
+        writer.writeString("Hello");
+        writer.stepIn(IonTypes.LIST);
+        writer.writeInt(1);
+        writer.writeInt(2);
+        writer.writeInt(3);
+        writer.stepOut();
+        writer.close();
+        let expectedBytes: Uint8Array = writer.getBytes();
+        let byteComparisons: [number, number][] = Array.from(ionBinary).map(
+            (byte, index) => [byte, expectedBytes[index]]
+        );
+        for (let [actualByte, expectedByte] of byteComparisons) {
+            assert.equal(actualByte, expectedByte);
+        }
+    });
+});

--- a/test/exampleValues.ts
+++ b/test/exampleValues.ts
@@ -1,0 +1,44 @@
+import {Timestamp} from "../src/IonTimestamp";
+import {Decimal} from "../src/IonDecimal";
+import {load, Value} from "../src/dom";
+
+// Used as a default filtering predicate in functions below
+function acceptAnyValue(_: any) : boolean {
+    return true;
+}
+
+// A common collection of JS values that can be reduced to a relevant subset using the provided filter function.
+export function exampleJsValuesWhere(filter: (v: any) => boolean = acceptAnyValue): any[] {
+    return [
+        null,
+        true, false,
+        Number.MIN_SAFE_INTEGER, -7.5, -7, 0, 7, 7.5, Number.MAX_SAFE_INTEGER,
+        "", "foo",
+        new Date(0),
+        Timestamp.parse('1970-01-01T00:00:00Z'),
+        new Decimal('1.5'),
+        [], [1, 2, 3], [{foo: "bar"}],
+        {}, {foo: "bar", baz: 5}, {foo: [1, 2, 3]}
+    ].filter(filter);
+}
+
+// A common collection of Ion dom.Value instances that can be reduced to a relevant subset using
+// the provided filter function.
+export function exampleIonValuesWhere(filter: (v: Value) => boolean = acceptAnyValue): Value[] {
+    return [
+        load('null')!, // null
+        load('null.string')!, // typed null
+        load('true')!, // boolean
+        load('1')!, // integer
+        load('15e-1')!, // float
+        load('15d-1')!, // decimal
+        load('1970-01-01T00:00:00.000Z')!, // timestamp
+        load('"Hello"')!, // string
+        load('Hello')!, // symbol
+        load('{{aGVsbG8gd29ybGQ=}}')!, // blob
+        load('{{"February"}}')!, // clob
+        load('[1, 2, 3]')!, // list
+        load('(1 2 3)')!, // s-expression
+        load('{foo: true, bar: "Hello", baz: 5, qux: null}')! // struct
+    ].filter(filter);
+}

--- a/test/mochaSupport.ts
+++ b/test/mochaSupport.ts
@@ -1,0 +1,10 @@
+// Generates a mocha-friendly string representation of the provided value that can be used in test names
+export function valueName(value: any): string {
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === "object") {
+        return `${value.constructor.name}(${value})`;
+    }
+    return `${typeof value}(${value})`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // TODO enable this to have stricter checking
     "strict": false,
     "strictNullChecks": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist/es6/es6",
     "experimentalDecorators": true
   }


### PR DESCRIPTION
*Issue #, if available:* #579 

CC: @yohanmartin

*Description of changes:*

### Added `ion.dump*()` functions

Adds 3 new top-level functions in the `ion` module:

```typescript
function dumpBinary(...values: any[]): Uint8Array {}
function dumpText(...values: any[]): string {}
function dumpPrettyText(...values: any[]): string {}
```

Each of these constructs the `Writer` implementation that corresponds to the requested format, writes each value to the writer, closes the writer, and returns the complete serialized stream to the user.

### Moves some test functions to a common `src` file

It makes sense to re-use some test functions and sample values across multiple `.ts` files in `test`. However, the Typescript compiler will throw an error if you reference functions from another file in `test`. I've instead moved the relevant functions to `src/IonTests.ts`, which already existed for this reason.

### Avoids using re-exports of load() and loadAll() within `test/dom`

`ion.load()` and `ion.loadAll()` are re-exports of `ion.dom.load()` and `ion.dom.loadAll()` respectively. The compiler will sometimes complain that `ion.load()` is not yet defined if it is referenced from within `ion.dom` test code. Changing these references to `ion.dom.*` in the test code prevents this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
