### PR TITLE
Updated CONTAINER_END event to include ionType

### DIFF
--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -402,8 +402,9 @@ export class IonEventFactory {
       case IonEventType.SYMBOL_TABLE:
         throw new Error("symbol tables unsupported.");
       case IonEventType.CONTAINER_END:
+        return new IonEndEvent(eventType, depth, ionType!);
       case IonEventType.STREAM_END:
-        return new IonEndEvent(eventType, depth);
+        return new IonEndEvent(eventType, depth, ionType!);
     }
   }
 }
@@ -909,8 +910,12 @@ class IonSexpEvent extends AbsIonContainerEvent {
 }
 
 class IonEndEvent extends AbstractIonEvent {
-  constructor(eventType: IonEventType, depth: number) {
-    super(eventType, null, null, [], depth, undefined);
+  constructor(eventType: IonEventType, depth: number, ionType: IonType) {
+    if (eventType === IonEventType.STREAM_END) {
+      super(eventType, null, null, [], depth, undefined);
+    } else {
+      super(eventType, ionType!, null, [], depth, undefined);
+    }
   }
 
   valueCompare(expected: IonEndEvent): ComparisonResult {


### PR DESCRIPTION
*Description of changes:*
This PR changes the CONTAINER_END event to include ionType to resolve read_compare with other test-driver implementations.

e.g. 
```
{
  event_type: CONTAINER_END,
  ion_type: SEXP,
  annotations: [
  ],
  depth: 0
}
```