### PR TITLE
Use number instead of JSBI.BigInt for smaller integers

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -486,7 +486,7 @@ export class ParserBinaryRaw {
           return null;
         }
         this.load_value();
-        if(this._curr instanceof JSBI) {
+        if (this._curr instanceof JSBI) {
           const bigInt: JSBI = this._curr!;
           return JSBI.toNumber(bigInt);
         }
@@ -781,7 +781,7 @@ export class ParserBinaryRaw {
     if (this._len === 0) {
       return JsbiSupport.ZERO;
     }
-    if(this._len < 6) {
+    if (this._len < 6) {
       return this.readUnsignedIntAsNumber();
     }
     return this.readUnsignedIntAsBigInt();

--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -486,8 +486,11 @@ export class ParserBinaryRaw {
           return null;
         }
         this.load_value();
-        const bigInt: JSBI = this._curr!;
-        return JSBI.toNumber(bigInt);
+        if(this._curr instanceof JSBI) {
+          const bigInt: JSBI = this._curr!;
+          return JSBI.toNumber(bigInt);
+        }
+        return this._curr!;
       case IonBinary.TB_FLOAT:
         if (this.isNull()) {
           return null;
@@ -771,10 +774,15 @@ export class ParserBinaryRaw {
   /**
    * Positive integers and negative integers are both encoded as an unsigned integer magnitude.
    * This function will read in the magnitude, leaving it to the caller to set the value's sign as appropriate.
+   *
+   * It returns `number` for `_len` less than 6 bytes. Otherwise, it returns `JSBI.BigInt` value.
    */
-  private _readIntegerMagnitude(): JSBI {
+  private _readIntegerMagnitude(): JSBI | number {
     if (this._len === 0) {
       return JsbiSupport.ZERO;
+    }
+    if(this._len < 6) {
+      return this.readUnsignedIntAsNumber();
     }
     return this.readUnsignedIntAsBigInt();
   }
@@ -793,7 +801,8 @@ export class ParserBinaryRaw {
         this._curr = this._readIntegerMagnitude();
         break;
       case IonBinary.TB_NEG_INT:
-        this._curr = JSBI.unaryMinus(this._readIntegerMagnitude());
+        let value = this._readIntegerMagnitude();
+        this._curr = value instanceof JSBI ? JSBI.unaryMinus(value) : -value;
         break;
       case IonBinary.TB_FLOAT:
         this._curr = this.read_binary_float();

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -96,18 +96,10 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
   ): boolean {
     let isSupportedType: boolean = false;
     let valueToCompare: any = null;
-    if (other instanceof Integer) {
-      isSupportedType = true;
-      if (this._bigIntValue == null && other._bigIntValue == null) {
-        valueToCompare = other.numberValue();
-      } else {
-        // One of them is a JSBI
-        valueToCompare = other.bigIntValue();
-      }
-    }
 
     if (options.onlyCompareIon) {
       // `compareOnlyIon` requires that the provided value be an ion.dom.Integer instance.
+      isSupportedType = true;
       if (this._bigIntValue == null && other._bigIntValue == null) {
         valueToCompare = other.numberValue();
       } else {

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -100,13 +100,13 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
       // `compareOnlyIon` requires that the provided value be an ion.dom.Integer instance.
       if (other instanceof Integer) {
         isSupportedType = true;
-        valueToCompare = other.numberValue();
+        valueToCompare = other.bigIntValue();
       }
     } else {
       // We will consider other Integer-ish types
       if (other instanceof global.Number || typeof other === "number") {
         isSupportedType = true;
-        valueToCompare = other.valueOf();
+        valueToCompare = JSBI.BigInt(other.valueOf());
       } else if (other instanceof JSBI) {
         isSupportedType = true;
         valueToCompare = other;
@@ -117,6 +117,6 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
       return false;
     }
 
-    return JSBI.EQ(this.numberValue(), valueToCompare);
+    return JSBI.equal(this.bigIntValue(), valueToCompare);
   }
 }

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -99,12 +99,14 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
 
     if (options.onlyCompareIon) {
       // `compareOnlyIon` requires that the provided value be an ion.dom.Integer instance.
-      isSupportedType = true;
-      if (this._bigIntValue == null && other._bigIntValue == null) {
-        valueToCompare = other.numberValue();
-      } else {
-        // One of them is a JSBI
-        valueToCompare = other.bigIntValue();
+      if (other instanceof Integer) {
+        isSupportedType = true;
+        if (this._bigIntValue == null && other._bigIntValue == null) {
+          valueToCompare = other.numberValue();
+        } else {
+          // One of them is a JSBI
+          valueToCompare = other.bigIntValue();
+        }
       }
     } else {
       // We will consider other Integer-ish types

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -96,17 +96,33 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
   ): boolean {
     let isSupportedType: boolean = false;
     let valueToCompare: any = null;
+    if (other instanceof Integer) {
+      isSupportedType = true;
+      if (this._bigIntValue == null && other._bigIntValue == null) {
+        valueToCompare = other.numberValue();
+      } else {
+        // One of them is a JSBI
+        valueToCompare = other.bigIntValue();
+      }
+    }
+
     if (options.onlyCompareIon) {
       // `compareOnlyIon` requires that the provided value be an ion.dom.Integer instance.
-      if (other instanceof Integer) {
-        isSupportedType = true;
+      if (this._bigIntValue == null && other._bigIntValue == null) {
+        valueToCompare = other.numberValue();
+      } else {
+        // One of them is a JSBI
         valueToCompare = other.bigIntValue();
       }
     } else {
       // We will consider other Integer-ish types
       if (other instanceof global.Number || typeof other === "number") {
         isSupportedType = true;
-        valueToCompare = JSBI.BigInt(other.valueOf());
+        if (this.bigIntValue == null) {
+          valueToCompare = other.valueOf();
+        } else {
+          valueToCompare = JSBI.BigInt(other.valueOf());
+        }
       } else if (other instanceof JSBI) {
         isSupportedType = true;
         valueToCompare = other;
@@ -117,6 +133,9 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
       return false;
     }
 
-    return JSBI.equal(this.bigIntValue(), valueToCompare);
+    if (valueToCompare instanceof JSBI) {
+      return JSBI.equal(this.bigIntValue(), valueToCompare);
+    }
+    return this.numberValue() == valueToCompare;
   }
 }

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -453,10 +453,16 @@ class IonIntEvent extends AbstractIonEvent {
   valueCompare(expected: IonEvent): ComparisonResult {
     if (expected instanceof IonIntEvent) {
       // convert both values to `JSBI.BigInt` first and then compare for precision.
-      let actualValue = this.ionValue instanceof JSBI ? this.ionValue : JSBI.BigInt(this.ionValue);
-      let expectedValue = expected.ionValue instanceof JSBI ? expected.ionValue : JSBI.BigInt(expected.ionValue);
+      let actualValue =
+        this.ionValue instanceof JSBI
+          ? this.ionValue
+          : JSBI.BigInt(this.ionValue);
+      let expectedValue =
+        expected.ionValue instanceof JSBI
+          ? expected.ionValue
+          : JSBI.BigInt(expected.ionValue);
 
-      if(JSBI.equal(actualValue, expectedValue)) {
+      if (JSBI.equal(actualValue, expectedValue)) {
         return new ComparisonResult(ComparisonResultType.EQUAL);
       }
     }

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -451,11 +451,14 @@ class IonIntEvent extends AbstractIonEvent {
   }
 
   valueCompare(expected: IonEvent): ComparisonResult {
-    if (
-      expected instanceof IonIntEvent &&
-      JSBI.equal(this.ionValue, expected.ionValue)
-    ) {
-      return new ComparisonResult(ComparisonResultType.EQUAL);
+    if (expected instanceof IonIntEvent) {
+      // convert both values to `JSBI.BigInt` first and then compare for precision.
+      let actualValue = this.ionValue instanceof JSBI ? this.ionValue : JSBI.BigInt(this.ionValue);
+      let expectedValue = expected.ionValue instanceof JSBI ? expected.ionValue : JSBI.BigInt(expected.ionValue);
+
+      if(JSBI.equal(actualValue, expectedValue)) {
+        return new ComparisonResult(ComparisonResultType.EQUAL);
+      }
     }
     return new ComparisonResult(
       ComparisonResultType.NOT_EQUAL,


### PR DESCRIPTION
*Issue #663*

*Description of changes:*
This PR works on a performance change using `number` instead of `JSBI.BigInt` for smaller integers.

*Changes:*
1. Change IonBinaryParser logic to use `number` for integers smaller than 6 bytes. Otherwise, use `JSBI.BigInt`. 
2. Modified dom.Value#Integers to use `JSBI.equal` for comparison. Hence converting both comparison values to `JSBI.BigInt` first for precision.
3. Modified the `IonEvent#valueCompare` for `Integer` Event to convert both comparison values to `JSBI.BigInt` first and then compare.

*Test:*
Verified performance using [benchmarkjs](https://benchmarkjs.com) with large binary ion file as input.

*Test Results:*
| Input file type  | Time(before enhancement) | Time (after enhancement) | % decrease in Time
|----------|:-------------:|------:|-----:|
| Binary - big integers | 12.666 | 12.820 | -1.215 
| Binary - small integers | 10.356 | 1.000 | 90.342 