### PR TITLE
Implement process for ion-js cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "ts-node": "^8.10.1",
     "tslint": "^5.20.1",
     "typedoc": "^0.16.10",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.3",
+    "yargs": "^15.4.1"
   },
   "peerDependencies": {
     "jsbi": "^3.1.1"

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -119,11 +119,11 @@ export class IonComparisonReport {
     comparisonReportFile: Writable;
     comparisonType: ComparisonType;
 
-    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: Writable, comprisonType: ComparisonType) {
+    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: Writable, comparisonType: ComparisonType) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.comparisonReportFile = comparisonReportFile;
-        this.comparisonType = comprisonType;
+        this.comparisonType = comparisonType;
     }
 
     writeComparisonReport(result: ComparisonResultType, message: string, event_index_lhs: number, event_index_rhs: number) {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -6,12 +6,14 @@ import {ComparisonContext, ComparisonType} from "./Compare";
 
 /** common CLI arguments structure
  *
- * @params outputFile,errorReportFile : 'any' datatype to use stdout as well as file write stream to write ion data
+ * @params
  * */
 export class IonCliCommonArgs {
     inputFiles: Array<string>;
-    outputFile: any;
     outputFormatName: OutputFormat;
+
+    // outputFile,errorReportFile: 'any' datatype to use stdout as well as file write stream to write ion data
+    outputFile: any;
     errorReportFile: any;
 
     constructor(argv: yargs.Arguments) {

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,15 +2,17 @@ import * as yargs from "yargs";
 import fs from "fs";
 import {OutputFormat} from "./OutputFormat";
 import {IonTypes, makeTextWriter} from "./Ion";
-import {Writable} from "stream";
 import {ComparisonContext, ComparisonType} from "./Compare";
 
-/** common CLI arguments structure */
+/** common CLI arguments structure
+ *
+ * @params outputFile,errorReportFile : 'any' datatype to use stdout as well as file write stream to write ion data
+ * */
 export class IonCliCommonArgs {
     inputFiles: Array<string>;
-    outputFile: Writable;
+    outputFile: any;
     outputFormatName: OutputFormat;
-    errorReportFile: Writable;
+    errorReportFile: any;
 
     constructor(argv: yargs.Arguments) {
         this.outputFile = argv["output"] ? fs.createWriteStream(argv["output"] as string, {flags: 'w'}) : process.stdout;
@@ -20,11 +22,11 @@ export class IonCliCommonArgs {
         this.inputFiles = argv["input-file"] as Array<string>;
     }
 
-    getOutputFile(): Writable {
+    getOutputFile(): any {
         return this.outputFile;
     }
 
-    getErrorReportFile(): Writable {
+    getErrorReportFile(): any {
         return this.errorReportFile;
     }
 
@@ -116,10 +118,10 @@ export class ComparisonResult {
 export class IonComparisonReport {
     lhs: ComparisonContext;
     rhs: ComparisonContext;
-    comparisonReportFile: Writable;
+    comparisonReportFile: any;
     comparisonType: ComparisonType;
 
-    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: Writable, comparisonType: ComparisonType) {
+    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: any, comparisonType: ComparisonType) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.comparisonReportFile = comparisonReportFile;

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -1,5 +1,5 @@
-import yargs from "yargs";
-import fs, {WriteStream} from "fs";
+import * as yargs from "yargs";
+import fs from "fs";
 import {OutputFormat} from "./OutputFormat";
 import {IonTypes, makeTextWriter} from "./Ion";
 import {Writable} from "stream";

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -13,6 +13,7 @@ export class IonCliCommonArgs {
     outputFormatName: OutputFormat;
 
     // outputFile,errorReportFile: 'any' datatype to use stdout as well as file write stream to write ion data
+    // for more information : https://github.com/amzn/ion-js/issues/627
     outputFile: any;
     errorReportFile: any;
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,13 +2,14 @@ import yargs from "yargs";
 import fs, {WriteStream} from "fs";
 import {OutputFormat} from "./OutputFormat";
 import {IonTypes, makeTextWriter} from "./Ion";
+import {Writable} from "stream";
 
 /** common CLI arguments structure */
 export class IonCliCommonArgs {
     inputFiles: Array<string>;
-    outputFile: WriteStream | NodeJS.WriteStream;
+    outputFile: Writable;
     outputFormatName: OutputFormat;
-    errorReportFile: WriteStream | NodeJS.WriteStream;
+    errorReportFile: Writable;
 
     constructor(argv: yargs.Arguments) {
         this.outputFile = argv["output"] ? fs.createWriteStream(argv["output"] as string, {flags: 'w'}) : process.stdout;
@@ -18,11 +19,11 @@ export class IonCliCommonArgs {
         this.inputFiles = argv["input-file"] as Array<string>;
     }
 
-    getOutputFile(): WriteStream | NodeJS.WriteStream {
+    getOutputFile(): Writable {
         return this.outputFile;
     }
 
-    getErrorReportFile(): WriteStream | NodeJS.WriteStream {
+    getErrorReportFile(): Writable {
         return this.errorReportFile;
     }
 

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -1,0 +1,89 @@
+import yargs from "yargs";
+import fs from "fs";
+import {OutputFormat} from "./OutputFormat";
+
+/** common CLI arguments structure */
+export class IonCliCommonArgs {
+    inputFiles: Array<string>;
+    outputFile: any;
+    outputFormatName: OutputFormat;
+    errorReportFile: any;
+
+    constructor(argv: yargs.Arguments) {
+        this.outputFile = argv["output"] ? fs.createWriteStream(<string>argv["output"], {flags: 'w'}) : process.stdout;
+        // create error output stream (DEFAULT: stderr)
+        this.errorReportFile = argv["error-report"] ? fs.createWriteStream(<string>argv["error-report"], {flags: 'w'}) : process.stderr;
+        this.outputFormatName = <OutputFormat>argv["output-format"];
+        this.inputFiles = <Array<string>>argv["inputfile"];
+    }
+
+    getOutputFile(): any {
+        return this.outputFile;
+    }
+
+    getErrorReportFile(): any {
+        return this.errorReportFile;
+    }
+
+    getInputFiles(): Array<string> {
+        return this.inputFiles;
+    }
+
+    getOutputFormatName(): OutputFormat {
+        return this.outputFormatName;
+    }
+}
+
+/** Error Types symbol[READ | WRITE | STATE] */
+export enum ErrorType {
+    READ = "READ",
+    WRITE = "WRITE",
+    STATE = "STATE"
+}
+
+/** Error structure for error report */
+export class IonCliError {
+    errorType: ErrorType;
+    location: string;
+    message: string;
+    errorReportFile: any;
+
+    constructor(errorType: ErrorType, location: string, message: string, errorReportFile: any) {
+        this.errorType = errorType;
+        this.location = location;
+        this.message = message;
+        this.errorReportFile = errorReportFile;
+    }
+
+    writeErrorReport() {
+        this.errorReportFile.write(this.errorType + ": " + this.location + " " + this.message + "\n");
+    }
+}
+
+const argv = yargs
+    .commandDir(__dirname,{
+        extensions: ['ts'],
+    })
+    .options({
+        'output': {
+            alias: 'o',
+            description: 'Output location. [default: stdout]',
+        },
+        'output-format': {
+            alias: 'f',
+            choices: ['pretty', 'text', 'binary', 'events', 'none'] as const,
+            default: 'pretty',
+            description: "Output format, from the set (text | pretty | binary |\n"
+                + "events | none). 'events' is only available with the\n"
+                + "'process' command, and outputs a serialized EventStream\n"
+                + "representing the input Ion stream(s)."
+        },
+        'error-report': {
+            alias: 'e',
+            description: 'ErrorReport location. [default: stderr]',
+        }
+    }).argv;
+
+
+
+

--- a/src/Compare.ts
+++ b/src/Compare.ts
@@ -132,7 +132,7 @@ export class Compare {
         }
         else if(comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIV_TIMELINE
             || comparisonType == ComparisonType.NON_EQUIVS) {
-            lhs.getEventStream().compareEquivs(rhs.getEventStream(), comparisonReport);
+            lhs.getEventStream().compareEquivs(rhs.getEventStream(), comparisonType, comparisonReport);
         }
     }
 }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -108,7 +108,10 @@ abstract class AbstractIonEvent implements IonEvent {
         }
         writer.stepIn(IonTypes.LIST);
         for (let i = 0; i < this.annotations.length; i++) {
+            writer.stepIn(IonTypes.STRUCT);
+            writer.writeFieldName("text");
             writer.writeString(this.annotations[i]);
+            writer.stepOut();
         }
         writer.stepOut();
     }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -489,8 +489,8 @@ class IonStructEvent extends AbsIonContainerEvent {//no embed support as of yet.
                     matchFound = child.compare(expectedChild);
                     if (matchFound.result == ComparisonResultType.EQUAL) paired[j] = true;
                     if (matchFound.result == ComparisonResultType.EQUAL && child.eventType === IonEventType.CONTAINER_START) {
-                        for (let k = j + 1; k < expectedChild.ionValue.length; k++) {
-                            paired[k] = true;
+                        for (let k = 0; k < expectedChild.ionValue.length; k++) {
+                            paired[k + j + 1] = true;
                         }
                         i += child.ionValue.length;
                     }
@@ -546,8 +546,8 @@ class IonSexpEvent extends AbsIonContainerEvent {
         if (container.length !== expectedContainer.length) return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "S-expression length don't match");
         for (let i: number = 0; i < container.length; i++) {
             let child = container[i];
-            let eventResult = child.compare(expectedContainer[i]).result;
-            if (eventResult == ComparisonResultType.NOT_EQUAL) {
+            let eventResult = child.compare(expectedContainer[i]);
+            if (eventResult.result == ComparisonResultType.NOT_EQUAL) {
                 return eventResult;
             } else if (child.eventType === IonEventType.CONTAINER_START) {
                 i += child.ionValue.length;

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -58,43 +58,43 @@ export class IonEventStream {
                         writer.writeNull(tempEvent.ionType!);
                         return;
                     }
-                    if(this.isEmbedded) {
+                    if (this.isEmbedded) {
                         writer.writeString(tempEvent.ionValue.toString());
-                    } else {
-                        switch (tempEvent.ionType) {
-                            case IonTypes.BOOL:
-                                writer.writeBoolean(tempEvent.ionValue);
-                                break;
-                            case IonTypes.STRING:
-                                writer.writeString(tempEvent.ionValue);
-                                break;
-                            case IonTypes.SYMBOL:
-                                writer.writeSymbol(tempEvent.ionValue);
-                                break;
-                            case IonTypes.INT:
-                                writer.writeInt(tempEvent.ionValue);
-                                break;
-                            case IonTypes.DECIMAL:
-                                writer.writeDecimal(tempEvent.ionValue);
-                                break;
-                            case IonTypes.FLOAT:
-                                writer.writeFloat64(tempEvent.ionValue);
-                                break;
-                            case IonTypes.NULL:
-                                writer.writeNull(tempEvent.ionType);
-                                break;
-                            case IonTypes.TIMESTAMP:
-                                writer.writeTimestamp(tempEvent.ionValue);
-                                break;
-                            case IonTypes.CLOB:
-                                writer.writeClob(tempEvent.ionValue);
-                                break;
-                            case IonTypes.BLOB:
-                                writer.writeBlob(tempEvent.ionValue);
-                                break;
-                            default:
-                                throw new Error("unexpected type: " + tempEvent.ionType!.name);
-                        }
+                        break;
+                    }
+                    switch (tempEvent.ionType) {
+                        case IonTypes.BOOL:
+                            writer.writeBoolean(tempEvent.ionValue);
+                            break;
+                        case IonTypes.STRING:
+                            writer.writeString(tempEvent.ionValue);
+                            break;
+                        case IonTypes.SYMBOL:
+                            writer.writeSymbol(tempEvent.ionValue);
+                            break;
+                        case IonTypes.INT:
+                            writer.writeInt(tempEvent.ionValue);
+                            break;
+                        case IonTypes.DECIMAL:
+                            writer.writeDecimal(tempEvent.ionValue);
+                            break;
+                        case IonTypes.FLOAT:
+                            writer.writeFloat64(tempEvent.ionValue);
+                            break;
+                        case IonTypes.NULL:
+                            writer.writeNull(tempEvent.ionType);
+                            break;
+                        case IonTypes.TIMESTAMP:
+                            writer.writeTimestamp(tempEvent.ionValue);
+                            break;
+                        case IonTypes.CLOB:
+                            writer.writeClob(tempEvent.ionValue);
+                            break;
+                        case IonTypes.BLOB:
+                            writer.writeBlob(tempEvent.ionValue);
+                            break;
+                        default:
+                            throw new Error("unexpected type: " + tempEvent.ionType!.name);
                     }
                     break;
                 case IonEventType.CONTAINER_START:
@@ -109,7 +109,6 @@ export class IonEventStream {
                     throw new Error("Symboltables unsupported.");
                 default:
                     throw new Error("Unexpected event type: " + tempEvent.eventType);
-
             }
         }
         writer.close();
@@ -217,7 +216,9 @@ export class IonEventStream {
                 tid = this.reader.next();
             }
         } catch (Error) {
-            new IonCliError(ErrorType.READ, path, Error.message, args.getErrorReportFile(), this.eventStream.length).writeErrorReport();
+            if(args) {
+                new IonCliError(ErrorType.READ, path, Error.message, args.getErrorReportFile(), this.eventStream.length).writeErrorReport();
+            }
         }
     }
 

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -35,7 +35,7 @@ export class IonEventStream {
     private eventStream: IonEvent[];
     private reader: Reader;
     private eventFactory: IonEventFactory;
-    isEventStream: boolean; // check if reader has an eventstream as input
+    isEventStream: boolean; // whether the reader has an event stream as input
 
     constructor(reader: Reader, path: string = "", args?: IonCliCommonArgs) {
         this.eventStream = [];
@@ -61,7 +61,7 @@ export class IonEventStream {
                 writer.writeFieldName(tempEvent.fieldName);
             }
             if((tempEvent.ionType == IonTypes.SEXP || tempEvent.ionType == IonTypes.LIST)
-                && tempEvent.annotations[0] == "embedded_documents") {
+                && this.isEmbedded(tempEvent)) {
                 isEmbedded = true;
             }
             writer.setAnnotations(tempEvent.annotations);
@@ -201,7 +201,8 @@ export class IonEventStream {
     }
 
     /**
-     * Returns boolean based on comparison result produced by compareEquivs method
+     * Returns true if this `IonEventStream` is equal to the provided `IonEventStream`
+     * as determined by the `ComparisonType`; returns false otherwise.
      * */
     equivs(expected: IonEventStream, comparisonType: ComparisonType): boolean {
         return this.compareEquivs(expected, comparisonType).result == ComparisonResultType.EQUAL;

--- a/src/OutputFormat.ts
+++ b/src/OutputFormat.ts
@@ -9,7 +9,8 @@ export enum OutputFormat {
     PRETTY = "pretty",
     TEXT = "text",
     BINARY = "binary",
-    EVENTS = "events"
+    EVENTS = "events",
+    NONE = "none"
 }
 
 export namespace OutputFormat {
@@ -22,6 +23,8 @@ export namespace OutputFormat {
             case OutputFormat.BINARY:
                 return makeBinaryWriter();
             case OutputFormat.EVENTS:
+                return makePrettyWriter();
+            case OutputFormat.NONE:
                 return makePrettyWriter();
             default:
                 throw new Error("Output Format " + name + " unexpected.");

--- a/src/OutputFormat.ts
+++ b/src/OutputFormat.ts
@@ -1,0 +1,30 @@
+import {Writer} from './IonWriter';
+import {
+    makePrettyWriter,
+    makeBinaryWriter,
+    makeTextWriter
+} from './Ion';
+
+export enum OutputFormat {
+    PRETTY = "pretty",
+    TEXT = "text",
+    BINARY = "binary",
+    EVENTS = "events"
+}
+
+export namespace OutputFormat {
+    export function createIonWriter(name: OutputFormat) : Writer {
+        switch (name) {
+            case OutputFormat.PRETTY:
+                return makePrettyWriter();
+            case OutputFormat.TEXT:
+                return makeTextWriter();
+            case OutputFormat.BINARY:
+                return makeBinaryWriter();
+            case OutputFormat.EVENTS:
+                return makePrettyWriter();
+            default:
+                throw new Error("Output Format " + name + " unexpected.");
+        }
+    }
+}

--- a/src/OutputFormat.ts
+++ b/src/OutputFormat.ts
@@ -14,7 +14,7 @@ export enum OutputFormat {
 }
 
 export namespace OutputFormat {
-    export function createIonWriter(name: OutputFormat) : Writer {
+    export function createIonWriter(name: OutputFormat) : Writer | null {
         switch (name) {
             case OutputFormat.PRETTY:
                 return makePrettyWriter();
@@ -25,7 +25,7 @@ export namespace OutputFormat {
             case OutputFormat.EVENTS:
                 return makePrettyWriter();
             case OutputFormat.NONE:
-                return makePrettyWriter();
+                return null;
             default:
                 throw new Error("Output Format " + name + " unexpected.");
         }

--- a/src/Process.ts
+++ b/src/Process.ts
@@ -1,0 +1,133 @@
+import {OutputFormat} from './OutputFormat';
+import {IonEventStream} from "./IonEventStream";
+import {Writer} from "./IonWriter";
+import {options} from 'yargs';
+import {makeReader} from "./Ion";
+import * as fs from 'fs';
+
+const argv = options({
+    'output': {
+        alias: 'o',
+        description: 'Output file',
+    },
+    'output-format': {
+        alias: 'f',
+        choices: ['pretty', 'text', 'binary', 'events'] as const,
+        default: 'pretty',
+        description: "Output format, from the set (text | pretty | binary |\n"
+            + "events | none). 'events' is only available with the\n"
+            + "'process' command, and outputs a serialized EventStream\n"
+            + "representing the input Ion stream(s)."
+    },
+    'error-report': {
+        alias: 'e',
+        description: 'Error report file',
+    }
+}).argv;
+
+class ProcessArgs {
+    inputFiles: Array<string>;
+    outputFile: any;
+    outputFormatName: string;
+    errorReportFile: any;
+
+    constructor() {
+        // create output stream (DEFAULT: stdout)
+        this.outputFile = argv["output"] ? fs.createWriteStream(<string> argv["output"], {flags : 'w'}) : process.stdout;
+        // create error output stream (DEFAULT: stderr)
+        this.errorReportFile = argv["error-report"] ? fs.createWriteStream(<string> argv["error-report"], {flags : 'w'}) : process.stderr;
+        this.outputFormatName = <string> argv["output-format"];
+        this.inputFiles = argv._;
+    }
+
+    getOutputFile(): any {
+        return this.outputFile;
+    }
+
+    getErrorReportFile(): any {
+        return this.errorReportFile;
+    }
+
+    getInputFiles(): Array<string> {
+        return this.inputFiles;
+    }
+
+    getOutputFormatName(): OutputFormat{
+        return <OutputFormat> this.outputFormatName;
+    }
+}
+
+/** Error structure for error report */
+class ProcessError {
+    errorType: string;
+    location: string;
+    message: string;
+    errorReportFile: any;
+
+    constructor(errorType: string, location: string, message: string, errorReportFile: any) {
+        this.errorType = errorType;
+        this.location = location;
+        this.message = message;
+        this.errorReportFile = errorReportFile;
+    }
+
+    writeErrorReport() {
+        this.errorReportFile.write(this.errorType + ": " + this.location + " " + this.message + "\n");
+    }
+}
+
+/**
+ *  Read the input file(s) and re-write in the format
+ *  specified by --output-format
+ *
+ *  Create error report through --error-report and output file specified by --output
+ */
+class Process {
+
+    constructor() {
+        let parsedArgs = new ProcessArgs();
+        let output_writer = OutputFormat.createIonWriter(parsedArgs.getOutputFormatName());
+        if(parsedArgs.getOutputFormatName() == "events") {
+            this.processEvents(output_writer, parsedArgs);
+        } else {
+            this.processFiles(output_writer, parsedArgs);
+        }
+    }
+
+    getInput(path: string): string | Buffer {
+        let options = path.endsWith(".10n") ? null : "utf8";
+        return fs.readFileSync(path, options);
+    }
+
+    processEvents(ionOutputWriter: Writer, args: ProcessArgs): void {
+        for (let path of args.getInputFiles()) {
+            try{
+                let ionReader = makeReader(this.getInput(path));
+                let eventStream = new IonEventStream(ionReader);
+                // processes ion stream into event stream
+                eventStream.writeEventStream(ionOutputWriter);
+                ionOutputWriter.close();
+                args.getOutputFile().write(ionOutputWriter.getBytes());
+            } catch(Error) {
+                new ProcessError("Process Events", path, Error.message, args.getErrorReportFile()).writeErrorReport();
+            }
+        }
+    }
+
+    processFiles(ionOutputWriter: Writer, args: ProcessArgs): void {
+        for (let path of args.getInputFiles()) {
+            try{
+                let ionReader = makeReader(this.getInput(path));
+                ionOutputWriter.writeValues(ionReader);
+                ionOutputWriter.close();
+                args.getOutputFile().write(ionOutputWriter.getBytes());
+            } catch(Error) {
+                new ProcessError("Process Files", path, Error.message, args.getErrorReportFile()).writeErrorReport();
+            }
+        }
+    }
+}
+
+let p = new Process();
+
+

--- a/src/Process.ts
+++ b/src/Process.ts
@@ -88,6 +88,7 @@ export class Process {
         for (let path of args.getInputFiles()) {
             this.processFile(ionOutputWriter, args, path);
         }
+        args.getOutputFile().write(ionOutputWriter.getBytes());
     }
 
     processFile(ionOutputWriter: Writer, args: IonCliCommonArgs, path: string): void {
@@ -104,7 +105,6 @@ export class Process {
         try {
             let eventStream = new IonEventStream(ionReader, path, args);
             eventStream.writeIon(ionOutputWriter);
-            args.getOutputFile().write(ionOutputWriter.getBytes());
         } catch (Error) {
             new IonCliError(ErrorType.WRITE, path, Error.message, args.getErrorReportFile()).writeErrorReport();
         }
@@ -114,7 +114,6 @@ export class Process {
         try {
             ionOutputWriter.writeValues(ionReader);
             ionOutputWriter.close();
-            args.getOutputFile().write(ionOutputWriter.getBytes());
         } catch (Error) {
             new IonCliError(ErrorType.WRITE, path, Error.message, args.getErrorReportFile()).writeErrorReport();
         }

--- a/src/Process.ts
+++ b/src/Process.ts
@@ -3,9 +3,13 @@ import {OutputFormat} from './OutputFormat';
 import {IonEventStream} from "./IonEventStream";
 import {Writer} from "./IonWriter";
 import {ErrorType, IonCliCommonArgs, IonCliError} from "./Cli";
-import {makeReader, Reader} from "./Ion";
+import {IonTypes, makeReader, Reader} from "./Ion";
 
-export const command = 'process <input file..>'
+/**
+ * The `command`, `describe`, and `handler` exports below are part of the yargs command module API
+ * See: https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
+ */
+export const command = 'process <input-file..>'
 
 export const describe = "Read the input file(s) (optionally, specifying ReadInstructions or a filter) and re-write in" +
     "the format specified by --output.";
@@ -16,19 +20,20 @@ export const handler = function (argv) {
 }
 
 /**
- *  Read the input file(s) and re-write in the format
- *  specified by --output-format
- *
+ *  Read the input file(s) and re-write in the format specified by --output-format
  *  Create error report through --error-report and output file specified by --output
  */
 export class Process {
+    private EVENT_STREAM = "$ion_event_stream";
 
     constructor(parsedArgs: IonCliCommonArgs) {
         let output_writer = OutputFormat.createIonWriter(parsedArgs.getOutputFormatName());
-        if(parsedArgs.getOutputFormatName() == OutputFormat.EVENTS) {
-            this.processEvents(output_writer, parsedArgs);
-        } else {
-            this.processFiles(output_writer, parsedArgs);
+        if (output_writer) {
+            if (parsedArgs.getOutputFormatName() == OutputFormat.EVENTS) {
+                this.processEvents(output_writer, parsedArgs);
+            } else {
+                this.processFiles(output_writer, parsedArgs);
+            }
         }
     }
 
@@ -37,28 +42,27 @@ export class Process {
         return fs.readFileSync(path, options);
     }
 
-    clearIonOutputWriter(ionOutputWriter: Writer){
-        while(ionOutputWriter.depth() > 0){
-            ionOutputWriter.stepOut();
-        }
-        ionOutputWriter.close();
-    }
-
     createReaderForProcess(path: string, args: IonCliCommonArgs): Reader {
         let ionReader;
-        try{
+        try {
             ionReader = makeReader(this.getInput(path));
-        } catch(Error) {
+        } catch (Error) {
             new IonCliError(ErrorType.READ, path, Error.message, args.getErrorReportFile()).writeErrorReport();
         }
         return ionReader;
+    }
+
+    isEventStream(ionReader: Reader): boolean {
+        let type = ionReader.next();
+        return type != null
+            && type == IonTypes.SYMBOL
+            && ionReader.stringValue() == this.EVENT_STREAM;
     }
 
     processEvents(ionOutputWriter: Writer, args: IonCliCommonArgs): void {
         for (let path of args.getInputFiles()) {
             this.processEvent(ionOutputWriter, args, path);
         }
-        args.getOutputFile().write(ionOutputWriter.getBytes());
     }
 
     processEvent(ionOutputWriter: Writer, args: IonCliCommonArgs, path: string): void {
@@ -67,37 +71,51 @@ export class Process {
     }
 
     writeToEventStream(ionOutputWriter: Writer, ionReader: Reader, path: string, args: IonCliCommonArgs): void {
-        try{
-            let eventStream = new IonEventStream(ionReader);
-            // processes ion stream into event stream
+        let eventStream;
+        try {
+            eventStream = new IonEventStream(ionReader, path, args);
+
+            // processes input stream into event stream
             eventStream.writeEventStream(ionOutputWriter);
             ionOutputWriter.close();
-        } catch(Error) {
-            this.clearIonOutputWriter(ionOutputWriter);
+            args.getOutputFile().write(ionOutputWriter.getBytes());
+        } catch (Error) {
             new IonCliError(ErrorType.WRITE, path, Error.message, args.getErrorReportFile()).writeErrorReport();
         }
     }
 
     processFiles(ionOutputWriter: Writer, args: IonCliCommonArgs): void {
         for (let path of args.getInputFiles()) {
-                this.processFile(ionOutputWriter, args, path);
-            }
-        if(args.getOutputFormatName() != OutputFormat.NONE) {
-            args.getOutputFile().write(ionOutputWriter.getBytes());
+            this.processFile(ionOutputWriter, args, path);
         }
     }
 
     processFile(ionOutputWriter: Writer, args: IonCliCommonArgs, path: string): void {
         let ionReader = this.createReaderForProcess(path, args);
-        this.writeToProcessFile(ionOutputWriter, ionReader, path, args);
+        if (this.isEventStream(ionReader)) {
+            let reader = this.createReaderForProcess(path, args);
+            this.writeToProcessFileFromEventStream(ionOutputWriter, reader, path, args);
+        } else {
+            this.writeToProcessFile(ionOutputWriter, ionReader, path, args);
+        }
+    }
+
+    writeToProcessFileFromEventStream(ionOutputWriter: Writer, ionReader: Reader, path: string, args: IonCliCommonArgs): void {
+        try {
+            let eventStream = new IonEventStream(ionReader, path, args);
+            eventStream.writeIon(ionOutputWriter);
+            args.getOutputFile().write(ionOutputWriter.getBytes());
+        } catch (Error) {
+            new IonCliError(ErrorType.WRITE, path, Error.message, args.getErrorReportFile()).writeErrorReport();
+        }
     }
 
     writeToProcessFile(ionOutputWriter: Writer, ionReader: Reader, path: string, args: IonCliCommonArgs): void {
-        try{
+        try {
             ionOutputWriter.writeValues(ionReader);
             ionOutputWriter.close();
-        } catch(Error) {
-            this.clearIonOutputWriter(ionOutputWriter);
+            args.getOutputFile().write(ionOutputWriter.getBytes());
+        } catch (Error) {
             new IonCliError(ErrorType.WRITE, path, Error.message, args.getErrorReportFile()).writeErrorReport();
         }
     }


### PR DESCRIPTION
**Description:**

As part of ion-test-driver, this commit is for ion-js-cli process. It supports:

 - --output(-o) : rewrite given input files to specified output format
 - --output-fomrat(-f): specify ion output format
 - --error-report(-e): generate error report to specified location 


 
**Completeted Tasks:**

1. Implement processFiles function for binary/text/pretty formats to rewrite given input files.
2. Implement processEvents for generating event stream out of ion stream.
3. Supports help menu with all options and usage
4. Supports multiple input files rewritten into same output file

**TO DO:**

- [X] Support symbol[READ | WRITE | STATE] for error-report.
- [X] Support multiple input files for error-report.
- [X] Support None output format 
- [ ] Implement other options --catalog, --imports, --filter

**Test:**

tested using multiple input files for all output formats and events.
e.g. ts-node process example.ion --output-format text --output output.ion --error-report error_report 
