### PR TITLE
Create  uInt8ArrayValue method for reader and deprecate Reader.byteValue

### DIFF
--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -186,6 +186,10 @@ export class BinaryReader implements Reader {
     return this._parser.byteValue();
   }
 
+  uInt8ArrayValue(): Uint8Array | null {
+    return this._parser.uInt8ArrayValue();
+  }
+
   booleanValue(): boolean | null {
     return this._parser.booleanValue();
   }

--- a/src/IonBinaryReader.ts
+++ b/src/IonBinaryReader.ts
@@ -183,7 +183,7 @@ export class BinaryReader implements Reader {
   }
 
   byteValue(): Uint8Array | null {
-    return this._parser.byteValue();
+    return this._parser.uInt8ArrayValue();
   }
 
   uInt8ArrayValue(): Uint8Array | null {

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -416,19 +416,7 @@ export class ParserBinaryRaw {
   }
 
   byteValue(): Uint8Array | null {
-    switch (this._raw_type) {
-      case IonBinary.TB_NULL:
-        return null;
-      case IonBinary.TB_CLOB:
-      case IonBinary.TB_BLOB:
-        if (this.isNull()) {
-          return null;
-        }
-        this.load_value();
-        return this._curr!;
-      default:
-        throw new Error("Current value is not a blob or clob.");
-    }
+    return this.uInt8ArrayValue();
   }
 
   uInt8ArrayValue(): Uint8Array | null {

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -43,7 +43,7 @@
 //    stringValue
 //    decimalValue
 //    timestampValue
-//    byteValue
+//    uInt8ArrayValue
 
 import JSBI from "jsbi";
 import * as IonBinary from "./IonBinary";
@@ -416,6 +416,22 @@ export class ParserBinaryRaw {
   }
 
   byteValue(): Uint8Array | null {
+    switch (this._raw_type) {
+      case IonBinary.TB_NULL:
+        return null;
+      case IonBinary.TB_CLOB:
+      case IonBinary.TB_BLOB:
+        if (this.isNull()) {
+          return null;
+        }
+        this.load_value();
+        return this._curr!;
+      default:
+        throw new Error("Current value is not a blob or clob.");
+    }
+  }
+
+  uInt8ArrayValue(): Uint8Array | null {
     switch (this._raw_type) {
       case IonBinary.TB_NULL:
         return null;

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -133,6 +133,7 @@ export interface Reader {
    * @return `null` if the current Ion value [[isNull]].
    *
    * @throw Error when the reader is not positioned on a `clob` or `blob` typed value.
+   * @deprecated Since version 4.2.  Use the `uInt8ArrayValue` method instead
    */
   byteValue(): Uint8Array | null;
 

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -137,6 +137,16 @@ export interface Reader {
   byteValue(): Uint8Array | null;
 
   /**
+   * Returns the current value as a `Uint8Array`.  This is only valid if `type() == IonTypes.CLOB`
+   * or `type() == IonTypes.BLOB`.
+   *
+   * @return `null` if the current Ion value [[isNull]].
+   *
+   * @throw Error when the reader is not positioned on a `clob` or `blob` typed value.
+   */
+  uInt8ArrayValue(): Uint8Array | null;
+
+  /**
    * Returns the current value as a [[Decimal]].  This is only valid if `type() == IonTypes.DECIMAL`.
    *
    * @return `null` if the current Ion value [[isNull]].

--- a/src/IonReader.ts
+++ b/src/IonReader.ts
@@ -133,7 +133,7 @@ export interface Reader {
    * @return `null` if the current Ion value [[isNull]].
    *
    * @throw Error when the reader is not positioned on a `clob` or `blob` typed value.
-   * @deprecated Since version 4.2.  Use the `uInt8ArrayValue` method instead
+   * @deprecated since version 4.2. Use the `uInt8ArrayValue` method instead.
    */
   byteValue(): Uint8Array | null;
 

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -300,22 +300,7 @@ export class TextReader implements Reader {
   }
 
   byteValue(): Uint8Array | null {
-    this.load_raw();
-    switch (this._type) {
-      case IonTypes.NULL:
-        return null;
-      case IonTypes.BLOB:
-        if (this.isNull()) {
-          return null;
-        }
-        return fromBase64(this._raw);
-      case IonTypes.CLOB:
-        if (this.isNull()) {
-          return null;
-        }
-        return this._raw;
-    }
-    throw new Error("Current value is not a blob or clob.");
+    return this.uInt8ArrayValue();
   }
 
   uInt8ArrayValue(): Uint8Array | null {

--- a/src/IonTextReader.ts
+++ b/src/IonTextReader.ts
@@ -318,6 +318,25 @@ export class TextReader implements Reader {
     throw new Error("Current value is not a blob or clob.");
   }
 
+  uInt8ArrayValue(): Uint8Array | null {
+    this.load_raw();
+    switch (this._type) {
+      case IonTypes.NULL:
+        return null;
+      case IonTypes.BLOB:
+        if (this.isNull()) {
+          return null;
+        }
+        return fromBase64(this._raw);
+      case IonTypes.CLOB:
+        if (this.isNull()) {
+          return null;
+        }
+        return this._raw;
+    }
+    throw new Error("Current value is not a blob or clob.");
+  }
+
   decimalValue(): Decimal | null {
     switch (this._type) {
       case IonTypes.NULL:

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -68,7 +68,7 @@ class IonTextReaderTests {
         let ionReader = ion.makeReader(ionToRead);
         ionReader.next();
 
-        assert.deepEqual(ionReader.byteValue(), Uint8Array.from([194, 128]));
+        assert.deepEqual(ionReader.uInt8ArrayValue(), Uint8Array.from([194, 128]));
     }
 
     @test "Read boolean value in struct"() {

--- a/test/iontests.ts
+++ b/test/iontests.ts
@@ -295,7 +295,7 @@ function roundTripEventStreams(input: string | Buffer) {
 //       (e.g., a class that implements IonReader)
 let allValueMethods = [
   "booleanValue",
-  "byteValue",
+  "uInt8ArrayValue",
   "decimalValue",
   "numberValue",
   "stringValue",
@@ -304,7 +304,7 @@ let allValueMethods = [
 let nonThrowingMethods = {
   null: {
     booleanValue: 1,
-    byteValue: 1,
+    uInt8ArrayValue: 1,
     decimalValue: 1,
     numberValue: 1,
     stringValue: 1,
@@ -317,8 +317,8 @@ let nonThrowingMethods = {
   timestamp: { timestampValue: 1 },
   symbol: { stringValue: 1 },
   string: { stringValue: 1 },
-  clob: { byteValue: 1 },
-  blob: { byteValue: 1 },
+  clob: { uInt8ArrayValue: 1 },
+  blob: { uInt8ArrayValue: 1 },
   list: {},
   sexp: {},
   struct: {},


### PR DESCRIPTION
*Issue #559*

*Description of changes:*
This Pr works on the above mentioned issue for deprecating use of `Reader.byteValue()` and instead use a new method `Reader.uInt8ArrayValue()`.

*Tasks:*
- create a new method called `uInt8ArrayValue.
- deprecate use of `byteValue` from tests