### PR TITLE
Provides friendlier decimal text serialization

### DIFF
--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -54,6 +54,8 @@ export class Context {
     }
 }
 
+let _jsbiZero = JSBI.BigInt(0);
+
 export class TextWriter extends AbstractWriter {
 
     protected containerContext: Context[];
@@ -159,17 +161,46 @@ export class TextWriter extends AbstractWriter {
         _assertDefined(value);
         this._serializeValue(IonTypes.DECIMAL, value, (value: Decimal) => {
             let s = '';
+
             let coefficient = value.getCoefficient();
-            if (JsbiSupport.isZero(coefficient) && value.isNegative()) {
+            if (JSBI.lessThan(coefficient, _jsbiZero)) {
+                coefficient = JSBI.unaryMinus(coefficient);
+            }
+            if (value.isNegative()) {
                 s += '-';
             }
-            s += coefficient.toString() + 'd';
 
             let exponent = value.getExponent();
-            if (exponent === 0 && _sign(exponent) === -1) {
-                s += '-';
+            let scale = -exponent;
+
+            if (exponent == 0) {
+                s += coefficient + '.';
+
+            } else if (exponent < 0) {
+                // Avoid printing small negative exponents using a heuristic
+                // adapted from http://speleotrove.com/decimal/daconvs.html
+
+                let significantDigits = coefficient.toString().length;
+                let adjustedExponent = significantDigits - 1 - scale;
+                if (adjustedExponent >= 0) {
+                    let wholeDigits = significantDigits - scale;
+                    s += coefficient.toString().substring(0, wholeDigits);
+                    s += '.';
+                    s += coefficient.toString().substring(wholeDigits, significantDigits);
+                } else if (adjustedExponent >= -6) {
+                    s += '0.';
+                    s += '00000'.substring(0, scale - significantDigits);
+                    s += coefficient;
+                } else {
+                    s += coefficient;
+                    s += 'd-';
+                    s += scale.toString();
+                }
+
+            } else {  // exponent > 0
+                s += coefficient + 'd' + exponent;
             }
-            s += exponent;
+
             this.writeUtf8(s);
         });
     }

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -54,8 +54,6 @@ export class Context {
     }
 }
 
-let _jsbiZero = JSBI.BigInt(0);
-
 export class TextWriter extends AbstractWriter {
 
     protected containerContext: Context[];
@@ -163,7 +161,7 @@ export class TextWriter extends AbstractWriter {
             let s = '';
 
             let coefficient = value.getCoefficient();
-            if (JSBI.lessThan(coefficient, _jsbiZero)) {
+            if (JSBI.lessThan(coefficient, JsbiSupport.ZERO)) {
                 coefficient = JSBI.unaryMinus(coefficient);
             }
             if (value.isNegative()) {

--- a/test/IonTextWriter.ts
+++ b/test/IonTextWriter.ts
@@ -139,10 +139,10 @@ describe("Text Writer", () => {
                 expected
             );
         };
-        decimalTest('Writes positive decimal', '123.456', '123456d-3');
-        decimalTest('Writes negative decimal', '-123.456', '-123456d-3');
-        decimalTest('Writes integer decimal', '123456.', '123456d0');
-        decimalTest('Mantissa-only decimal has leading zero', '123456d-6', '123456d-6');
+        decimalTest('Writes positive decimal', '123.456', '123.456');
+        decimalTest('Writes negative decimal', '-123.456', '-123.456');
+        decimalTest('Writes integer decimal', '123456.', '123456.');
+        decimalTest('Mantissa-only decimal has leading zero', '123456d-6', '0.123456');
         writerTest('Writes null decimal using null',
             writer => writer.writeDecimal(null),
             'null.decimal');
@@ -154,7 +154,7 @@ describe("Text Writer", () => {
                 writer.setAnnotations(['foo', 'bar']);
                 writer.writeDecimal(ion.Decimal.parse('123.456'))
             },
-            'foo::bar::123456d-3');
+            'foo::bar::123.456');
     });
 
     describe("Writing floats", () => {
@@ -548,7 +548,7 @@ describe("Text Writer", () => {
   symbol: a5::symbol,
   symbol: null.symbol,
   timestamp: a8::2017-04-03T00:00:00.000Z,
-  decimal: a9::12d-1,
+  decimal: a9::1.2,
   struct: a10::{
     symbol: a11::symbol
   },
@@ -557,7 +557,7 @@ describe("Text Writer", () => {
     a15::"string",
     a16::symbol,
     a19::2017-04-03T00:00:00.000Z,
-    a20::12d-1,
+    a20::1.2,
     a21::{
     },
     a22::[


### PR DESCRIPTION
Resolves #606 

Follows the logic used in ion-java's [_Private_IonTextAppender.printDecimal()](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/impl/_Private_IonTextAppender.java#L719).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
