### PR TITLE
JSON.stringify() support for dom.Clob

### DIFF
--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -20,4 +20,26 @@ export class Clob extends Lob(IonTypes.CLOB) {
         writer.setAnnotations(this.getAnnotations());
         writer.writeClob(this);
     }
+
+    toJSON() {
+        // Because the text encoding of the bytes stored in this Clob is unknown,
+        // we write each byte out as a unicode escape (e.g. 127 -> 0x7f -> \u007f)
+        // unless it happens to fall within the ASCII range.
+        // See the Ion cookbook's guide to down-converting to JSON for details:
+        // http://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json
+        let encodedText = '';
+        for (let byte of this) {
+            if (byte >= 32 && byte <= 126) {
+                encodedText += String.fromCharCode(byte);
+                continue;
+            }
+            let hex = byte.toString(16);
+            if (hex.length == 1) {
+                encodedText += "\\u000" + hex;
+            } else {
+                encodedText += "\\u00" + hex;
+            }
+        }
+        return encodedText;
+    }
 }

--- a/src/dom/Clob.ts
+++ b/src/dom/Clob.ts
@@ -23,7 +23,7 @@ export class Clob extends Lob(IonTypes.CLOB) {
 
     toJSON() {
         // Because the text encoding of the bytes stored in this Clob is unknown,
-        // we write each byte out as a unicode escape (e.g. 127 -> 0x7f -> \u007f)
+        // we write each byte out as a Unicode escape (e.g. 127 -> 0x7f -> \u007f)
         // unless it happens to fall within the ASCII range.
         // See the Ion cookbook's guide to down-converting to JSON for details:
         // http://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json

--- a/test/dom/json.ts
+++ b/test/dom/json.ts
@@ -1,6 +1,6 @@
 import {assert} from "chai";
 import * as ion from "../../src/Ion";
-import {Decimal, decodeUtf8, IonTypes, Timestamp, toBase64} from "../../src/Ion";
+import {Decimal, IonTypes, Timestamp, toBase64} from "../../src/Ion";
 import {load, Value} from "../../src/dom";
 import {encodeUtf8} from "../../src/IonTests";
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #587. Related to #563.

*Description of changes:*

Defines `toJSON()` for the `dom.Clob` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
