### PR TITLE
Add support for duplicate fieldnames in dom.Value#Struct

### DIFF
--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -120,7 +120,7 @@ export class Null extends Value(Object, IonTypes.NULL, FromJsConstructor.NONE) {
     this._unsupportedOperationOrNullDereference("fieldNames");
   }
 
-  fields(): [string, Value][] {
+  fields(): [string, Value[]][] {
     this._unsupportedOperationOrNullDereference("fields");
   }
 

--- a/src/dom/Null.ts
+++ b/src/dom/Null.ts
@@ -120,7 +120,7 @@ export class Null extends Value(Object, IonTypes.NULL, FromJsConstructor.NONE) {
     this._unsupportedOperationOrNullDereference("fieldNames");
   }
 
-  fields(): [string, Value[]][] {
+  fields(): [string, Value][] {
     this._unsupportedOperationOrNullDereference("fields");
   }
 

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -48,9 +48,8 @@ export class Struct extends Value(
     super();
     // Struct fields will always be stored as (fieldName, fieldValues) => (string, Value[])
     for (const [fieldName, fieldValue] of fields) {
-      this._fields[fieldName] = Array.isArray(fieldValue)
-        ? fieldValue
-        : [fieldValue];
+      this._fields[fieldName] =
+        fieldValue instanceof Value ? [fieldValue] : fieldValue;
     }
     this._setAnnotations(annotations);
 

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -41,7 +41,10 @@ export class Struct extends Value(
    * @param fields        An iterator of field name/value pairs to represent as a struct.
    * @param annotations   An optional array of strings to associate with this null value.
    */
-  constructor(fields: Iterable<[string, Value]> | Iterable<[string, Value[]]>, annotations: string[] = []) {
+  constructor(
+    fields: Iterable<[string, Value]> | Iterable<[string, Value[]]>,
+    annotations: string[] = []
+  ) {
     super();
     for (const [fieldName, fieldValue] of fields) {
       this._fields[fieldName] = fieldValue;
@@ -114,7 +117,7 @@ export class Struct extends Value(
       return child!;
     }
     let values: Value[] | undefined = [];
-    child.forEach(value => values!.push(...value.getAll(...pathTail)!));
+    child.forEach((value) => values!.push(...value.getAll(...pathTail)!));
     return values!;
   }
 
@@ -233,7 +236,11 @@ export class Struct extends Value(
           const expectedChild = valueToCompare[j];
           matchFound =
             child[0] === expectedChild[0] &&
-            this._ionValueEquals(child[1].sort(), expectedChild[1].sort(), options);
+            this._ionValueEquals(
+              child[1].sort(),
+              expectedChild[1].sort(),
+              options
+            );
           if (matchFound) {
             paired[j] = true;
           }

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -228,11 +228,13 @@ export class Struct extends Value(
 
   // helper function for comparison of all values of a field
   _ionValueEquals(child: Value[], expectedChild: Value[], options): boolean {
-    for (const value of child) {
-      for (const expectedValue of expectedChild) {
-        if (!value.equals(expectedValue, options)) {
-          return false;
-        }
+    if (child.length !== expectedChild.length) {
+      return false;
+    }
+
+    for (let i: number = 0; i < child.length; i++) {
+      if (!child[i].equals(expectedChild[i], options)) {
+        return false;
       }
     }
     return true;

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -107,6 +107,14 @@ export interface Value {
   get(...pathElements: PathElement[]): Value | null;
 
   /**
+   * For the Struct type, returns an array containing all the values for given field name or field name path
+   *
+   * @param One or more values to be used to index into the Value.
+   * @returns null if no value is found at the specified path. Otherwise, returns the discovered Value.
+   */
+  getAll(...pathElements: PathElement[]): Value[] | null;
+
+  /**
    * For the Struct type, returns an array containing the names of the fields in the Struct;
    * otherwise throws an Error.
    */
@@ -116,7 +124,13 @@ export interface Value {
    * For the Struct type, returns an array containing the field name/value pairs in the Struct;
    * otherwise throws an Error.
    */
-  fields(): [string, Value[]][];
+  fields(): [string, Value][];
+
+  /**
+   * For the Struct type, returns an array containing the field name/values pairs in the Struct;
+   * otherwise throws an Error.
+   */
+  allFields(): [string, Value[]][];
 
   /**
    * For the Struct, List, and SExpression types, returns an array containing the container's
@@ -316,8 +330,12 @@ export function Value<Clazz extends Constructor>(
       this._unsupportedOperation("fieldNames");
     }
 
-    fields(): [string, Value[]][] {
+    fields(): [string, Value][] {
       this._unsupportedOperation("fields");
+    }
+
+    allFields(): [string, Value[]][] {
+      this._unsupportedOperation("allFields");
     }
 
     elements(): Value[] {
@@ -326,6 +344,10 @@ export function Value<Clazz extends Constructor>(
 
     get(...pathElements: PathElement[]): Value | null {
       this._unsupportedOperation("get");
+    }
+
+    getAll(...pathElements: PathElement[]): Value[] | null {
+      this._unsupportedOperation("getAll");
     }
 
     as<T extends Value>(ionValueType: Constructor<T>): T {

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -116,7 +116,7 @@ export interface Value {
    * For the Struct type, returns an array containing the field name/value pairs in the Struct;
    * otherwise throws an Error.
    */
-  fields(): [string, Value][];
+  fields(): [string, Value[]][];
 
   /**
    * For the Struct, List, and SExpression types, returns an array containing the container's
@@ -316,7 +316,7 @@ export function Value<Clazz extends Constructor>(
       this._unsupportedOperation("fieldNames");
     }
 
-    fields(): [string, Value][] {
+    fields(): [string, Value[]][] {
       this._unsupportedOperation("fields");
     }
 

--- a/src/dom/Value.ts
+++ b/src/dom/Value.ts
@@ -107,7 +107,19 @@ export interface Value {
   get(...pathElements: PathElement[]): Value | null;
 
   /**
-   * For the Struct type, returns an array containing all the values for given field name or field name path
+   * Like the `get(PathElement[])` method, but returns *all* of the values associated
+   * with a given field name instead of just the last one. For example, for the
+   * following struct:
+   *
+   *     {
+   *         foo: 1,
+   *         foo: null,
+   *         foo: true,
+   *     }
+   *
+   * a call to `get("foo")` would return a `dom.Boolean` representing `true`
+   * while a call to `getAll("foo")` would return an `Array` of
+   * `dom.Value`s: `[1, null, true]`.
    *
    * @param One or more values to be used to index into the Value.
    * @returns null if no value is found at the specified path. Otherwise, returns the discovered Value.
@@ -127,8 +139,20 @@ export interface Value {
   fields(): [string, Value][];
 
   /**
-   * For the Struct type, returns an array containing the field name/values pairs in the Struct;
-   * otherwise throws an Error.
+   * Like the `fields()` method, but returns an array containing the field name/value pairs with *all* of
+   * the associated values to a field name, instead of field name/value pairs with just the last associated value
+   * to a field name. For example, for the
+   * following struct:
+   *
+   *     {
+   *         foo: 1,
+   *         foo: null,
+   *         foo: true,
+   *     }
+   *
+   * a call to `fields()` would return a field name "foo" with a `dom.Boolean` representing `true`
+   * while a call to `allFields()` would return  a field name "foo" with an `Array` of
+   * `dom.Value`s: `[1, null, true]`.
    */
   allFields(): [string, Value[]][];
 

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -126,11 +126,15 @@ function _loadValue(reader: Reader): Value {
 }
 
 function _loadStruct(reader: Reader): Struct {
-  const children: Map<string, Value> = new Map();
+  const children: Map<string, Value[]> = new Map();
   const annotations: string[] = reader.annotations();
   reader.stepIn();
   while (reader.next()) {
-    children.set(reader.fieldName()!, _loadValue(reader));
+    if (children.has(reader.fieldName()!)) {
+      children.get(reader.fieldName()!)!.push(_loadValue(reader));
+    } else {
+      children.set(reader.fieldName()!, [_loadValue(reader)]);
+    }
   }
   reader.stepOut();
   return new Struct(children.entries(), annotations);

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -484,10 +484,10 @@ describe('DOM', () => {
       assert.equal("Jacob", s["name"]["middle"]);
 
       // Iteration
-      for (let [fieldName, values] of s) {
+      for (let [fieldName, value] of s) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
-         values.forEach(value => assert.isFalse(value.isNull()));
+         assert.isFalse(value.isNull());
       }
 
       assert.equal(2, s.fields().length)
@@ -532,10 +532,10 @@ describe('DOM', () => {
 
 
       // Iteration
-      for (let [fieldName, values] of s) {
+      for (let [fieldName, value] of s) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
-         values.forEach(value => assert.isFalse(value.isNull()));
+         assert.isFalse(value.isNull());
       }
 
       // length is 1 with two values: 55, 41

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -455,7 +455,7 @@ describe('DOM', () => {
       assert.equal("Jacob", s.get("name", "middle")!.stringValue());
 
       // Iteration
-      for (let [fieldName, values] of s.fields()) {
+      for (let [fieldName, values] of s.allFields()) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
          values.forEach(value => {assert.isFalse(value.isNull())});
@@ -501,11 +501,35 @@ describe('DOM', () => {
           '}'
       )!;
 
+      let s1: Value = load(
+          'foo::bar::{' +
+          'name: {' +
+          'first: "John", ' +
+          'middle: "Jacob", ' +
+          'last: "Jingleheimer-Schmidt",' +
+          '},' +
+          'name: {' +
+          'first: "Jessie", ' +
+          'middle: "Bob", ' +
+          'last: "Pinkman",' +
+          '},' +
+          'age: 41' +
+          '}'
+      )!;
       assert.equal(IonTypes.STRUCT, s.getType());
       assert.deepEqual(['foo', 'bar'], s.getAnnotations());
 
       // Field access return last value for a fieldname
       assert.equal(41, s.age);
+
+      // get all values for given field name
+      assert.equal(55, s.getAll("age")[0]);
+      assert.equal(41, s.getAll("age")[1]);
+      assert.equal(2, s.getAll("age").length);
+      assert.isTrue(s1.getAll('name','middle')![0].equals("Jacob", {onlyCompareIon: false}));
+      assert.isTrue(s1.getAll('name','middle')![1].equals("Bob", {onlyCompareIon: false}));
+      assert.equal(2, s1.getAll('name','middle')!.length);
+
 
       // Iteration
       for (let [fieldName, values] of s) {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -455,10 +455,10 @@ describe('DOM', () => {
       assert.equal("Jacob", s.get("name", "middle")!.stringValue());
 
       // Iteration
-      for (let [fieldName, value] of s.fields()) {
+      for (let [fieldName, values] of s.fields()) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
-         assert.isFalse(value.isNull());
+         values.forEach(value => {assert.isFalse(value.isNull())});
       }
 
       assert.equal(2, s.fields().length);
@@ -484,10 +484,10 @@ describe('DOM', () => {
       assert.equal("Jacob", s["name"]["middle"]);
 
       // Iteration
-      for (let [fieldName, value] of s) {
+      for (let [fieldName, values] of s) {
          assert.isTrue(typeof fieldName === "string");
          assert.isTrue(fieldName.length > 0);
-         assert.isFalse(value.isNull());
+         values.forEach(value => assert.isFalse(value.isNull()));
       }
 
       assert.equal(2, s.fields().length)

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -492,4 +492,29 @@ describe('DOM', () => {
 
       assert.equal(2, s.fields().length)
    });
+
+   it('load() Struct with duplicate fields as any', () => {
+      let s: any = load(
+          'foo::bar::{' +
+          'age: 55, ' +
+          'age: 41' +
+          '}'
+      )!;
+
+      assert.equal(IonTypes.STRUCT, s.getType());
+      assert.deepEqual(['foo', 'bar'], s.getAnnotations());
+
+      // Field access return last value for a fieldname
+      assert.equal(41, s.age);
+
+      // Iteration
+      for (let [fieldName, values] of s) {
+         assert.isTrue(typeof fieldName === "string");
+         assert.isTrue(fieldName.length > 0);
+         values.forEach(value => assert.isFalse(value.isNull()));
+      }
+
+      // length is 1 with two values: 55, 41
+      assert.equal(1, s.fields().length)
+   });
 });

--- a/test/dom/equivalence.ts
+++ b/test/dom/equivalence.ts
@@ -351,9 +351,14 @@ describe("Equivalence", () => {
     let value1: Value = load("{ foo: 'bar', foo: 'baz' }")!;
     let value2: Value = load("{ foo: 'bar', foo: 'baz' }")!;
     let value3: Value = load("{ foo: 'bar', foo: 'qux' }")!;
+    let value4: Value = load("{ foo: 1, baz: true, foo: 2 }")!;
+    let value5: Value = load("{ foo: 2, foo: 1, baz: true }")!;
 
     assert.isTrue(value1.equals(value2));
-    assert.isTrue(value1.equals(value2));
+    assert.isTrue(value2.equals(value1));
     assert.isFalse(value1.equals(value3));
+
+    // Equivalence for unordered fields
+    assert.isTrue(value4.equals(value5));
   });
 });

--- a/test/dom/equivalence.ts
+++ b/test/dom/equivalence.ts
@@ -347,4 +347,13 @@ describe("Equivalence", () => {
       )
     );
   });
+  it("equals() for Struct with duplicate fields", () => {
+    let value1: Value = load("{ foo: 'bar', foo: 'baz' }")!;
+    let value2: Value = load("{ foo: 'bar', foo: 'baz' }")!;
+    let value3: Value = load("{ foo: 'bar', foo: 'qux' }")!;
+
+    assert.isTrue(value1.equals(value2));
+    assert.isTrue(value1.equals(value2));
+    assert.isFalse(value1.equals(value3));
+  });
 });


### PR DESCRIPTION
*Description of changes:*
This PR is to support duplicate fields in a Struct according to the [Ion Spec](https://amzn.github.io/ion-docs/docs/spec.html#struct).

*Tasks:*

1.  Added changes in the `dom.Value#Struct` for supporting duplicate fields. (All the `Struct` field will now be stored in `(fieldname, values)` -> `[string, Value[]]` form)
2.  `dom.Value#Struct` constructor would accept both `Iterable<string, Value>` as well as `Iterable<string, Value[]>` for creating `Struct`.
2.  Added `getAll` and `allFields` methods for getting all values of Struct fields.
3.  `toString` method returns with all the values of Struct fields.
2.  Changes in test suite for duplicate fields.
3.  add tests for duplicate fields. 
