### PR TITLE
Updated CONTAINER_END event to include ionType

### DIFF
--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -912,9 +912,9 @@ class IonSexpEvent extends AbsIonContainerEvent {
 class IonEndEvent extends AbstractIonEvent {
   constructor(eventType: IonEventType, depth: number, ionType: IonType) {
     if(eventType === IonEventType.STREAM_END) {
-      super(eventType, null, null, [], depth, undefined)
+      super(eventType, null, null, [], depth, undefined);
     } else {
-      super(eventType, ionType!, null, [], depth, undefined)
+      super(eventType, ionType!, null, [], depth, undefined);
     }
   }
 

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -910,7 +910,7 @@ class IonSexpEvent extends AbsIonContainerEvent {
 }
 
 class IonEndEvent extends AbstractIonEvent {
-  constructor(eventType: IonEventType, depth: number) {
+  constructor(eventType: IonEventType, depth: number, ionType: IonType) {
     if(eventType === IonEventType.STREAM_END) {
       super(eventType, null, null, [], depth, undefined)
     } else {

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -402,8 +402,9 @@ export class IonEventFactory {
       case IonEventType.SYMBOL_TABLE:
         throw new Error("symbol tables unsupported.");
       case IonEventType.CONTAINER_END:
+        return new IonEndEvent(eventType, depth, ionType!);
       case IonEventType.STREAM_END:
-        return new IonEndEvent(eventType, depth);
+        return new IonEndEvent(eventType, depth, ionType!);
     }
   }
 }
@@ -910,7 +911,11 @@ class IonSexpEvent extends AbsIonContainerEvent {
 
 class IonEndEvent extends AbstractIonEvent {
   constructor(eventType: IonEventType, depth: number) {
-    super(eventType, null, null, [], depth, undefined);
+    if(eventType === IonEventType.STREAM_END) {
+      super(eventType, null, null, [], depth, undefined)
+    } else {
+      super(eventType, ionType!, null, [], depth, undefined)
+    }
   }
 
   valueCompare(expected: IonEndEvent): ComparisonResult {


### PR DESCRIPTION
*Description of changes:*
This PR changes the CONTAINER_END event to include ionType in order to resolve read_compare with other test-driver implementations.

