### PR TITLE
Version bump to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-js",
-  "version": "3.2.0-SNAPSHOT",
+  "version": "4.0.0",
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",


### PR DESCRIPTION
*Description of changes:*

Bumps `ion-js`' version number from `3.2.0-SNAPSHOT` to `4.0.0` in preparation for the next release. The upcoming release converts `jsbi` to a peer dependency, which is a breaking change and requires a major version bump.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
