### PR TITLE
added changes for using equals() in tests

### DIFF
--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -19,10 +19,10 @@ import * as ion from '../src/Ion';
 
 @suite('Text Reader')
 class IonTextReaderTests {
-    private static first_value_equal(input, expected) {
+    private static escapeTerminatorTest(input, expected) {
         let reader = ion.makeReader(input);
         reader.next();
-        assert.equal(reader.value(), expected);
+        assert.equal(reader.stringValue(), expected);
     }
 
     private static ivmTest(reader, value, expected, depth, annotations) {
@@ -41,7 +41,7 @@ class IonTextReaderTests {
         let ionReader = ion.makeReader(ionToRead);
         ionReader.next();
 
-        assert.equal(ionReader.value(), "string");
+        assert.equal(ionReader.stringValue(), "string");
     }
 
     @test "Read emoji with modifier"() {
@@ -60,7 +60,7 @@ class IonTextReaderTests {
         let ionReader = ion.makeReader(ionToRead);
         ionReader.next();
 
-        assert.equal(ionReader.value(), true);
+        assert.equal(ionReader.booleanValue(), true);
     }
 
     @test "Read clob value"() {
@@ -68,7 +68,7 @@ class IonTextReaderTests {
         let ionReader = ion.makeReader(ionToRead);
         ionReader.next();
 
-        assert.deepEqual(ionReader.value(), Uint8Array.from([194, 128]));
+        assert.deepEqual(ionReader.byteValue(), Uint8Array.from([194, 128]));
     }
 
     @test "Read boolean value in struct"() {
@@ -78,7 +78,7 @@ class IonTextReaderTests {
         ionReader.stepIn();
         ionReader.next();
 
-        assert.equal(ionReader.value(), false);
+        assert.equal(ionReader.booleanValue(), false);
     }
 
     @test "resolves symbol IDs"() {
@@ -88,13 +88,13 @@ class IonTextReaderTests {
         ionReader.stepIn();
         ionReader.next();
         assert.equal(ionReader.fieldName(), 'version');
-        assert.equal(ionReader.value(), 'imports');
+        assert.equal(ionReader.stringValue(), 'imports');
         ionReader.next();
         assert.equal(ionReader.fieldName(), "rock");
-        assert.equal(ionReader.value(), "paper");
+        assert.equal(ionReader.stringValue(), "paper");
         ionReader.next();
         assert.equal(ionReader.fieldName(), "scissors");
-        assert.equal(ionReader.value(), 'taco');
+        assert.equal(ionReader.stringValue(), 'taco');
     }
 
     @test "Parse through struct"() {
@@ -108,7 +108,7 @@ class IonTextReaderTests {
         ionReader.next();
 
         assert.equal(ionReader.fieldName(), "key");
-        assert.equal(ionReader.value(), "string");
+        assert.equal(ionReader.stringValue(), "string");
 
         assert.isNull(ionReader.next());
     }
@@ -133,7 +133,7 @@ class IonTextReaderTests {
         ionReader.next();
 
         assert.equal(ionReader.fieldName(), "key2");
-        assert.equal(ionReader.value(), "string2");
+        assert.equal(ionReader.stringValue(), "string2");
 
         assert.isNull(ionReader.next());
     }
@@ -177,10 +177,10 @@ class IonTextReaderTests {
         ionReader.stepIn(); // Step into the array.
 
         ionReader.next();
-        assert.equal(ionReader.value(), "v1");
+        assert.equal(ionReader.stringValue(), "v1");
 
         ionReader.next();
-        assert.equal(ionReader.value(), "v2");
+        assert.equal(ionReader.stringValue(), "v2");
 
         assert.isNull(ionReader.next());
     }
@@ -202,10 +202,10 @@ class IonTextReaderTests {
         ionReader.stepIn(); // Step into the inner array.
 
         ionReader.next();
-        assert.equal(ionReader.value(), "v1");
+        assert.equal(ionReader.stringValue(), "v1");
 
         ionReader.next();
-        assert.equal(ionReader.value(), "v2");
+        assert.equal(ionReader.stringValue(), "v2");
 
         assert.isNull(ionReader.next());
     }
@@ -218,15 +218,15 @@ class IonTextReaderTests {
     }
 
     @test "Parses escaped terminators correctly."() {
-        IonTextReaderTests.first_value_equal("'abc\\''", "abc'");
-        IonTextReaderTests.first_value_equal("'''abc\\''''", "abc'");
-        IonTextReaderTests.first_value_equal("'abc\\'' taco", "abc'");
-        IonTextReaderTests.first_value_equal("'''abc\\'''' taco", "abc'");
-        IonTextReaderTests.first_value_equal("'''abc\\'''' '''''' taco", "abc'");
-        IonTextReaderTests.first_value_equal('"abc\\""', 'abc"');
-        IonTextReaderTests.first_value_equal('"abc\\"" taco', 'abc"');
-        IonTextReaderTests.first_value_equal("'\\\n'", "");
-        IonTextReaderTests.first_value_equal("'''short1\\\n'''\n\n'''\\\nmulti-line string\nwith embedded\\nnew line\ncharacters\\\n'''", "short1multi-line string\nwith embedded\nnew line\ncharacters");
+        IonTextReaderTests.escapeTerminatorTest("'abc\\''", "abc'");
+        IonTextReaderTests.escapeTerminatorTest("'''abc\\''''", "abc'");
+        IonTextReaderTests.escapeTerminatorTest("'abc\\'' taco", "abc'");
+        IonTextReaderTests.escapeTerminatorTest("'''abc\\'''' taco", "abc'");
+        IonTextReaderTests.escapeTerminatorTest("'''abc\\'''' '''''' taco", "abc'");
+        IonTextReaderTests.escapeTerminatorTest('"abc\\""', 'abc"');
+        IonTextReaderTests.escapeTerminatorTest('"abc\\"" taco', 'abc"');
+        IonTextReaderTests.escapeTerminatorTest("'\\\n'", "");
+        IonTextReaderTests.escapeTerminatorTest("'''short1\\\n'''\n\n'''\\\nmulti-line string\nwith embedded\\nnew line\ncharacters\\\n'''", "short1multi-line string\nwith embedded\nnew line\ncharacters");
 
     };
 

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -1,89 +1,93 @@
-import {assert} from "chai";
-import {Value, load, loadAll} from "../../src/dom";
-import {Decimal, dom, IonType, IonTypes, Timestamp} from "../../src/Ion";
+import { assert } from "chai";
+import { Value, load, loadAll } from "../../src/dom";
+import { Decimal, dom, IonType, IonTypes, Timestamp } from "../../src/Ion";
 import * as ion from "../../src/Ion";
 import JSBI from "jsbi";
 import * as JsValueConversion from "../../src/dom/JsValueConversion";
-import {_hasValue} from "../../src/util";
-import {Constructor} from "../../src/dom/Value";
-import {exampleDatesWhere, exampleIonValuesWhere, exampleJsValuesWhere, exampleTimestampsWhere} from "../exampleValues";
-import {valueName} from "../mochaSupport";
-
-// The same test logic performed by assert.equals() but without an assertion.
-function jsEqualsIon(jsValue, ionValue): boolean {
-    return jsValue == ionValue;
-}
+import { Constructor } from "../../src/dom/Value";
+import {
+  exampleDatesWhere,
+  exampleIonValuesWhere,
+  exampleJsValuesWhere,
+  exampleTimestampsWhere,
+} from "../exampleValues";
+import { valueName } from "../mochaSupport";
 
 // Tests whether each value is or is not an instance of dom.Value
 function instanceOfValueTest(expected: boolean, ...values: any[]) {
-    for (let value of values) {
-        it(`${valueName(value)} instanceof Value`, () => {
-            assert.equal(value instanceof Value, expected);
-        });
-    }
+  for (let value of values) {
+    it(`${valueName(value)} instanceof Value`, () => {
+      assert.equal(value instanceof Value, expected);
+    });
+  }
 }
 
-function instanceOfValueSubclassTest(constructor: Constructor, expected: boolean, ...values: any[]) {
-    for (let value of values) {
-        it(`${valueName(value)} instanceof ${constructor.name}`, () => {
-            assert.equal(value instanceof constructor, expected);
-        });
-    }
+function instanceOfValueSubclassTest(
+  constructor: Constructor,
+  expected: boolean,
+  ...values: any[]
+) {
+  for (let value of values) {
+    it(`${valueName(value)} instanceof ${constructor.name}`, () => {
+      assert.equal(value instanceof constructor, expected);
+    });
+  }
 }
 
 // Describes the static side of dom.Value subclasses
 interface DomValueConstructor extends Constructor {
-    _getIonType(): IonType;
+  _getIonType(): IonType;
 }
 
 // The constructors of all dom.Value subclasses
 const DOM_VALUE_SUBCLASSES: DomValueConstructor[] = [
-    dom.Null,
-    dom.Boolean,
-    dom.Integer,
-    dom.Float,
-    dom.Decimal,
-    dom.Timestamp,
-    dom.Clob,
-    dom.Blob,
-    dom.String,
-    dom.Symbol,
-    dom.List,
-    dom.SExpression,
-    dom.Struct
+  dom.Null,
+  dom.Boolean,
+  dom.Integer,
+  dom.Float,
+  dom.Decimal,
+  dom.Timestamp,
+  dom.Clob,
+  dom.Blob,
+  dom.String,
+  dom.Symbol,
+  dom.List,
+  dom.SExpression,
+  dom.Struct,
 ];
 
 // Converts each argument in `valuesToRoundTrip` to a dom.Value, writes it to an Ion stream, and then load()s the Ion
 // stream back into a dom.Value. Finally, compares the original dom.Value with the dom.Value load()ed from the stream
 // to ensure that no data was lost.
-function domRoundTripTest(typeName: string,
-                          equalityTest: (p1, p2) => boolean,
-                          ...valuesToRoundTrip: any[]) {
-    describe(typeName, () => {
-        for (let value of valuesToRoundTrip) {
-            it(value + '', () => {
-                let writer = ion.makeBinaryWriter();
-                // Make a dom.Value out of the provided value if it isn't one already
-                let domValue;
-                if (value instanceof Value) {
-                    domValue = value as Value;
-                } else {
-                    domValue = Value.from(value);
-                }
-                // Serialize the dom.Value using the newly instantiated writer
-                domValue.writeTo(writer);
-                writer.close();
-                // Load the serialized version of the value
-                let roundTripped = load(writer.getBytes())!;
-                // Verify that nothing was lost in the round trip
-                assert.isNotNull(roundTripped);
-                assert.equal(domValue.isNull(), roundTripped.isNull());
-                assert.equal(domValue.getType(), roundTripped.getType());
-                assert.deepEqual(domValue.getAnnotations(), roundTripped.getAnnotations());
-                assert.isTrue(equalityTest(domValue, roundTripped));
-            });
+function domRoundTripTest(typeName: string, ...valuesToRoundTrip: any[]) {
+  describe(typeName, () => {
+    for (let value of valuesToRoundTrip) {
+      it(value + "", () => {
+        let writer = ion.makeBinaryWriter();
+        // Make a dom.Value out of the provided value if it isn't one already
+        let domValue;
+        if (value instanceof Value) {
+          domValue = value as Value;
+        } else {
+          domValue = Value.from(value);
         }
-    });
+        // Serialize the dom.Value using the newly instantiated writer
+        domValue.writeTo(writer);
+        writer.close();
+        // Load the serialized version of the value
+        let roundTripped = load(writer.getBytes())!;
+        // Verify that nothing was lost in the round trip
+        assert.isNotNull(roundTripped);
+        assert.equal(domValue.isNull(), roundTripped.isNull());
+        assert.equal(domValue.getType(), roundTripped.getType());
+        assert.deepEqual(
+          domValue.getAnnotations(),
+          roundTripped.getAnnotations()
+        );
+        assert.isTrue(domValue.equals(roundTripped));
+      });
+    }
+  });
 }
 
 /**
@@ -98,372 +102,255 @@ function domRoundTripTest(typeName: string,
  *                              comparing it to `jsValue`. This is helpful if jsValue is a boxed primitive
  *                              but you want to test for equality with the primitive representation.
  */
-function domValueTest(jsValue,
-                      expectedIonType,
-                      equalityTest: (p1, p2) => boolean = jsEqualsIon,
-                      expectValue?) {
-    function validateDomValue(domValue: Value, annotations) {
-        let equalityTestValue = _hasValue(expectValue) ? expectValue : jsValue;
-        // Verify that the new dom.Value is considered equal to the original (unwrapped) JS value.
-        assert.isTrue(equalityTest(equalityTestValue, domValue));
-        assert.equal(expectedIonType, domValue.getType());
-        let expectedDomType: any = JsValueConversion._domConstructorFor(expectedIonType);
-        assert.isTrue(domValue instanceof expectedDomType);
-        assert.deepEqual(annotations, domValue.getAnnotations());
-    }
+function domValueTest(jsValue, expectedIonType) {
+  function validateDomValue(domValue: Value, annotations) {
+    let equalityTestValue = jsValue;
+    // Verify that the new dom.Value is considered equal to the original (unwrapped) JS value.
+    assert.isTrue(
+      domValue.equals(equalityTestValue, { onlyCompareIon: false })
+    );
+    assert.equal(expectedIonType, domValue.getType());
+    let expectedDomType: any = JsValueConversion._domConstructorFor(
+      expectedIonType
+    );
+    assert.isTrue(domValue instanceof expectedDomType);
+    assert.deepEqual(annotations, domValue.getAnnotations());
+  }
 
-    return () => {
-        // Test Value.from() with and without specifying annotations
-        let annotations = ['foo', 'bar', 'baz'];
-        it('' + jsValue, () => {
-            validateDomValue(Value.from(jsValue), []);
-        });
-        it(annotations.join('::') + '::' + jsValue, () => {
-            validateDomValue(Value.from(jsValue, annotations), annotations);
-        });
-    };
+  return () => {
+    // Test Value.from() with and without specifying annotations
+    let annotations = ["foo", "bar", "baz"];
+    it("" + jsValue, () => {
+      validateDomValue(Value.from(jsValue), []);
+    });
+    it(annotations.join("::") + "::" + jsValue, () => {
+      validateDomValue(Value.from(jsValue, annotations), annotations);
+    });
+  };
 }
 
-describe('Value', () => {
-    describe('from()', () => {
-        describe('null',
-            domValueTest(
-                null,
-                IonTypes.NULL,
-                (_, domValue) => domValue.isNull()
-            )
-        );
-        describe('boolean',
-            domValueTest(true, IonTypes.BOOL)
-        );
-        describe('Boolean',
-            domValueTest(new Boolean(true), IonTypes.BOOL, jsEqualsIon, true)
-        );
-        describe('number (integer)',
-            domValueTest(7, IonTypes.INT)
-        );
-        describe('Number (integer)',
-            domValueTest(new Number(7), IonTypes.INT, jsEqualsIon, 7)
-        );
-        describe('BigInt',
-            domValueTest(
-                JSBI.BigInt(7),
-                IonTypes.INT,
-                (jsValue, domValue) => JSBI.equal(jsValue, domValue.bigIntValue()!)
-            )
-        );
-        describe('number (floating point)',
-            domValueTest(7.5, IonTypes.FLOAT)
-        );
-        describe('Number (floating point)',
-            domValueTest(new Number(7.5), IonTypes.FLOAT, jsEqualsIon, 7.5)
-        );
-        describe('Decimal',
-            domValueTest(
-                new Decimal("7.5"),
-                IonTypes.DECIMAL,
-                (jsValue, domValue) => domValue.decimalValue().equals(jsValue)
-            )
-        );
-        describe('Date', () => {
-                for (let date of [...exampleDatesWhere(), new Date()]) {
-                    domValueTest(
-                        date,
-                        IonTypes.TIMESTAMP,
-                        (jsValue, domValue) => {
-                            return domValue.dateValue().getTime() == jsValue.getTime()
-                                && domValue.timestampValue().getDate().getTime() === jsValue.getTime();
-                        }
-                    )();
-                }
-            }
-        );
-        describe('Timestamp', () => {
-                for (let timestamp of exampleTimestampsWhere()) {
-                    domValueTest(
-                        timestamp,
-                        IonTypes.TIMESTAMP,
-                        (jsValue, domValue) => domValue.timestampValue().equals(jsValue)
-                    )();
-                }
-            }
-        );
-        describe('string',
-            domValueTest(
-                'Hello',
-                IonTypes.STRING,
-            )
-        );
-        describe('String',
-            domValueTest(
-                new String('Hello'),
-                IonTypes.STRING,
-                jsEqualsIon,
-                'Hello'
-            )
-        );
-        describe('Blob',
-            domValueTest(
-                new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
-                IonTypes.BLOB,
-                (jsValue, domValue) =>
-                    jsValue.every(
-                        (byte, index) => byte === domValue[index]
-                    )
-            )
-        );
-        describe('List',
-            domValueTest(
-                [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-                IonTypes.LIST,
-                (jsValue, domValue) =>
-                    jsValue.every(
-                        (listItem, index) => listItem === domValue[index].numberValue()
-                    )
-                )
-        );
-        describe('Struct',
-            domValueTest(
-                {foo: 7, bar: true, baz: 98.6, qux: 'Hello'},
-                IonTypes.STRUCT,
-                (jsValue, domValue) =>
-                    Object.entries(jsValue)
-                          .every(([key, value]) => domValue.get(key).valueOf() === value)
-            )
-        );
-        describe('List inside Struct',
-            domValueTest(
-                {foo: [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]},
-                IonTypes.STRUCT,
-                (jsValue, domValue) => {
-                    assert.isTrue(domValue instanceof dom.Struct);
-                    assert.isTrue(domValue['foo'] instanceof dom.List);
-                    let domList: dom.List = domValue['foo'];
-                    return jsValue.foo.every(
-                        (arrayNumber, index) => arrayNumber === domList[index].numberValue()
-                    )
-                }
-            )
-        );
-        describe('Struct inside List',
-            domValueTest(
-                [{foo: 7, bar: true, baz: 98.6, qux: 'Hello'}],
-                IonTypes.LIST,
-                (jsValue, domValue) => {
-                    assert.isTrue(domValue instanceof dom.List);
-                    assert.isTrue(domValue[0] instanceof dom.Struct);
-                    let domStruct: dom.Struct = domValue[0];
-                    return Object.entries(jsValue[0])
-                                 .every(([key, value]) => domStruct.get(key)!.valueOf() === value)
-                }
-            )
-        );
+describe("Value", () => {
+  describe("from()", () => {
+    describe("null", domValueTest(null, IonTypes.NULL));
+    describe("boolean", domValueTest(true, IonTypes.BOOL));
+    describe("Boolean", domValueTest(new Boolean(true), IonTypes.BOOL));
+    describe("number (integer)", domValueTest(7, IonTypes.INT));
+    describe("Number (integer)", domValueTest(new Number(7), IonTypes.INT));
+    describe("BigInt", domValueTest(JSBI.BigInt(7), IonTypes.INT));
+    describe("number (floating point)", domValueTest(7.5, IonTypes.FLOAT));
+    describe(
+      "Number (floating point)",
+      domValueTest(new Number(7.5), IonTypes.FLOAT)
+    );
+    describe("Decimal", domValueTest(new Decimal("7.5"), IonTypes.DECIMAL));
+    describe("Date", () => {
+      for (let date of [...exampleDatesWhere(), new Date()]) {
+        domValueTest(date, IonTypes.TIMESTAMP)();
+      }
     });
-    describe('instanceof', () => {
-        describe('All dom.Value subclasses are instances of dom.Value', () => {
-            instanceOfValueTest(
-                true,
-                ...exampleIonValuesWhere()
-            );
-        });
-        describe('No plain Javascript value is an instance of dom.Value', () => {
-            instanceOfValueTest(
-                false,
-                ...exampleJsValuesWhere(),
-                Object.create(null)
-            );
-        });
-        for (let subclass of DOM_VALUE_SUBCLASSES) {
-            describe(`${subclass.name}`, () => {
-                // Javascript values are not instances of any dom.Value subclass
-                describe(`Plain Javascript value instanceof dom.${subclass.name}`, () => {
-                    instanceOfValueSubclassTest(
-                        subclass,
-                        false,
-                        ...exampleJsValuesWhere()
-                    );
-                });
-                // Non-null dom.Values whose Ion type matches that of the constructor must be instances of that
-                // dom.Value subclass.
-                describe(`Non-null ${subclass._getIonType().name} instanceof dom.${subclass.name}`, () => {
-                    instanceOfValueSubclassTest(
-                        subclass,
-                        true,
-                        ...exampleIonValuesWhere(
-                            (value) =>
-                                (value.isNull() && subclass === dom.Null)
-                                || (!value.isNull() && value.getType() === subclass._getIonType())
-                        )
-                    );
-                });
-                // Null dom.Values and those whose Ion type does NOT match that of the constructor must not be instances
-                // of that dom.Value subclass.
-                describe(`Null or non-${subclass._getIonType().name} instanceof dom.${subclass.name}`, () => {
-                    instanceOfValueSubclassTest(
-                        subclass,
-                        false,
-                        ...exampleIonValuesWhere(
-                            (value) =>
-                                (value.isNull() && subclass !== dom.Null)
-                                || (!value.isNull() && value.getType() !== subclass._getIonType())
-                        )
-                    );
-                });
-            });
-        }
+    describe("Timestamp", () => {
+      for (let timestamp of exampleTimestampsWhere()) {
+        domValueTest(timestamp, IonTypes.TIMESTAMP)();
+      }
     });
-    describe('writeTo()', () => {
-        domRoundTripTest(
-            'Null',
-            (n1, n2) => true, // isNull() and getType() are already checked in `domRoundTripTest`
-            // Test `null` of every Ion type
-            ...Object.values(IonTypes)
-                     .map(ionType => load('null.' + ionType.name)!)
-        );
-        domRoundTripTest(
-          'Boolean',
-            (b1, b2) => b1.booleanValue() === b2.booleanValue(),
+    describe("string", domValueTest("Hello", IonTypes.STRING));
+    describe("String", domValueTest(new String("Hello"), IonTypes.STRING));
+    describe(
+      "Blob",
+      domValueTest(
+        new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
+        IonTypes.BLOB
+      )
+    );
+    describe(
+      "List",
+      domValueTest([9, 8, 7, 6, 5, 4, 3, 2, 1, 0], IonTypes.LIST)
+    );
+    describe(
+      "Struct",
+      domValueTest(
+        { foo: 7, bar: true, baz: 98.6, qux: "Hello" },
+        IonTypes.STRUCT
+      )
+    );
+    describe(
+      "List inside Struct",
+      domValueTest({ foo: [9, 8, 7, 6, 5, 4, 3, 2, 1, 0] }, IonTypes.STRUCT)
+    );
+    describe(
+      "Struct inside List",
+      domValueTest(
+        [{ foo: 7, bar: true, baz: 98.6, qux: "Hello" }],
+        IonTypes.LIST
+      )
+    );
+  });
+  describe("instanceof", () => {
+    describe("All dom.Value subclasses are instances of dom.Value", () => {
+      instanceOfValueTest(true, ...exampleIonValuesWhere());
+    });
+    describe("No plain Javascript value is an instance of dom.Value", () => {
+      instanceOfValueTest(
+        false,
+        ...exampleJsValuesWhere(),
+        Object.create(null)
+      );
+    });
+    for (let subclass of DOM_VALUE_SUBCLASSES) {
+      describe(`${subclass.name}`, () => {
+        // Javascript values are not instances of any dom.Value subclass
+        describe(`Plain Javascript value instanceof dom.${subclass.name}`, () => {
+          instanceOfValueSubclassTest(
+            subclass,
+            false,
+            ...exampleJsValuesWhere()
+          );
+        });
+        // Non-null dom.Values whose Ion type matches that of the constructor must be instances of that
+        // dom.Value subclass.
+        describe(`Non-null ${subclass._getIonType().name} instanceof dom.${
+          subclass.name
+        }`, () => {
+          instanceOfValueSubclassTest(
+            subclass,
             true,
-            false
-        );
-        domRoundTripTest(
-            'Integer',
-            (i1, i2) => i1.numberValue() === i2.numberValue(),
-            Number.MIN_SAFE_INTEGER,
-            -8675309,
-            -24601,
-            0,
-            24601,
-            8675309,
-            Number.MAX_SAFE_INTEGER
-        );
-        domRoundTripTest(
-            'Float',
-            (f1, f2) => Object.is(f1.numberValue(), f2.numberValue()), // Supports NaN equality
-            Number.NEGATIVE_INFINITY,
-            -867.5309,
-            -2.4601,
-            0.0,
-            2.4601,
-            867.5309,
-            Number.POSITIVE_INFINITY,
-            Number.NaN
-        );
-        domRoundTripTest(
-            'Decimal',
-            (d1, d2) => d1.decimalValue().equals(d2.decimalValue()),
-            new Decimal("0"),
-            new Decimal("1.5"),
-            new Decimal("-1.5"),
-            new Decimal(".00001"),
-            new Decimal("-.00001"),
-        );
-        domRoundTripTest(
-            'Timestamp',
-            (t1, t2) => t1.timestampValue().equals(t2.timestampValue()),
-            ...exampleDatesWhere(),
-            ...exampleTimestampsWhere()
-        );
-        domRoundTripTest(
-            'String',
-            (s1, s2) => s1.stringValue() === s2.stringValue(),
-            "",
-            "foo",
-            "bar",
-            "baz",
-            load('foo::bar::baz::"Hello"')
-        );
-        domRoundTripTest(
-            'Symbol',
-            (s1, s2) => s1.stringValue() === s2.stringValue(),
-            load('foo'),
-            load("'bar'"),
-            load('foo::bar::baz'),
-        );
-        domRoundTripTest(
-            'Blob',
-            (b1, b2) => b1.every((value, index) => value === b2[index]),
-            load('{{aGVsbG8gd29ybGQ=}}'),
-            load('foo::bar::{{aGVsbG8gd29ybGQ=}}'),
-        );
-        domRoundTripTest(
-            'Clob',
-            (c1, c2) => c1.every((value, index) => value === c2[index]),
-            load('{{"February"}}'),
-            load('month::{{"February"}}'),
-        );
-        domRoundTripTest(
-            'List',
-            (l1, l2) => l1.reduce(
-                (equalSoFar, value, index) =>
-                    // The dom.Value classes don't have an easy test for deep equality,
-                    // so here we only check for general structure.
-                    equalSoFar
-                        && value.isNull() === l2[index].isNull()
-                        && value.getType() === l2[index].getType(),
-                true
-            ),
-            [],
-            [1, 2, 3],
-            ['foo', 'bar', 'baz'],
-            [new Date(0), true, "hello", null]
-        );
-        domRoundTripTest(
-            'S-Expression',
-            (s1, s2) => s1.reduce(
-                (equalSoFar, value, index) =>
-                    // The dom.Value classes don't have an easy test for deep equality,
-                    // so here we only check for general structure.
-                    equalSoFar
-                        && value.isNull() === s2[index].isNull()
-                        && value.getType() === s2[index].getType(),
-                true
-            ),
-            load('()'),
-            load('(1 2 3)'),
-            load('("foo" "bar" "baz")'),
-            load('(1970-01-01T00:00:00.000Z true "hello" null null.struct)')
-        );
-        domRoundTripTest(
-            'Struct',
-            (s1: Value, s2: Value) => s1.fields().reduce(
-                (equalSoFar, [key, value]) =>
-                    // The dom.Value classes don't have an easy test for deep equality,
-                    // so here we only check for general structure.
-                    equalSoFar
-                        && value.isNull() === s2[key].isNull()
-                        && value.getType() === s2[key].getType(),
-                true
-            ),
-            {},
-            {foo: 5, bar: "baz", qux: true},
-            {foo: ['dog', 'cat', 'mouse']}
-        );
+            ...exampleIonValuesWhere(
+              (value) =>
+                (value.isNull() && subclass === dom.Null) ||
+                (!value.isNull() && value.getType() === subclass._getIonType())
+            )
+          );
+        });
+        // Null dom.Values and those whose Ion type does NOT match that of the constructor must not be instances
+        // of that dom.Value subclass.
+        describe(`Null or non-${subclass._getIonType().name} instanceof dom.${
+          subclass.name
+        }`, () => {
+          instanceOfValueSubclassTest(
+            subclass,
+            false,
+            ...exampleIonValuesWhere(
+              (value) =>
+                (value.isNull() && subclass !== dom.Null) ||
+                (!value.isNull() && value.getType() !== subclass._getIonType())
+            )
+          );
+        });
+      });
+    }
+  });
+  describe("writeTo()", () => {
+    domRoundTripTest(
+      "Null",
+      // isNull() and getType() are already checked in `domRoundTripTest`
+      // Test `null` of every Ion type
+      ...Object.values(IonTypes).map((ionType) => load("null." + ionType.name)!)
+    );
+    domRoundTripTest("Boolean", true, false);
+    domRoundTripTest(
+      "Integer",
+      Number.MIN_SAFE_INTEGER,
+      -8675309,
+      -24601,
+      0,
+      24601,
+      8675309,
+      Number.MAX_SAFE_INTEGER
+    );
+    domRoundTripTest(
+      "Float",
+      // Supports NaN equality
+      Number.NEGATIVE_INFINITY,
+      -867.5309,
+      -2.4601,
+      0.0,
+      2.4601,
+      867.5309,
+      Number.POSITIVE_INFINITY,
+      Number.NaN
+    );
+    domRoundTripTest(
+      "Decimal",
+      new Decimal("0"),
+      new Decimal("1.5"),
+      new Decimal("-1.5"),
+      new Decimal(".00001"),
+      new Decimal("-.00001")
+    );
+    domRoundTripTest(
+      "Timestamp",
+      ...exampleDatesWhere(),
+      ...exampleTimestampsWhere()
+    );
+    domRoundTripTest(
+      "String",
+      "",
+      "foo",
+      "bar",
+      "baz",
+      load('foo::bar::baz::"Hello"')
+    );
+    domRoundTripTest(
+      "Symbol",
+      load("foo"),
+      load("'bar'"),
+      load("foo::bar::baz")
+    );
+    domRoundTripTest(
+      "Blob",
+      load("{{aGVsbG8gd29ybGQ=}}"),
+      load("foo::bar::{{aGVsbG8gd29ybGQ=}}")
+    );
+    domRoundTripTest(
+      "Clob",
+      load('{{"February"}}'),
+      load('month::{{"February"}}')
+    );
+    domRoundTripTest(
+      "List",
+      [],
+      [1, 2, 3],
+      ["foo", "bar", "baz"],
+      [new Date(0), true, "hello", null]
+    );
+    domRoundTripTest(
+      "S-Expression",
+      load("()"),
+      load("(1 2 3)"),
+      load('("foo" "bar" "baz")'),
+      load('(1970-01-01T00:00:00.000Z true "hello" null null.struct)')
+    );
+    domRoundTripTest(
+      "Struct",
+      {},
+      { foo: 5, bar: "baz", qux: true },
+      { foo: ["dog", "cat", "mouse"] }
+    );
+  });
+  describe("Large containers", () => {
+    const LARGE_CONTAINER_NUM_ENTRIES = 1_000_000;
+    let largeJsArray: Value[] = new Array(LARGE_CONTAINER_NUM_ENTRIES);
+    let largeJsObject = {};
+    for (let i = 0; i < LARGE_CONTAINER_NUM_ENTRIES; i++) {
+      let ionValue = Value.from(i);
+      largeJsArray[i] = ionValue;
+      largeJsObject[i] = ionValue;
+    }
+    it("List", () => {
+      let ionList = Value.from(largeJsArray) as any;
+      assert.equal(ionList.getType(), IonTypes.LIST);
+      assert.equal(ionList.length, LARGE_CONTAINER_NUM_ENTRIES);
     });
-    describe('Large containers', () => {
-        const LARGE_CONTAINER_NUM_ENTRIES = 1_000_000;
-        let largeJsArray: Value[] = new Array(LARGE_CONTAINER_NUM_ENTRIES);
-        let largeJsObject = {};
-        for (let i = 0; i < LARGE_CONTAINER_NUM_ENTRIES; i++) {
-            let ionValue = Value.from(i);
-            largeJsArray[i] = ionValue;
-            largeJsObject[i] = ionValue;
-        }
-        it('List', () => {
-            let ionList = Value.from(largeJsArray) as any;
-            assert.equal(ionList.getType(), IonTypes.LIST);
-            assert.equal(ionList.length, LARGE_CONTAINER_NUM_ENTRIES);
-        });
-        it('S-Expression', () => {
-            let ionSExpression = new dom.SExpression(largeJsArray) as any;
-            assert.equal(ionSExpression.getType(), IonTypes.SEXP);
-            assert.equal(ionSExpression.length, LARGE_CONTAINER_NUM_ENTRIES);
-        });
-        it('Struct', function () {
-            this.timeout(5_000)
-            let ionStruct = Value.from(largeJsObject) as any;
-            assert.equal(ionStruct.getType(), IonTypes.STRUCT);
-            assert.equal(ionStruct.fields().length, LARGE_CONTAINER_NUM_ENTRIES);
-        });
+    it("S-Expression", () => {
+      let ionSExpression = new dom.SExpression(largeJsArray) as any;
+      assert.equal(ionSExpression.getType(), IonTypes.SEXP);
+      assert.equal(ionSExpression.length, LARGE_CONTAINER_NUM_ENTRIES);
     });
+    it("Struct", function () {
+      this.timeout(5_000);
+      let ionStruct = Value.from(largeJsObject) as any;
+      assert.equal(ionStruct.getType(), IonTypes.STRUCT);
+      assert.equal(ionStruct.fields().length, LARGE_CONTAINER_NUM_ENTRIES);
+    });
+  });
 });

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -77,13 +77,6 @@ function domRoundTripTest(typeName: string, ...valuesToRoundTrip: any[]) {
         // Load the serialized version of the value
         let roundTripped = load(writer.getBytes())!;
         // Verify that nothing was lost in the round trip
-        assert.isNotNull(roundTripped);
-        assert.equal(domValue.isNull(), roundTripped.isNull());
-        assert.equal(domValue.getType(), roundTripped.getType());
-        assert.deepEqual(
-          domValue.getAnnotations(),
-          roundTripped.getAnnotations()
-        );
         assert.isTrue(domValue.equals(roundTripped));
       });
     }
@@ -97,10 +90,6 @@ function domRoundTripTest(typeName: string, ...valuesToRoundTrip: any[]) {
  *
  * @param jsValue               A JS value to pass to Value.from().
  * @param expectedIonType       The new dom.Value's expected Ion type.
- * @param equalityTest          A function that tests whether the new dom.Value is equal to the provided jsValue.
- * @param expectValue           If specified, `equalityTest` will compare the new dom.Value to `expectValue` instead of
- *                              comparing it to `jsValue`. This is helpful if jsValue is a boxed primitive
- *                              but you want to test for equality with the primitive representation.
  */
 function domValueTest(jsValue, expectedIonType) {
   function validateDomValue(domValue: Value, annotations) {

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -13,435 +13,491 @@
  * permissions and limitations under the License.
  */
 
-import {assert} from 'chai';
-import * as ion from '../src/Ion';
-import {IonType, Reader, Writer} from '../src/Ion';
-import * as fs from 'fs';
-import * as path from 'path';
-import {IonEventStream} from '../src/events/IonEventStream';
-import {IonEventType} from "../src/events/IonEvent";
+import { assert } from "chai";
+import * as ion from "../src/Ion";
+import { IonType, Reader, Writer } from "../src/Ion";
+import * as fs from "fs";
+import * as path from "path";
+import { IonEventStream } from "../src/events/IonEventStream";
+import { IonEventType } from "../src/events/IonEvent";
 
 function findFiles(folder: string, files: string[] = []) {
-    fs.readdirSync(folder).forEach(file => {
-        let filePath = path.join(folder, file);
-        let stats = fs.lstatSync(filePath);
-        if (stats.isDirectory()) {
-            findFiles(filePath, files);
-        } else {
-            files.push(filePath);
-        }
-    });
-    return files;
+  fs.readdirSync(folder).forEach((file) => {
+    let filePath = path.join(folder, file);
+    let stats = fs.lstatSync(filePath);
+    if (stats.isDirectory()) {
+      findFiles(filePath, files);
+    } else {
+      files.push(filePath);
+    }
+  });
+  return files;
 }
 
 function exhaust(reader: Reader) {
-    for (let type; type = reader.next();) {
-        if (type.isContainer && !reader.isNull()) {
-            reader.stepIn();
-            exhaust(reader);
-            reader.stepOut();
-        } else {
-            reader.value();
-        }
+  for (let type; (type = reader.next()); ) {
+    if (type.isContainer && !reader.isNull()) {
+      reader.stepIn();
+      exhaust(reader);
+      reader.stepOut();
+    } else {
+      reader.value();
     }
+  }
 }
 
-function makeEventStream(src: string | Buffer | Uint8Array, writer: Writer): IonEventStream {
-    writer.writeValues(ion.makeReader(src));
-    writer.close();
-    return new IonEventStream(ion.makeReader(writer.getBytes()));
+function makeEventStream(
+  src: string | Buffer | Uint8Array,
+  writer: Writer
+): IonEventStream {
+  writer.writeValues(ion.makeReader(src));
+  writer.close();
+  return new IonEventStream(ion.makeReader(writer.getBytes()));
 }
 
-function equivsTest(path: string, expectedEquivalence = true, equivsTimelines = false) {
-    let bytes = getInput(path)
-    let originalEvents = new IonEventStream(ion.makeReader(bytes)).getEvents();
-    let textEvents = makeEventStream(bytes, ion.makeTextWriter()).getEvents();
-    let binEvents = makeEventStream(bytes, ion.makeBinaryWriter()).getEvents();
+function equivsTest(
+  path: string,
+  expectedEquivalence = true,
+  equivsTimelines = false
+) {
+  let bytes = getInput(path);
+  let originalEvents = new IonEventStream(ion.makeReader(bytes)).getEvents();
+  let textEvents = makeEventStream(bytes, ion.makeTextWriter()).getEvents();
+  let binEvents = makeEventStream(bytes, ion.makeBinaryWriter()).getEvents();
 
-    //i is the index of each toplevel container start event
-    for (let i = 0; i < originalEvents.length - 2; i += originalEvents[i].ionValue.length + 1) {
-        let event = originalEvents[i];
-        let textEvent = textEvents[i];
-        let binEvent = binEvents[i];
-        //Comparisons can be either IonEventStream[](Embedded Documents List of strings interpreted as top level streams).
-        //Or an IonEvent[](contents of an sexp of equivalent Ion values).
-        let comparisons : any = [];
-        if (event.annotations[0] === 'embedded_documents') {
-            //we found a list of strings that we need to interpret as top level ion text streams.
-            for (let j = 0; j < event.ionValue.length - 1; j++) {
-                comparisons.push(
-                    [
-                        new IonEventStream(ion.makeReader(event.ionValue[j].ionValue)),
-                        new IonEventStream(ion.makeReader(textEvent.ionValue[j].ionValue)),
-                        new IonEventStream(ion.makeReader(binEvent.ionValue[j].ionValue))
-                    ]
-                );
-            }
-        } else {//we're in an sexp
-            for (let j = 0; j < event.ionValue.length - 1; j++) {
-                comparisons.push([event.ionValue[j], textEvent.ionValue[j], binEvent.ionValue[j]]);
-                if (event.ionValue[j].eventType === IonEventType.CONTAINER_START) {
-                    j += event.ionValue[j].ionValue.length
-                }
-            }
+  //i is the index of each toplevel container start event
+  for (
+    let i = 0;
+    i < originalEvents.length - 2;
+    i += originalEvents[i].ionValue.length + 1
+  ) {
+    let event = originalEvents[i];
+    let textEvent = textEvents[i];
+    let binEvent = binEvents[i];
+    //Comparisons can be either IonEventStream[](Embedded Documents List of strings interpreted as top level streams).
+    //Or an IonEvent[](contents of an sexp of equivalent Ion values).
+    let comparisons: any = [];
+    if (event.annotations[0] === "embedded_documents") {
+      //we found a list of strings that we need to interpret as top level ion text streams.
+      for (let j = 0; j < event.ionValue.length - 1; j++) {
+        comparisons.push([
+          new IonEventStream(ion.makeReader(event.ionValue[j].ionValue)),
+          new IonEventStream(ion.makeReader(textEvent.ionValue[j].ionValue)),
+          new IonEventStream(ion.makeReader(binEvent.ionValue[j].ionValue)),
+        ]);
+      }
+    } else {
+      //we're in an sexp
+      for (let j = 0; j < event.ionValue.length - 1; j++) {
+        comparisons.push([
+          event.ionValue[j],
+          textEvent.ionValue[j],
+          binEvent.ionValue[j],
+        ]);
+        if (event.ionValue[j].eventType === IonEventType.CONTAINER_START) {
+          j += event.ionValue[j].ionValue.length;
         }
-        //width is the number of "copies"  of each value (original, text, binary)
-        let width = comparisons[0].length;
-        //if we're equal everybody equals everybody
-        //if !eq only the copies in our row are equal
-        //every value in row j must compare with every other row
-        for (let j = 0; j < comparisons.length; j++) {
-            for (let k = j + 1; k < comparisons.length; k++) {
-                //l tracks our index within row j
-                for (let l = 0; l < width; l++) {
-                    //m tracks our index within row k
-                    for (let m = 0; m < width; m++) {
-                        if (equivsTimelines) {
-                            assert.equal(comparisons[j][l].ionValue.compareTo(comparisons[k][m].ionValue), 0);
-                        } else {
-                            assert.equal(comparisons[j][l].equals(comparisons[k][m]), expectedEquivalence);
-                        }
-                    }
-                }
-            }
-        }
+      }
     }
+    //width is the number of "copies"  of each value (original, text, binary)
+    let width = comparisons[0].length;
+    //if we're equal everybody equals everybody
+    //if !eq only the copies in our row are equal
+    //every value in row j must compare with every other row
+    for (let j = 0; j < comparisons.length; j++) {
+      for (let k = j + 1; k < comparisons.length; k++) {
+        //l tracks our index within row j
+        for (let l = 0; l < width; l++) {
+          //m tracks our index within row k
+          for (let m = 0; m < width; m++) {
+            if (equivsTimelines) {
+              assert.equal(
+                comparisons[j][l].ionValue.compareTo(
+                  comparisons[k][m].ionValue
+                ),
+                0
+              );
+            } else {
+              assert.equal(
+                comparisons[j][l].equals(comparisons[k][m]),
+                expectedEquivalence
+              );
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 function nonEquivsTest(path: string) {
-    equivsTest(path, false);
+  equivsTest(path, false);
 }
 
 function equivTimelinesTest(path: string) {
-    equivsTest(path, true, true);
+  equivsTest(path, true, true);
 }
 
 function readerCompareTest(source: string | Buffer) {
-    function toBytes(source: string | Buffer, writer: Writer) {
-        let reader = ion.makeReader(source);
-        writer.writeValues(reader);
-        writer.close();
-        return writer.getBytes();
-    }
+  function toBytes(source: string | Buffer, writer: Writer) {
+    let reader = ion.makeReader(source);
+    writer.writeValues(reader);
+    writer.close();
+    return writer.getBytes();
+  }
 
-    let ionBinary = toBytes(source, ion.makeBinaryWriter());
-    let ionText = toBytes(source, ion.makeTextWriter());
+  let ionBinary = toBytes(source, ion.makeBinaryWriter());
+  let ionText = toBytes(source, ion.makeTextWriter());
 
-    readerCompare(ion.makeReader(ionBinary), ion.makeReader(ionText));
+  readerCompare(ion.makeReader(ionBinary), ion.makeReader(ionText));
 }
 
 function readerCompare(r1: Reader, r2: Reader) {
-    checkReaderValueMethods(r1, r2, null);
+  checkReaderValueMethods(r1, r2, null);
 
-    while (true) {
-        let t1 = r1.next();
-        let t2 = r2.next();
+  while (true) {
+    let t1 = r1.next();
+    let t2 = r2.next();
 
-        let v;
-        try {
-            v = r1.value();
-        } catch (e) {
-            v = 'value() threw ' + e.message;
-        }
-        assert.equal(t1, t2);
+    assert.equal(t1, t2);
 
-        checkReaderValueMethods(r1, r2, t1);
+    checkReaderValueMethods(r1, r2, t1);
 
-        if (t1 === null) {
-            break;
-        }
-
-        if (t1.isContainer && !r1.isNull()) {
-            r1.stepIn();
-            r2.stepIn();
-            readerCompare(r1, r2);
-            r1.stepOut();
-            r2.stepOut();
-        }
+    if (t1 === null) {
+      break;
     }
+
+    if (t1.isContainer && !r1.isNull()) {
+      r1.stepIn();
+      r2.stepIn();
+      readerCompare(r1, r2);
+      r1.stepOut();
+      r2.stepOut();
+    }
+  }
 }
 
 function checkReaderValueMethods(r1: Reader, r2: Reader, type: IonType | null) {
-    // This RegEx will immediately match any string that's passed to it.
-    // It's used to allow assert.throws() to accept any Error that's thrown.
-    const ANY_ERROR_MESSAGE = new RegExp('^');
-    allValueMethods.forEach(methodName => {
-        let typeName = type == null ? 'null' : type.name;
-        if (type != null && nonThrowingMethods[typeName][methodName]) {
-            let v1 = r1[methodName]();
-            let v2 = r2[methodName]();
-            assert(v1 !== undefined, "unexpected 'undefined' response");
-            assert(v2 !== undefined, "unexpected 'undefined' response");
-            assert.deepEqual(v1, v2, methodName + '():  ' + v1 + ' != ' + v2);
-        } else if (type != null && methodName === 'value' && type.isContainer && r1.isNull()) {
-            // special case for Reader.value() when the readers are pointed at a null container
-            assert.isNull(r1[methodName](), 'Expected ' + methodName + '() to return null');
-            assert.isNull(r2[methodName](), 'Expected ' + methodName + '() to return null');
-        } else {
-            assert.throws(() => {
-                r1[methodName]()
-            }, ANY_ERROR_MESSAGE, 'Expected ' + methodName + '() to throw');
-            assert.throws(() => {
-                r2[methodName]()
-            }, ANY_ERROR_MESSAGE, 'Expected ' + methodName + '() to throw');
-        }
-    });
+  // This RegEx will immediately match any string that's passed to it.
+  // It's used to allow assert.throws() to accept any Error that's thrown.
+  const ANY_ERROR_MESSAGE = new RegExp("^");
+  allValueMethods.forEach((methodName) => {
+    let typeName = type == null ? "null" : type.name;
+    if (type != null && nonThrowingMethods[typeName][methodName]) {
+      let v1 = r1[methodName]();
+      let v2 = r2[methodName]();
+      assert(v1 !== undefined, "unexpected 'undefined' response");
+      assert(v2 !== undefined, "unexpected 'undefined' response");
+      assert.deepEqual(v1, v2, methodName + "():  " + v1 + " != " + v2);
+    } else if (
+      type != null &&
+      methodName === "value" &&
+      type.isContainer &&
+      r1.isNull()
+    ) {
+      // special case for Reader.value() when the readers are pointed at a null container
+      assert.isNull(
+        r1[methodName](),
+        "Expected " + methodName + "() to return null"
+      );
+      assert.isNull(
+        r2[methodName](),
+        "Expected " + methodName + "() to return null"
+      );
+    } else {
+      assert.throws(
+        () => {
+          r1[methodName]();
+        },
+        ANY_ERROR_MESSAGE,
+        "Expected " + methodName + "() to throw"
+      );
+      assert.throws(
+        () => {
+          r2[methodName]();
+        },
+        ANY_ERROR_MESSAGE,
+        "Expected " + methodName + "() to throw"
+      );
+    }
+  });
 
-    assert(r1.depth() !== undefined, 'depth() is undefined');
-    assert(r1.depth() !== null, 'depth() is null');
-    assert(r1.depth() >= 0, 'depth() is less than 0');
-    assert.equal(r1.depth(), r2.depth(), "depths don't match");
+  assert(r1.depth() !== undefined, "depth() is undefined");
+  assert(r1.depth() !== null, "depth() is null");
+  assert(r1.depth() >= 0, "depth() is less than 0");
+  assert.equal(r1.depth(), r2.depth(), "depths don't match");
 
-    assert(r1.fieldName() !== undefined, 'fieldname() is undefined');
-    assert.equal(r1.fieldName(), r2.fieldName(), "fieldnames don't match");
+  assert(r1.fieldName() !== undefined, "fieldname() is undefined");
+  assert.equal(r1.fieldName(), r2.fieldName(), "fieldnames don't match");
 
-    assert(r1.isNull() !== undefined, 'isNull() is undefined');
-    assert(r1.isNull() !== null, 'isNull() is null');
-    assert.equal(r1.isNull(), r2.isNull(), "isNull values don't match");
+  assert(r1.isNull() !== undefined, "isNull() is undefined");
+  assert(r1.isNull() !== null, "isNull() is null");
+  assert.equal(r1.isNull(), r2.isNull(), "isNull values don't match");
 
-    assert(r1.annotations() !== undefined, 'annotations() is undefined');
-    assert(r1.annotations() !== null, 'annotations() is null');
-    assert.deepEqual(r1.annotations(), r2.annotations(), "annotations don't match");
+  assert(r1.annotations() !== undefined, "annotations() is undefined");
+  assert(r1.annotations() !== null, "annotations() is null");
+  assert.deepEqual(
+    r1.annotations(),
+    r2.annotations(),
+    "annotations don't match"
+  );
 
-    assert(r1.type() !== undefined, 'type() is undefined');
-    assert.equal(r1.type(), type, "type() doesn't match expected type");
-    assert.equal(r1.type(), r2.type(), "types don't match");
+  assert(r1.type() !== undefined, "type() is undefined");
+  assert.equal(r1.type(), type, "type() doesn't match expected type");
+  assert.equal(r1.type(), r2.type(), "types don't match");
 }
 
 function getInput(path: string): string | Buffer {
-    let options = path.endsWith(".10n") ? null : "utf8";
-    return fs.readFileSync(path, options);
+  let options = path.endsWith(".10n") ? null : "utf8";
+  return fs.readFileSync(path, options);
 }
 
 function roundTripEventStreams(input: string | Buffer) {
-    let streams: IonEventStream[] = [];
-    streams.push(new IonEventStream(ion.makeReader(input)));
+  let streams: IonEventStream[] = [];
+  streams.push(new IonEventStream(ion.makeReader(input)));
 
-    let textWriter = ion.makeTextWriter();
-    streams.push(makeEventStream(input, textWriter));
-    let text = textWriter.getBytes();
+  let textWriter = ion.makeTextWriter();
+  streams.push(makeEventStream(input, textWriter));
+  let text = textWriter.getBytes();
 
-    let binaryWriter = ion.makeBinaryWriter();
-    streams.push(makeEventStream(input, binaryWriter));
-    let binary = binaryWriter.getBytes();
+  let binaryWriter = ion.makeBinaryWriter();
+  streams.push(makeEventStream(input, binaryWriter));
+  let binary = binaryWriter.getBytes();
 
-    // text -> text -> eventstream
-    streams.push(makeEventStream(text, ion.makeTextWriter()));
+  // text -> text -> eventstream
+  streams.push(makeEventStream(text, ion.makeTextWriter()));
 
-    // text -> binary -> eventstream
-    streams.push(makeEventStream(text, ion.makeBinaryWriter()));
+  // text -> binary -> eventstream
+  streams.push(makeEventStream(text, ion.makeBinaryWriter()));
 
-    // binary -> text -> eventstream
-    streams.push(makeEventStream(binary, ion.makeTextWriter()));
+  // binary -> text -> eventstream
+  streams.push(makeEventStream(binary, ion.makeTextWriter()));
 
-    // binary -> binary -> eventstream
-    streams.push(makeEventStream(binary, ion.makeBinaryWriter()));
+  // binary -> binary -> eventstream
+  streams.push(makeEventStream(binary, ion.makeBinaryWriter()));
 
-    // eventstream -> eventstream
-    textWriter = ion.makeTextWriter();
-    streams[0].writeEventStream(textWriter);
-    textWriter.close();
-    streams.push(new IonEventStream(ion.makeReader(textWriter.getBytes())));
+  // eventstream -> eventstream
+  textWriter = ion.makeTextWriter();
+  streams[0].writeEventStream(textWriter);
+  textWriter.close();
+  streams.push(new IonEventStream(ion.makeReader(textWriter.getBytes())));
 
-    for (let i = 0; i < streams.length - 1; i++) {
-        for (let j = i + 1; j < streams.length; j++) {
-            if (!streams[i].equals(streams[j])) {
-                throw new Error("Streams unequal.");
-            }
-        }
+  for (let i = 0; i < streams.length - 1; i++) {
+    for (let j = i + 1; j < streams.length; j++) {
+      if (!streams[i].equals(streams[j])) {
+        throw new Error("Streams unequal.");
+      }
     }
+  }
 }
 
 // TBD:  add some mechanism to know when this list needs to be updated
 //       (e.g., a class that implements IonReader)
 let allValueMethods = [
-    'booleanValue',
-    'byteValue',
-    'decimalValue',
-    'numberValue',
-    'stringValue',
-    'timestampValue',
-    'value',
+  "booleanValue",
+  "byteValue",
+  "decimalValue",
+  "numberValue",
+  "stringValue",
+  "timestampValue",
 ];
 let nonThrowingMethods = {
-    null: {booleanValue: 1, byteValue: 1, decimalValue: 1, numberValue: 1, stringValue: 1, timestampValue: 1, value: 1},
-    bool: {booleanValue: 1, value: 1},
-    int: {numberValue: 1, value: 1},
-    float: {numberValue: 1, value: 1},
-    decimal: {decimalValue: 1, value: 1},
-    timestamp: {timestampValue: 1, value: 1},
-    symbol: {stringValue: 1, value: 1},
-    string: {stringValue: 1, value: 1},
-    clob: {byteValue: 1, value: 1},
-    blob: {byteValue: 1, value: 1},
-    list: {},
-    sexp: {},
-    struct: {},
+  null: {
+    booleanValue: 1,
+    byteValue: 1,
+    decimalValue: 1,
+    numberValue: 1,
+    stringValue: 1,
+    timestampValue: 1,
+  },
+  bool: { booleanValue: 1 },
+  int: { numberValue: 1 },
+  float: { numberValue: 1 },
+  decimal: { decimalValue: 1 },
+  timestamp: { timestampValue: 1 },
+  symbol: { stringValue: 1 },
+  string: { stringValue: 1 },
+  clob: { byteValue: 1 },
+  blob: { byteValue: 1 },
+  list: {},
+  sexp: {},
+  struct: {},
 };
 
 function toSkipList(paths: Array<string>): Map<string, number> {
-    let skipList = new Map<string, number>();
-    paths.forEach(path => {
-        skipList[path] = 1;
-    });
+  let skipList = new Map<string, number>();
+  paths.forEach((path) => {
+    skipList[path] = 1;
+  });
 
-    // additional, known bad/slow test files:
-    skipList['ion-tests/iontestdata/good/equivs/lists.ion'] = 1;     // runs too long, causes TravisCI to fail
-    skipList['ion-tests/iontestdata/good/equivs/sexps.ion'] = 1;     // runs too long, causes TravisCI to fail
+  // additional, known bad/slow test files:
+  skipList["ion-tests/iontestdata/good/equivs/lists.ion"] = 1; // runs too long, causes TravisCI to fail
+  skipList["ion-tests/iontestdata/good/equivs/sexps.ion"] = 1; // runs too long, causes TravisCI to fail
 
-    return skipList;
+  return skipList;
 }
 
 let goodSkipList = toSkipList([
-    'ion-tests/iontestdata/good/decimalsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
-    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/floatsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/intBinary.ion',
-    'ion-tests/iontestdata/good/intsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/symbolZero.ion',
-    'ion-tests/iontestdata/good/symbolExplicitZero.10n',
-    'ion-tests/iontestdata/good/symbolImplicitZero.10n',
-    'ion-tests/iontestdata/good/utf16.ion',
-    'ion-tests/iontestdata/good/utf32.ion',
-    'ion-tests/iontestdata/good/item1.10n',
-    'ion-tests/iontestdata/good/typecodes/T7-large.10n', // https://github.com/amzn/ion-js/issues/541
-    'ion-tests/iontestdata/good/typecodes/T7-small.10n', // https://github.com/amzn/ion-js/issues/541
+  "ion-tests/iontestdata/good/decimalsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/binaryInts.ion",
+  "ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/floatsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/intBinary.ion",
+  "ion-tests/iontestdata/good/intsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/symbolZero.ion",
+  "ion-tests/iontestdata/good/symbolExplicitZero.10n",
+  "ion-tests/iontestdata/good/symbolImplicitZero.10n",
+  "ion-tests/iontestdata/good/utf16.ion",
+  "ion-tests/iontestdata/good/utf32.ion",
+  "ion-tests/iontestdata/good/item1.10n",
+  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amzn/ion-js/issues/541
+  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amzn/ion-js/issues/541
 ]);
 
 let badSkipList = toSkipList([
-    'ion-tests/iontestdata/bad/annotationLengthTooLongContainer.10n',
-    'ion-tests/iontestdata/bad/annotationLengthTooLongScalar.10n',
-    'ion-tests/iontestdata/bad/annotationLengthTooShortContainer.10n',
-    'ion-tests/iontestdata/bad/annotationLengthTooShortScalar.10n',
-    'ion-tests/iontestdata/bad/annotationNested.10n',
-    'ion-tests/iontestdata/bad/annotationWithNoValue.10n',
-    'ion-tests/iontestdata/bad/emptyAnnotatedInt.10n',
-    'ion-tests/iontestdata/bad/localSymbolTableImportNullMaxId.ion',
-    'ion-tests/iontestdata/bad/negativeIntZero.10n',
-    'ion-tests/iontestdata/bad/negativeIntZeroLn.10n',
-    'ion-tests/iontestdata/bad/nopPadWithAnnotations.10n',
-    'ion-tests/iontestdata/bad/structOrderedEmpty.10n',
-    'ion-tests/iontestdata/bad/timestamp/timestampNegativeFraction.10n',
-    'ion-tests/iontestdata/bad/timestamp/timestampSept31.10n',
-    'ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_1.10n',
-    'ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_2.10n',
-    'ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.10n', // https://github.com/amzn/ion-js/issues/542
-    'ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.ion', // https://github.com/amzn/ion-js/issues/542
-    'ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.10n', // https://github.com/amzn/ion-js/issues/542
-    'ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.ion', // https://github.com/amzn/ion-js/issues/542
-    'ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n', // https://github.com/amzn/ion-js/issues/543
-    'ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n', // https://github.com/amzn/ion-js/issues/543
-    'ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n', // https://github.com/amzn/ion-js/issues/543
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n', // https://github.com/amzn/ion-js/issues/544
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_10.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_11.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_12.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_13.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_14.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_2.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_3.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_4.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_5.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_6.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_7.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_8.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_1_length_9.10n', // https://github.com/amzn/ion-js/issues/545
-    'ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n', // https://github.com/amzn/ion-js/issues/546
-    'ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n', // https://github.com/amzn/ion-js/issues/547
+  "ion-tests/iontestdata/bad/annotationLengthTooLongContainer.10n",
+  "ion-tests/iontestdata/bad/annotationLengthTooLongScalar.10n",
+  "ion-tests/iontestdata/bad/annotationLengthTooShortContainer.10n",
+  "ion-tests/iontestdata/bad/annotationLengthTooShortScalar.10n",
+  "ion-tests/iontestdata/bad/annotationNested.10n",
+  "ion-tests/iontestdata/bad/annotationWithNoValue.10n",
+  "ion-tests/iontestdata/bad/emptyAnnotatedInt.10n",
+  "ion-tests/iontestdata/bad/localSymbolTableImportNullMaxId.ion",
+  "ion-tests/iontestdata/bad/negativeIntZero.10n",
+  "ion-tests/iontestdata/bad/negativeIntZeroLn.10n",
+  "ion-tests/iontestdata/bad/nopPadWithAnnotations.10n",
+  "ion-tests/iontestdata/bad/structOrderedEmpty.10n",
+  "ion-tests/iontestdata/bad/timestamp/timestampNegativeFraction.10n",
+  "ion-tests/iontestdata/bad/timestamp/timestampSept31.10n",
+  "ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_1.10n",
+  "ion-tests/iontestdata/bad/timestamp/outOfRange/leapDayNonLeapYear_2.10n",
+  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.10n", // https://github.com/amzn/ion-js/issues/542
+  "ion-tests/iontestdata/bad/annotationSymbolIDUnmapped.ion", // https://github.com/amzn/ion-js/issues/542
+  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.10n", // https://github.com/amzn/ion-js/issues/542
+  "ion-tests/iontestdata/bad/fieldNameSymbolIDUnmapped.ion", // https://github.com/amzn/ion-js/issues/542
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction10d-1.10n", // https://github.com/amzn/ion-js/issues/543
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction11d-1.10n", // https://github.com/amzn/ion-js/issues/543
+  "ion-tests/iontestdata/bad/timestamp/timestampFraction1d0.10n", // https://github.com/amzn/ion-js/issues/543
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_0.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_1.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_10.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_11.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_12.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_13.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_14.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_15.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_2.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_3.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_4.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_5.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_6.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_7.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_8.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_15_length_9.10n", // https://github.com/amzn/ion-js/issues/544
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_10.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_11.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_12.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_13.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_14.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_2.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_3.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_4.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_5.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_6.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_7.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_8.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_1_length_9.10n", // https://github.com/amzn/ion-js/issues/545
+  "ion-tests/iontestdata/bad/typecodes/type_3_length_0.10n", // https://github.com/amzn/ion-js/issues/546
+  "ion-tests/iontestdata/bad/typecodes/type_6_length_0.10n", // https://github.com/amzn/ion-js/issues/547
 ]);
 
 let eventSkipList = toSkipList([
-    'ion-tests/iontestdata/good/allNulls.ion',
-    'ion-tests/iontestdata/good/clobWithNonAsciiCharacter.10n',
-    'ion-tests/iontestdata/good/clobs.ion',
-    'ion-tests/iontestdata/good/decimalsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
-    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n',
-    'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
-    'ion-tests/iontestdata/good/equivs/paddedInts.10n',
-    'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
-    'ion-tests/iontestdata/good/floatsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/innerVersionIdentifiers.ion',
-    'ion-tests/iontestdata/good/intBinary.ion',
-    'ion-tests/iontestdata/good/intsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/lists.ion',
-    'ion-tests/iontestdata/good/nopPadInsideEmptyStructZeroSymbolId.10n',
-    'ion-tests/iontestdata/good/nopPadInsideStructWithNopPadThenValueZeroSymbolId.10n',
-    'ion-tests/iontestdata/good/nopPadInsideStructWithValueThenNopPad.10n',
-    'ion-tests/iontestdata/good/notVersionMarkers.ion',
-    'ion-tests/iontestdata/good/sexpAnnotationQuotedOperator.ion',
-    'ion-tests/iontestdata/good/subfieldVarInt.ion',
-    'ion-tests/iontestdata/good/symbolExplicitZero.10n',
-    'ion-tests/iontestdata/good/symbolImplicitZero.10n',
-    'ion-tests/iontestdata/good/symbolZero.ion',
-    'ion-tests/iontestdata/good/utf16.ion',
-    'ion-tests/iontestdata/good/utf32.ion',
-    'ion-tests/iontestdata/good/item1.10n',
-    'ion-tests/iontestdata/good/typecodes/T6-large.10n', // https://github.com/amzn/ion-js/issues/554
-    'ion-tests/iontestdata/good/typecodes/T11.10n', // https://github.com/amzn/ion-js/issues/548
-    'ion-tests/iontestdata/good/typecodes/T12.10n', // https://github.com/amzn/ion-js/issues/548
-    'ion-tests/iontestdata/good/typecodes/T13.10n', // https://github.com/amzn/ion-js/issues/548
-    'ion-tests/iontestdata/good/typecodes/T7-large.10n', // https://github.com/amzn/ion-js/issues/549
-    'ion-tests/iontestdata/good/typecodes/T7-small.10n', // https://github.com/amzn/ion-js/issues/549
+  "ion-tests/iontestdata/good/allNulls.ion",
+  "ion-tests/iontestdata/good/clobWithNonAsciiCharacter.10n",
+  "ion-tests/iontestdata/good/clobs.ion",
+  "ion-tests/iontestdata/good/decimalsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/binaryInts.ion",
+  "ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n",
+  "ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n",
+  "ion-tests/iontestdata/good/equivs/paddedInts.10n",
+  "ion-tests/iontestdata/good/equivs/systemSymbols.ion",
+  "ion-tests/iontestdata/good/floatsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/innerVersionIdentifiers.ion",
+  "ion-tests/iontestdata/good/intBinary.ion",
+  "ion-tests/iontestdata/good/intsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/lists.ion",
+  "ion-tests/iontestdata/good/nopPadInsideEmptyStructZeroSymbolId.10n",
+  "ion-tests/iontestdata/good/nopPadInsideStructWithNopPadThenValueZeroSymbolId.10n",
+  "ion-tests/iontestdata/good/nopPadInsideStructWithValueThenNopPad.10n",
+  "ion-tests/iontestdata/good/notVersionMarkers.ion",
+  "ion-tests/iontestdata/good/sexpAnnotationQuotedOperator.ion",
+  "ion-tests/iontestdata/good/subfieldVarInt.ion",
+  "ion-tests/iontestdata/good/symbolExplicitZero.10n",
+  "ion-tests/iontestdata/good/symbolImplicitZero.10n",
+  "ion-tests/iontestdata/good/symbolZero.ion",
+  "ion-tests/iontestdata/good/utf16.ion",
+  "ion-tests/iontestdata/good/utf32.ion",
+  "ion-tests/iontestdata/good/item1.10n",
+  "ion-tests/iontestdata/good/typecodes/T6-large.10n", // https://github.com/amzn/ion-js/issues/554
+  "ion-tests/iontestdata/good/typecodes/T11.10n", // https://github.com/amzn/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T12.10n", // https://github.com/amzn/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T13.10n", // https://github.com/amzn/ion-js/issues/548
+  "ion-tests/iontestdata/good/typecodes/T7-large.10n", // https://github.com/amzn/ion-js/issues/549
+  "ion-tests/iontestdata/good/typecodes/T7-small.10n", // https://github.com/amzn/ion-js/issues/549
 ]);
 
 let readerCompareSkipList = toSkipList([]);
 
 let equivsSkipList = toSkipList([
-    'ion-tests/iontestdata/good/equivs/annotatedIvms.ion',
-    'ion-tests/iontestdata/good/equivs/binaryInts.ion',
-    'ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion',
-    'ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion',
-    'ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion',
-    'ion-tests/iontestdata/good/equivs/localSymbolTables.ion',
-    'ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion',
-    'ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n',
-    'ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n',
-    'ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion',
-    'ion-tests/iontestdata/good/equivs/systemSymbols.ion',
-    'ion-tests/iontestdata/good/equivs/systemSymbolsAsAnnotations.ion',
-    'ion-tests/iontestdata/good/equivs/textNewlines.ion',
+  "ion-tests/iontestdata/good/equivs/annotatedIvms.ion",
+  "ion-tests/iontestdata/good/equivs/binaryInts.ion",
+  "ion-tests/iontestdata/good/equivs/decimalsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/floatsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/intsWithUnderscores.ion",
+  "ion-tests/iontestdata/good/equivs/localSymbolTableAppend.ion",
+  "ion-tests/iontestdata/good/equivs/localSymbolTableNullSlots.ion",
+  "ion-tests/iontestdata/good/equivs/localSymbolTables.ion",
+  "ion-tests/iontestdata/good/equivs/nonIVMNoOps.ion",
+  "ion-tests/iontestdata/good/equivs/nopPadEmptyStruct.10n",
+  "ion-tests/iontestdata/good/equivs/nopPadNonEmptyStruct.10n",
+  "ion-tests/iontestdata/good/equivs/structsFieldsDiffOrder.ion",
+  "ion-tests/iontestdata/good/equivs/systemSymbols.ion",
+  "ion-tests/iontestdata/good/equivs/systemSymbolsAsAnnotations.ion",
+  "ion-tests/iontestdata/good/equivs/textNewlines.ion",
 
-    'ion-tests/iontestdata/good/equivs/clobNewlines.ion', // https://github.com/amzn/ion-js/issues/550
-    'ion-tests/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion', // https://github.com/amzn/ion-js/issues/551
-    'ion-tests/iontestdata/good/equivs/longStringsWithComments.ion', // https://github.com/amzn/ion-js/issues/552
+  "ion-tests/iontestdata/good/equivs/clobNewlines.ion", // https://github.com/amzn/ion-js/issues/550
+  "ion-tests/iontestdata/good/equivs/localSymbolTableWithAnnotations.ion", // https://github.com/amzn/ion-js/issues/551
+  "ion-tests/iontestdata/good/equivs/longStringsWithComments.ion", // https://github.com/amzn/ion-js/issues/552
 ]);
 
 let nonEquivsSkipList = toSkipList([
-    'ion-tests/iontestdata/good/non-equivs/clobs.ion',
-    'ion-tests/iontestdata/good/non-equivs/floats.ion',
-    'ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion',
-    'ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion',//Cannot pass until we implement symbol token support.
+  "ion-tests/iontestdata/good/non-equivs/clobs.ion",
+  "ion-tests/iontestdata/good/non-equivs/floats.ion",
+  "ion-tests/iontestdata/good/non-equivs/floatsVsDecimals.ion",
+  "ion-tests/iontestdata/good/non-equivs/symbolTablesUnknownText.ion", //Cannot pass until we implement symbol token support.
 ]);
 
-let goodTestsPath = path.join('ion-tests', 'iontestdata', 'good');
-let badTestsPath = path.join('ion-tests', 'iontestdata', 'bad');
-let equivTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'equivs');
-let nonEquivTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'non-equivs');
-let equivTimelineTestsPath = path.join('ion-tests', 'iontestdata', 'good', 'timestamp', 'equivTimeline');
+let goodTestsPath = path.join("ion-tests", "iontestdata", "good");
+let badTestsPath = path.join("ion-tests", "iontestdata", "bad");
+let equivTestsPath = path.join("ion-tests", "iontestdata", "good", "equivs");
+let nonEquivTestsPath = path.join(
+  "ion-tests",
+  "iontestdata",
+  "good",
+  "non-equivs"
+);
+let equivTimelineTestsPath = path.join(
+  "ion-tests",
+  "iontestdata",
+  "good",
+  "timestamp",
+  "equivTimeline"
+);
 
 let goodTestFiles = findFiles(goodTestsPath);
 let badTestFiles = findFiles(badTestsPath);
@@ -449,83 +505,73 @@ let equivTestFiles = findFiles(equivTestsPath);
 let nonEquivTestFiles = findFiles(nonEquivTestsPath);
 let equivTimelineTestFiles = findFiles(equivTimelineTestsPath);
 
-function skipOrTest(paths: Array<string>, skipLists: Array<Map<string, number>>, test: (s: string) => void): void {
-    for (let path of paths) {
-        let skipped = false;
+function skipOrTest(
+  paths: Array<string>,
+  skipLists: Array<Map<string, number>>,
+  test: (s: string) => void
+): void {
+  for (let path of paths) {
+    let skipped = false;
 
-        if (path.endsWith('.md')) {
-            skipped = true;
-        } else {
-            for (let skipList of skipLists) {
-                if (skipList[path]) {
-                    it.skip(path, () => {});
-                    skipped = true;
-                    break;
-                }
-            }
+    if (path.endsWith(".md")) {
+      skipped = true;
+    } else {
+      for (let skipList of skipLists) {
+        if (skipList[path]) {
+          it.skip(path, () => {});
+          skipped = true;
+          break;
         }
-        if (!skipped) {
-            it(path, () => test(path));
-        }
+      }
     }
+    if (!skipped) {
+      it(path, () => test(path));
+    }
+  }
 }
 
-describe('ion-tests', () => {
-    describe('Good', () => {
-        skipOrTest(
-            goodTestFiles,
-            [goodSkipList],
-            (path) => exhaust(ion.makeReader(getInput(path)))
-        );
-    });
+describe("ion-tests", () => {
+  describe("Good", () => {
+    skipOrTest(goodTestFiles, [goodSkipList], (path) =>
+      exhaust(ion.makeReader(getInput(path)))
+    );
+  });
 
-    describe('Bad', () => {
-        skipOrTest(
-            badTestFiles,
-            [badSkipList],
-            (path) => assert.throws(() => exhaust(ion.makeReader(getInput(path))))
-        );
-    });
+  describe("Bad", () => {
+    skipOrTest(badTestFiles, [badSkipList], (path) =>
+      assert.throws(() => exhaust(ion.makeReader(getInput(path))))
+    );
+  });
 
-    describe('Equivs', () => {
-        skipOrTest(
-            equivTestFiles,
-            [equivsSkipList],
-            (path) => equivsTest(path)
-        );
-    });
+  describe("Equivs", () => {
+    skipOrTest(equivTestFiles, [equivsSkipList], (path) => equivsTest(path));
+  });
 
-    describe('Non-equivs', () => {
-        skipOrTest(
-            nonEquivTestFiles,
-            [nonEquivsSkipList],
-            (path) => nonEquivsTest(path)
-        );
-    });
+  describe("Non-equivs", () => {
+    skipOrTest(nonEquivTestFiles, [nonEquivsSkipList], (path) =>
+      nonEquivsTest(path)
+    );
+  });
 
-    describe('Equiv timelines', () => {
-        skipOrTest(
-            equivTimelineTestFiles,
-            [],
-            (path) => equivTimelinesTest(path)
-        );
-    });
+  describe("Equiv timelines", () => {
+    skipOrTest(equivTimelineTestFiles, [], (path) => equivTimelinesTest(path));
+  });
 
-    describe('EventStream', () => {
-        skipOrTest(
-            // Re-use the 'good' file set
-            goodTestFiles,
-            [eventSkipList],
-            (path) => roundTripEventStreams(getInput(path))
-        );
-    });
+  describe("EventStream", () => {
+    skipOrTest(
+      // Re-use the 'good' file set
+      goodTestFiles,
+      [eventSkipList],
+      (path) => roundTripEventStreams(getInput(path))
+    );
+  });
 
-    describe('ReaderCompare', () => {
-        skipOrTest(
-            // Re-use the 'good' file set
-            goodTestFiles,
-            [eventSkipList, readerCompareSkipList],
-            (path) => readerCompareTest(getInput(path))
-        );
-    });
+  describe("ReaderCompare", () => {
+    skipOrTest(
+      // Re-use the 'good' file set
+      goodTestFiles,
+      [eventSkipList, readerCompareSkipList],
+      (path) => readerCompareTest(getInput(path))
+    );
+  });
 });


### PR DESCRIPTION
*Issue #663*

*Description of changes:*

- Use `equals` method for `dom.Value` comparison tests.
- Remove use of deprecated method `.value()` from tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
