### PR TITLE
Set version to v4.1.0-SNAPSHOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-js",
-  "version": "4.0.1",
+  "version": "4.1.0-SNAPSHOT",
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",


### PR DESCRIPTION
Bumping the package version to `v4.1.0-SNAPSHOT` following the `v4.0.1` release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
