### PR TITLE
Updates IonTextReader.annotations() to avoid returning special annotation strings within single quotes

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -28,7 +28,6 @@ import {SymbolToken} from "./IonSymbolToken";
 import {IonType} from "./IonType";
 import {IonTypes} from "./IonTypes";
 import {JsbiSupport} from "./JsbiSupport";
-import {_toInt} from "./util";
 
 const EOF = -1;  // EOF is end of container, distinct from undefined which is value has been consumed
 const ERROR           = -2;
@@ -751,10 +750,7 @@ export class ParserTextRaw {
             let ch = this._read_after_whitespace(true);
             if (ch == CH_CL && this._peek() == CH_CL) {
                 this._read(); // consume the colon character
-                let sid = NaN;
-                if (symbol[0] === '$') {
-                    sid = _toInt(symbol.substr(1, symbol.length));
-                }
+                let sid = this._parseSymbolId(symbol);
                 if (sid === 0) {
                     throw new Error('Symbol ID zero is not supported.');
                 } else if (isNaN(sid)) {
@@ -1516,6 +1512,23 @@ export class ParserTextRaw {
             ii++;
         }
         return ch;
+    }
+
+    /**
+     * Attempts to parse a SID from a string such as "$5".  Specifically:
+     * if s starts with '$', and the remaining chars are in the range ['0'..'9']
+     * and can be parsed as an int, returns the int value;  otherwise returns NaN.
+     */
+    private _parseSymbolId(s: string): number {
+        if (s[0] !== '$') {
+            return NaN;
+        }
+        for (let i = 1; i < s.length; i++) {
+            if (s[i] < '0' || s[i] > '9') {
+                return NaN;
+            }
+        }
+        return parseInt(s.substr(1, s.length));
     }
 
     private _error(msg: string): void {

--- a/src/IonSymbolToken.ts
+++ b/src/IonSymbolToken.ts
@@ -14,8 +14,9 @@
  */
 
 /**
- * An Ion symbol token (field name, annotation, and symbol values)
- * providing both the symbol text and the assigned symbol ID.
+ * An Ion symbol token (used to represent field names, annotations,
+ * and symbol values) providing both the symbol text and the assigned
+ * symbol ID.
  */
 export class SymbolToken {
     private static _UNKNOWN_SYMBOL_ID = -1;

--- a/src/IonSymbolToken.ts
+++ b/src/IonSymbolToken.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * An Ion symbol token (field name, annotation, and symbol values)
+ * providing both the symbol text and the assigned symbol ID.
+ */
+export class SymbolToken {
+    private static _UNKNOWN_SYMBOL_ID = -1;
+
+    constructor(private text: string | null,
+                private sid: number = SymbolToken._UNKNOWN_SYMBOL_ID) {
+    }
+
+    /**
+     * Returns the text of this symbol, or null if the text is unknown.
+     */
+    public getText(): string | null {
+        return this.text;
+    }
+
+    /**
+     * Returns the symbol ID (sid) of this symbol, or -1 if the sid is unknown.
+     */
+    public getSid(): number {
+        return this.sid;
+    }
+}
+

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -151,7 +151,7 @@ export class TextReader implements Reader {
                 this._raw_type = undefined;
             } else if (this._raw_type === T_STRUCT) {
                 if (p.annotations().length !== 1) break;
-                if (p.annotations()[0] != ion_symbol_table) break;
+                if (p.annotations()[0].getText() != ion_symbol_table) break;
                 this._type = get_ion_type(this._raw_type);
                 this._symtab = makeSymbolTable(this._cat, this);
                 this._raw = undefined;
@@ -217,20 +217,19 @@ export class TextReader implements Reader {
     }
 
     annotations(): string[] {
-        let ann : string[] = [];
-        for (let str of this._parser.annotations()) {
-            ann.push(str);
-        }
-        for (let i = 0; i < ann.length; i++) {
-            if(ann[i].length > 1 && ann[i][0] === '$') {
-                let tempStr = ann[i].substr(1, ann[i].length);
-                if (+tempStr === +tempStr) {//look up sid, +str === +str is a one line is integer hack
-                    let symbol = this._symtab.getSymbolText(Number(tempStr));
-                    if(symbol === undefined || symbol === null) throw new Error("Unresolvable symbol ID, symboltokens unsupported.");
-                    ann[i] = symbol;
+        let ann: string[] = [];
+        this._parser.annotations().forEach((st) => {
+            let text = st.getText();
+            if (text !== null) {
+                ann.push(text);
+            } else {
+                let symbol = this._symtab.getSymbolText(st.getSid());
+                if (symbol === undefined || symbol === null) {
+                    throw new Error("Unresolvable symbol ID, symboltokens unsupported.");
                 }
+                ann.push(symbol);
             }
-        }
+        });
         return ann;
     }
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -217,20 +217,18 @@ export class TextReader implements Reader {
     }
 
     annotations(): string[] {
-        let ann: string[] = [];
-        this._parser.annotations().forEach((st) => {
+        return this._parser.annotations().map((st) => {
             let text = st.getText();
             if (text !== null) {
-                ann.push(text);
+                return text;
             } else {
                 let symbol = this._symtab.getSymbolText(st.getSid());
                 if (symbol === undefined || symbol === null) {
                     throw new Error("Unresolvable symbol ID, symboltokens unsupported.");
                 }
-                ann.push(symbol);
+                return symbol;
             }
         });
-        return ann;
     }
 
     isNull(): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,3 +36,17 @@ export function _assertDefined(value: any): void {
         throw new Error("Expected value to be defined");
     }
 }
+
+/**
+ * If s consists solely of chars ['0'..'9'] and can be parsed as an int,
+ * returns the int value;  otherwise returns NaN.
+ */
+export function _toInt(s: string): number {
+    for (let i = 0; i < s.length; i++) {
+        if (s[i] < '0' || s[i] > '9') {
+            return NaN;
+        }
+    }
+    return parseInt(s);
+}
+

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,4 +36,3 @@ export function _assertDefined(value: any): void {
         throw new Error("Expected value to be defined");
     }
 }
-

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,16 +37,3 @@ export function _assertDefined(value: any): void {
     }
 }
 
-/**
- * If s consists solely of chars ['0'..'9'] and can be parsed as an int,
- * returns the int value;  otherwise returns NaN.
- */
-export function _toInt(s: string): number {
-    for (let i = 0; i < s.length; i++) {
-        if (s[i] < '0' || s[i] > '9') {
-            return NaN;
-        }
-    }
-    return parseInt(s);
-}
-

--- a/test/IonAnnotations.ts
+++ b/test/IonAnnotations.ts
@@ -44,6 +44,13 @@ describe('Annotations', () => {
         assert.deepEqual(reader.annotations(), ['$ion_symbol_table']);
     });
 
+    it('Does not resolve non-ID annotations ($)', () => {
+        let data = "'$'::123";
+        let reader = ion.makeReader(data);
+        reader.next();
+        assert.deepEqual(reader.annotations(), ["$"]);
+    });
+
     it('Does not resolve non-ID annotations ($3)', () => {
         let data = "'$3'::123";
         let reader = ion.makeReader(data);

--- a/test/IonAnnotations.ts
+++ b/test/IonAnnotations.ts
@@ -44,11 +44,18 @@ describe('Annotations', () => {
         assert.deepEqual(reader.annotations(), ['$ion_symbol_table']);
     });
 
-    it('Does not resolve non-ID annotations', () => {
+    it('Does not resolve non-ID annotations ($3)', () => {
         let data = "'$3'::123";
         let reader = ion.makeReader(data);
         reader.next();
-        assert.deepEqual(reader.annotations(), ["'$3'"]);
+        assert.deepEqual(reader.annotations(), ["$3"]);
+    });
+
+    it('Does not resolve non-ID annotations ($1.00)', () => {
+        let data = "'$1.00'::123";
+        let reader = ion.makeReader(data);
+        reader.next();
+        assert.deepEqual(reader.annotations(), ["$1.00"]);
     });
 
     it('Create annotations', () => {

--- a/test/IonParserTextRaw.ts
+++ b/test/IonParserTextRaw.ts
@@ -19,6 +19,7 @@ import {ParserTextRaw} from '../src/IonParserTextRaw';
 import {IonTypes} from "../src/IonTypes";
 import {IonType} from "../src/IonType";
 import JSBI from "jsbi";
+import {SymbolToken} from "../src/IonSymbolToken";
 
 // a few notes/surprises:
 // - fieldNameType() always appears to return 9 (T_IDENTIFIER) when positioned on a field,
@@ -266,20 +267,22 @@ describe('IonParserTextRaw', () => {
 
     it('Reads annotations', () => {
         let p = new ParserTextRaw(new StringSpan('z::[1, y::2, x::{a: w::3, b: v::(s::t::u::4)}, r::5]'));
-        p.next(); assert.deepEqual(p.annotations(), ['z']);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('z')]);
         p.next(); assert.deepEqual(p.annotations(), []);
-        p.next(); assert.deepEqual(p.annotations(), ['y']);
-        p.next(); assert.deepEqual(p.annotations(), ['x']);
-        p.next(); assert.deepEqual(p.annotations(), ['w']);
-        p.next(); assert.deepEqual(p.annotations(), ['v']);
-        p.next(); assert.deepEqual(p.annotations(), ['s', 't', 'u']);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('y')]);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('x')]);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('w')]);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('v')]);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('s'),
+                                                     new SymbolToken('t'),
+                                                     new SymbolToken('u')]);
 
         assert.equal(p.next(), -1);  // "EOF" (end of nested sexp)
         assert.deepEqual(p.annotations(), []);
         assert.equal(p.next(), -1);  // "EOF" (end of nested struct)
         assert.deepEqual(p.annotations(), []);
 
-        p.next(); assert.deepEqual(p.annotations(), ['r']);
+        p.next(); assert.deepEqual(p.annotations(), [new SymbolToken('r')]);
         assert.equal(p.next(), -1);  // "EOF" (end of list)
         assert.deepEqual(p.annotations(), []);
     })


### PR DESCRIPTION
* introduces `SymbolToken` class, currently only used internally
* IonParserTextRaw's `ann` array is now of type `SymbolToken[]` instead of `any[]` (well, `string[]` in practice)
* removes logic that would incorrectly identify `'$1.00'` as SID 1, in favor of a stronger test

Resolves #610 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
