### PR TITLE
add deleteField method for deleting keys of Struct type

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -62,10 +62,10 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
             },
             deleteProperty: function (target, name): boolean {
                 // Property is deleted only if it's in _field Collection
-                // reference Document: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#Return_value
                 if (name in target._fields) {
                     delete target._fields[name];
                 }
+                // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#Return_value
                 return true;
             }
         });

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -62,6 +62,7 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
             },
             deleteProperty: function (target, name): boolean {
                 // Property is deleted only if it's in _field Collection
+                // reference Document: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#Return_value
                 if (name in target._fields) {
                     delete target._fields[name];
                 }

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -59,6 +59,13 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
                     return target[name];
                 }
                 return target._fields[name];
+            },
+            deleteProperty: function (target, name): boolean {
+                // Property is deleted only if it's in _field Collection
+                if (name in target._fields) {
+                    delete target._fields[name];
+                }
+                return true;
             }
         });
     }
@@ -113,6 +120,14 @@ export class Struct extends Value(Object, IonTypes.STRUCT, FromJsConstructor.NON
             value.writeTo(writer);
         }
         writer.stepOut();
+    }
+
+    deleteField(name: string): boolean {
+        if (name in this._fields) {
+            delete this._fields[name];
+            return true;
+        }
+        return false;
     }
 
     toJSON() {

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -140,8 +140,8 @@ export interface Value {
     writeTo(writer: Writer): void;
 
     /**
-     * For the Struct type, deletes the key/field if it's in the _fields collection
-     * otherwise throws an Error.
+     * For the Struct type, deletes the field with provided name if present. Returns a boolean
+     * indicating whether the Struct was modified. For all other types, throws an Error.
      */
     deleteField(name: string): boolean;
 }
@@ -296,7 +296,7 @@ export function Value<Clazz extends Constructor>(BaseClass: Clazz, ionType: IonT
         }
 
         deleteField(name: string): boolean {
-            this._unsupportedOperation('delete');
+            this._unsupportedOperation('deleteField');
         }
 
         // Returns the IonType associated with a particular dom.Value subclass. Useful for testing.

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -138,6 +138,12 @@ export interface Value {
      * @param writer    An Ion Writer to which the value should be written.
      */
     writeTo(writer: Writer): void;
+
+    /**
+     * For the Struct type, deletes the key/field if it's in the _fields collection
+     * otherwise throws an Error.
+     */
+    deleteField(name: string): boolean;
 }
 
 /**
@@ -287,6 +293,10 @@ export function Value<Clazz extends Constructor>(BaseClass: Clazz, ionType: IonT
 
         writeTo(writer: Writer): void {
             this._unsupportedOperation('writeTo');
+        }
+
+        deleteField(name: string): boolean {
+            this._unsupportedOperation('delete');
         }
 
         // Returns the IonType associated with a particular dom.Value subclass. Useful for testing.

--- a/test/dom/propertyShadowing.ts
+++ b/test/dom/propertyShadowing.ts
@@ -1,5 +1,6 @@
 import {assert} from "chai";
 import {dom, IonTypes} from "../../src/Ion";
+import {Err} from "typedoc/dist/lib/utils/result";
 
 describe('dom.Struct property shadowing', () => {
     it('Built-in properties cannot be shadowed', () => {
@@ -7,13 +8,18 @@ describe('dom.Struct property shadowing', () => {
         let s = dom.Value.from({
             getType: "baz",
             getAnnotations: 56,
-            fieldNames: ['dog', 'cat', 'mouse']
+            fieldNames: ['dog', 'cat', 'mouse'],
+            toString: 10,
+            greetings: "hi",
+            age: 7
         }, ['foo', 'bar']);
+
+        let l = dom.Value.from([1, 2, 3]);
 
         // Method names are still directly accessible
         assert.equal(s.getType(), IonTypes.STRUCT);
         assert.deepEqual(s.getAnnotations(), ['foo', 'bar']);
-        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames']);
+        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames', 'toString', 'greetings', 'age']);
 
         // Fields with names that would shadow a built-in are accessible via Value#get()
         assert.equal(s.get('getType')!.stringValue(), "baz");
@@ -21,6 +27,29 @@ describe('dom.Struct property shadowing', () => {
         assert.equal(s.get('fieldNames', 0)!.stringValue(), 'dog');
         assert.equal(s.get('fieldNames', 1)!.stringValue(), 'cat');
         assert.equal(s.get('fieldNames', 2)!.stringValue(), 'mouse');
+
+        // deleteProperty proxy method
+        assert.isTrue(delete s['greetings']);
+        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames', 'toString', 'age']);
+
+        // deleteField Struct method
+        assert.isTrue(s.deleteField('age'));
+        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames', 'toString']);
+
+        // delete for properties that match built-in
+        assert.equal(s.get('toString')!.numberValue(), 10);
+        assert.isTrue(delete s['toString']);
+        assert.equal(s.toString(),'{getType: baz, getAnnotations: 56, fieldNames: [dog, cat, mouse]}');
+        assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames']);
+
+        // delete for field that doesn't exist
+        assert.isFalse(s.deleteField('toString'));
+        assert.isFalse(s.deleteField('greetings'));
+        assert.isFalse(s.deleteField('name'));
+        assert.isUndefined(s['greetings']);
+
+        // deleteField will throw an error if it's called on a dom.Value that isn't a struct
+        assert.throws(() => l.deleteField("1"), Error);
 
         // get() does not return values for properties on `Object`
         assert.isNull(s.get('toString'));

--- a/test/dom/propertyShadowing.ts
+++ b/test/dom/propertyShadowing.ts
@@ -1,6 +1,5 @@
 import {assert} from "chai";
 import {dom, IonTypes} from "../../src/Ion";
-import {Err} from "typedoc/dist/lib/utils/result";
 
 describe('dom.Struct property shadowing', () => {
     it('Built-in properties cannot be shadowed', () => {
@@ -13,8 +12,6 @@ describe('dom.Struct property shadowing', () => {
             greetings: "hi",
             age: 7
         }, ['foo', 'bar']);
-
-        let l = dom.Value.from([1, 2, 3]);
 
         // Method names are still directly accessible
         assert.equal(s.getType(), IonTypes.STRUCT);
@@ -39,7 +36,7 @@ describe('dom.Struct property shadowing', () => {
         // delete for properties that match built-in
         assert.equal(s.get('toString')!.numberValue(), 10);
         assert.isTrue(delete s['toString']);
-        assert.equal(s.toString(),'{getType: baz, getAnnotations: 56, fieldNames: [dog, cat, mouse]}');
+        assert.equal(typeof s.toString, "function");
         assert.deepEqual(s.fieldNames(), ['getType', 'getAnnotations', 'fieldNames']);
 
         // delete for field that doesn't exist
@@ -49,6 +46,7 @@ describe('dom.Struct property shadowing', () => {
         assert.isUndefined(s['greetings']);
 
         // deleteField will throw an error if it's called on a dom.Value that isn't a struct
+        let l = dom.Value.from([1, 2, 3]);
         assert.throws(() => l.deleteField("1"), Error);
 
         // get() does not return values for properties on `Object`


### PR DESCRIPTION
*Issue #, if available:*   #622 

*Description of changes:*
added a deleteField method which will delete the keys for Struct type. 
added unit-tests to check if deleteField works with built-in and user defind properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
