### PR TITLE
Changed tsconfig to generate ES6 module correctly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,13 +37,13 @@ module.exports = function(grunt) {
     },
     ts: {
       'es6-es6': {
-        tsconfig: 'tsconfig.json'
+        tsconfig: 'tsconfig.es6.json'
       },
       'amd-es6': {
         tsconfig: 'tsconfig.amd.json'
       },
       'commonjs-es6': {
-        tsconfig: 'tsconfig.commonjs.json'
+        tsconfig: 'tsconfig.json'
       },
       'test-driver' : {
         tsconfig: './test-driver/tsconfig.json'

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/commonjs/es6"
+    "module": "es6",
+    "outDir": "dist/es6/es6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 // Base Typscript Compiler Configuration
-// Targets ES6 Module system and ES6 feature set.
+// Targets CommonJS Module system and ES6 feature set.
 {
   "include": [
     "src/**/*"
@@ -20,7 +20,7 @@
     "strict": false,
     "strictNullChecks": true,
     "rootDirs": ["src", "test"],
-    "outDir": "dist/es6/es6",
+    "outDir": "dist/commonjs/es6",
     "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
*Issue #667*

*Description of changes:*
This PR aims to solve the above mentioned issue of `ion-js` not generating the ES6 module correctly.  As a solution to this I have changed the `tsconfig` files to generate correct modules. The `tsconfig` before and after the change contained modules as following:

Before change:
```
tsconfig.js -> CommonJS module config
tsconfig.commonjs.js -> CommonJS module config
tsconfig.amd.js -> AMD module config

```
After change:
```
tsconfig.js -> CommonJS module config
tsconfig.es.js -> ES6 module config
tsconfig.amd.js -> AMD module config
```
Modified `Gruntfile.js` to include proper `tsconfig`(with CommonJS module) for node environment.

Test: 

- Tested this using a simple code to load ion data using `dom.load` with individual module syntax 
- `require` for CommonJS module and `import` for ES6 module