### PR TITLE
Performance improvement in unicode decode 

### DIFF
--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+import {TextDecoder} from "util";
+
+// verify if TextDecoder exists globally or not
+let textDecoder = TextDecoder ? new TextDecoder("utf8", {fatal: true}) : null;
+
 /**
  * @file Constants and helper methods for Unicode.
  * @see https://amzn.github.io/ion-docs/stringclob.html
@@ -60,6 +65,10 @@ export function encodeUtf8(s: string): Uint8Array {
 }
 
 export function decodeUtf8(bytes: Uint8Array): string {
+  // for bytes > 512 use TextDecoder method - decode()
+  if(bytes.length > 512 && textDecoder != null) {
+    return textDecoder.decode(bytes);
+  }
   let i = 0,
     s = "",
     c;

--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -13,10 +13,15 @@
  * permissions and limitations under the License.
  */
 
-import { TextDecoder } from "util";
+const JS_DECODER_MAX_BYTES = 512;
 
-// verify if TextDecoder exists globally or not
-let textDecoder = TextDecoder ? new TextDecoder("utf8", { fatal: true }) : null;
+// Check whether this runtime supports the `TextDecoder` feature
+let textDecoder;
+if (global["TextDecoder"] != null) {
+  textDecoder = new global["TextDecoder"]("utf8", { fatal: true });
+} else {
+  textDecoder = null;
+}
 
 /**
  * @file Constants and helper methods for Unicode.
@@ -66,7 +71,7 @@ export function encodeUtf8(s: string): Uint8Array {
 
 export function decodeUtf8(bytes: Uint8Array): string {
   // for bytes > 512 use TextDecoder method - decode()
-  if (bytes.length > 512 && textDecoder != null) {
+  if (bytes.length > JS_DECODER_MAX_BYTES && textDecoder != null) {
     return textDecoder.decode(bytes);
   }
   let i = 0,

--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -13,10 +13,10 @@
  * permissions and limitations under the License.
  */
 
-import {TextDecoder} from "util";
+import { TextDecoder } from "util";
 
 // verify if TextDecoder exists globally or not
-let textDecoder = TextDecoder ? new TextDecoder("utf8", {fatal: true}) : null;
+let textDecoder = TextDecoder ? new TextDecoder("utf8", { fatal: true }) : null;
 
 /**
  * @file Constants and helper methods for Unicode.
@@ -66,7 +66,7 @@ export function encodeUtf8(s: string): Uint8Array {
 
 export function decodeUtf8(bytes: Uint8Array): string {
   // for bytes > 512 use TextDecoder method - decode()
-  if(bytes.length > 512 && textDecoder != null) {
+  if (bytes.length > 512 && textDecoder != null) {
     return textDecoder.decode(bytes);
   }
   let i = 0,


### PR DESCRIPTION
*Issue*: #618 

*Description of changes:*
This PR contains changes for improving performance of Unicode decode method.

*Changes:*

- Changed the `decodeUtf8` method to use native JS `TextDecoder` for `Uint8Array` of greater than 512 bytes. The threshold is set according to the findings from #618 using [Benchmark.js](https://benchmarkjs.com). 
- Also as not every platform would have runtime feature `TextDecoder`, added a check to verify if global variable `TextDecoder` exist or not.