### PR TITLE
Changes jsbi to be a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "grunt-ts": "^6.0.0-beta.21",
     "grunt-tslint": "^5.0.2",
     "grunt-typedoc": "^0.2.4",
+    "jsbi": "3.1.1",
     "mocha": "^6.2.0",
     "mocha-typescript": "^1.1.17",
     "nyc": "^14.1.1",
@@ -79,7 +80,7 @@
     "typedoc": "^0.16.10",
     "typescript": "^3.6.2"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jsbi": "^3.1.1"
   }
 }


### PR DESCRIPTION
Resolves #588 

For development purposes, I'm proposing we pin the devDependency of jsbi to 3.1.1.  When ^3.1.1 is specified, npm currently installs 3.1.2, which is fine; however, when linking a local ion-js to a local ion-hash-js, npm install for ion-hash-js replaces ion-js's jsbi with version 3.1.1 for some odd reason, which tsc identifies as incompatible with 3.1.2 (from ion-hash-js).  It's quite confusing.

As noted in #588, this is a breaking change, as it has the potential to break the build of any consuming package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
