### PR TITLE
Update semantic-release version hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mocha-typescript": "^1.1.17",
     "nyc": "^14.1.1",
     "prettier": "2.1.2",
-    "semantic-release": "^15.13.24",
+    "semantic-release": "^17.2.3",
     "source-map-support": "^0.5.19",
     "ts-node": "^8.10.1",
     "tslint": "^5.20.1",


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/advisories/GHSA-r2j6-p67h-q639

*Description of changes:*

Tested via `npm install`, changing this version hint, and then another `npm install`. In both cases all unit tests succeeded.
```
npm install
```
*many lines of output elided*
```
  3078 passing (11s)
  170 pending
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
