### PR TITLE
SharedSymbolTables no longer treat object properties as symbols.

### DIFF
--- a/src/IonSharedSymbolTable.ts
+++ b/src/IonSharedSymbolTable.ts
@@ -30,7 +30,7 @@ export class SharedSymbolTable {
     // Iterate through the symbol array in reverse order so if the same string appears more than
     // once the smaller symbol ID is stored.
     for (let m = _symbols.length - 1; m >= 0; m--) {
-      this._idsByText[_symbols[m]] = m;
+      this._idsByText.set(_symbols[m], m);
     }
   }
 
@@ -61,6 +61,6 @@ export class SharedSymbolTable {
   }
 
   getSymbolId(text: string): number | undefined {
-    return this._idsByText[text];
+    return this._idsByText.get(text);
   }
 }

--- a/test/IonLocalSymbolTable.ts
+++ b/test/IonLocalSymbolTable.ts
@@ -140,4 +140,16 @@ describe('Local symbol table', () => {
         assert.equal(originalId, duplicateId, "Duplicate symbol was not given original id");
         assert.equal(originalLength + 1, symbolTable.symbols.length, "Duplicate symbol added to symbol table");
     });
+
+    // See https://github.com/amzn/ion-js/issues/645
+    it('SST Object properties are not treated as symbols (Issue #645)', () => {
+        const symbolTable = defaultLocalSymbolTable();
+        symbolTable.addSymbol("foo");
+        assert.equal(symbolTable.getSymbolId("foo"), 10);
+
+        // 'size' has not been added to the symbol table.
+        // It is, however, a property (an accessor) on the 'Map' data type.
+        // Asking for its symbol ID should return undefined.
+        assert.isUndefined(symbolTable.getSymbolId("size"));
+    });
 });


### PR DESCRIPTION
*Issue #, if available:* #645 

*Description of changes:*

Modifies `SharedSymbolTable` (used to represent imported SSTs and the system symbol table) so it avoids co-mingling symbols and object properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
