### PR TITLE
Flattened `dist` output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     // TODO enable this to have stricter checking
     "strict": false,
     "strictNullChecks": true,
-    "rootDir": ".",
+    "rootDirs": ["src", "test"],
     "outDir": "dist/es6/es6",
     "experimentalDecorators": true
   }


### PR DESCRIPTION
*Description of changes:*
PR #580 caused `dist` folders to include a new `src` subdirectory. This change will:
* Remove the `src` subdirectory from `dist/*`, restoring the old path structures.
* Allow Webstorm to perform `import`s across files in `test`.

Unfortunately, this setting does generate a benign compiler warning. I've opened #583 to address that down the road.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
