### PR TITLE
Prevent struct property shadowing

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -30,7 +30,7 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
      * separately to allow field names that would otherwise collide with public properties from the Struct class
      * itself to be stored. (e.g. 'stringValue', 'fields', or 'elements')
      */
-    private _fields = {};
+    private _fields = Object.create(null);
 
     /**
      * Constructor.
@@ -48,9 +48,9 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
         return new Proxy(this, {
             // All values set by the user are stored in `this._fields` to avoid
             // potentially overwriting Struct methods.
-            set: function(target, name, value): any  {
+            set: function(target, name, value): boolean {
                 target._fields[name] = value;
-                return true;
+                return true; // Indicates that the assignment succeeded
             },
             get: function(target, name): any  {
                 // Property accesses will look for matching Struct API properties before

--- a/test/dom/propertyShadowing.ts
+++ b/test/dom/propertyShadowing.ts
@@ -21,5 +21,10 @@ describe('dom.Struct property shadowing', () => {
         assert.equal(s.get('fieldNames', 0)!.stringValue(), 'dog');
         assert.equal(s.get('fieldNames', 1)!.stringValue(), 'cat');
         assert.equal(s.get('fieldNames', 2)!.stringValue(), 'mouse');
+
+        // get() does not return values for properties on `Object`
+        assert.isNull(s.get('toString'));
+        assert.isNull(s.get('toLocaleString'));
+        assert.isNull(s.get('valueOf'));
     })
 });

--- a/test/dom/propertyShadowing.ts
+++ b/test/dom/propertyShadowing.ts
@@ -1,0 +1,25 @@
+import {assert} from "chai";
+import {dom, IonTypes} from "../../src/Ion";
+
+describe('dom.Struct property shadowing', () => {
+    it('Built-in properties cannot be shadowed', () => {
+        // Create a struct with field names that conflict with method names
+        let s = dom.Value.from({
+            getType: "baz",
+            getAnnotations: 56,
+            fieldNames: ['dog', 'cat', 'mouse']
+        }, ['foo', 'bar']);
+
+        // Method names are still directly accessible
+        assert.equal(s.getType(), IonTypes.STRUCT);
+        assert.deepEqual(s.getAnnotations(), ['foo', 'bar']);
+        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames']);
+
+        // Fields with names that would shadow a built-in are accessible via Value#get()
+        assert.equal(s.get('getType')!.stringValue(), "baz");
+        assert.equal(s.get('getAnnotations')!.numberValue(), 56);
+        assert.equal(s.get('fieldNames', 0)!.stringValue(), 'dog');
+        assert.equal(s.get('fieldNames', 1)!.stringValue(), 'cat');
+        assert.equal(s.get('fieldNames', 2)!.stringValue(), 'mouse');
+    })
+});


### PR DESCRIPTION
*Issue #, if available:* #585 

*Description of changes:*

`dom.Struct` now stores its fields in a private `object` called `_fields`. Instances of `dom.Struct` are wrapped in a [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) that:
* Causes all property `set` calls to store the provided value in the `_fields` object rather than storing them on the `dom.Struct` itself.
* Causes all property `get` calls to check whether the requested property name is part of `dom.Struct`'s API; if it is, the API member is returned. If it isn't, `get` will treat the property access as a request for a field.

The `get()` method has been modified to only resolve to fields.

CC @yohanmartin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
