### PR TITLE
Adding `postion()` API to Reader (#654)

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -103,6 +103,10 @@ export class BinaryReader implements Reader {
     this._raw_type = BOC;
   }
 
+  position(): number {
+    return this._parser.source().position();
+  }
+
   next(): IonType | null {
     this._annotations = null;
 

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -317,6 +317,10 @@ export class ParserBinaryRaw {
     return Decimal._fromBigIntCoefficient(isNegative, coefficient, exponent);
   }
 
+  source(): BinarySpan {
+    return this._in;
+  }
+
   next(): any {
     if (this._curr === undefined && this._len > 0) {
       this._in.skip(this._len);

--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -386,6 +386,10 @@ export class ParserTextRaw {
     return this._fieldnameType;
   }
 
+  source(): StringSpan {
+    return this._in;
+  }
+
   annotations(): SymbolToken[] {
     return this._ann;
   }

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -42,6 +42,17 @@ export type ReaderScalarValue =
  */
 export interface Reader {
   /**
+   * Return the position of the current reader.
+   * The position refers to the character distance between the char where the reader
+   * stared (e.g. the first character of the file), and the current character the reader
+   * is reading.
+   *
+   * @returns a [[number]] type presenting the position of the character the reading is
+   * currently reading.
+   */
+  position(): number | null;
+
+  /**
    * Advances the reader to the next value in the stream at the current depth.
    *
    * @return The corresponding [[IonType]] of the value the reader moves to, or `null`

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -140,6 +140,10 @@ export class TextReader implements Reader {
     return false;
   }
 
+  position() {
+    return this._parser.source().position();
+  }
+
   next() {
     this._raw = undefined;
     if (this._raw_type === EOF) {


### PR DESCRIPTION
*Issue #, if available:*
#654

*Description of changes:*
(Copied from issue description)
Hi, 

**Description**
As a user of ion-js, I would love to be able to get position information from ionReader, so that when using ionReader to read a ion file, I can know which position I'm currently at.

**Application scenario**
Our team uses ion to define a format, e.g. paragraph `P` uses certain format style `S`, and the definition of style `S` is out side of the paragraph itself. see blow:
```
style::{
  name:S,
  font:Arial,
  .....
}
....
....
paragraph::{
  name:A,
  style:S,
  .....
}
```
I'm working on a vs code extension: ion-style-peek, so that in the above ion file, when users are viewing paragraph `A` and call `go to definition` on `S`, the editor will jump to style `S`.  Similar implementation can be found: https://github.com/pranaygp/vscode-css-peek

To implement the above, we need to get the position when parsing style in the ion, hence the requesting issue. 

We can get position information from the below two paths:
```
Reader -> BinaryReader -> ParserBinaryRaw -> StringSpan
Reader -> TextReader -> ParserTextRaw -> BinarySpan
```

Thanks!

Ethan



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
