### PR TITLE
Changes for test-driver clob and float events

### DIFF
--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -516,7 +516,7 @@ class IonFloatEvent extends AbstractIonEvent {
     }
     if (
       expected instanceof IonFloatEvent &&
-      this.ionValue === expected.ionValue
+      Object.is(this.ionValue, expected.ionValue)
     ) {
       return new ComparisonResult(ComparisonResultType.EQUAL);
     }

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -705,10 +705,10 @@ class IonClobEvent extends AbstractIonEvent {
     if (!(expected instanceof IonClobEvent)) {
       return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
     }
-    if(this.ionValue.length !== expected.ionValue.length) {
+    if (this.ionValue.length !== expected.ionValue.length) {
       return new ComparisonResult(
-          ComparisonResultType.NOT_EQUAL,
-          this.ionValue + " vs. " + expected.ionValue
+        ComparisonResultType.NOT_EQUAL,
+        this.ionValue + " vs. " + expected.ionValue
       );
     }
     for (let i = 0; i < this.ionValue.length; i++) {

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -511,9 +511,6 @@ class IonFloatEvent extends AbstractIonEvent {
   }
 
   valueCompare(expected: IonEvent): ComparisonResult {
-    if (isNaN(this.ionValue) && isNaN(expected.ionValue)) {
-      return new ComparisonResult(ComparisonResultType.EQUAL);
-    }
     if (
       expected instanceof IonFloatEvent &&
       Object.is(this.ionValue, expected.ionValue)

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -705,6 +705,12 @@ class IonClobEvent extends AbstractIonEvent {
     if (!(expected instanceof IonClobEvent)) {
       return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
     }
+    if(this.ionValue.length !== expected.ionValue.length) {
+      return new ComparisonResult(
+          ComparisonResultType.NOT_EQUAL,
+          this.ionValue + " vs. " + expected.ionValue
+      );
+    }
     for (let i = 0; i < this.ionValue.length; i++) {
       if (this.ionValue[i] !== expected.ionValue[i]) {
         return new ComparisonResult(
@@ -713,6 +719,7 @@ class IonClobEvent extends AbstractIonEvent {
         );
       }
     }
+
     return new ComparisonResult(ComparisonResultType.EQUAL);
   }
 


### PR DESCRIPTION
*Description of changes:*
 This PR works on modifying IonEvent valueCompare() method for clob and float. 

1. Clobs need to consider length of clobs for equality. (5926a79)
2. Floats need to differentiate between +0 and -0. (ce2bb26)

This PR solves the problem of non-equivs comparison in clob and float events and aligns it with other implementations of test-driver. 

e.g.  Clob
```
[
    {{"hello"}},
    {{"hello "}},
    {{" hello"}},
    {{" hello "}},
]
```
Here, `{{"hello"}}`  and `{{"hello "}}` were being stated as `EQUAL` before. Now it shows them as `NOT_EQUAL` as they both have different
lengths.

e.g. Float
```
[
    0e0,
    -0e0,
]
```
Here, 0e0 and -0e0 were being stated as `EQUAL` before. Now it shows them as `NOT_EQUAL` as -0 and +0 are not equal.