### PR TITLE
Changes for broken struct issue with text parser

### DIFF
--- a/src/IonParserTextRaw.ts
+++ b/src/IonParserTextRaw.ts
@@ -687,6 +687,7 @@ export class ParserTextRaw {
       ch = this._read_after_whitespace(true);
       if (ch != CH_CL) {
         this._error("expected ':'");
+        return;
       }
       this._ops.unshift(this._read_struct_comma);
       this._ops.unshift(this._read_value);

--- a/test/IonTextReader.ts
+++ b/test/IonTextReader.ts
@@ -162,6 +162,19 @@ class IonTextReaderTests {
         assert.isNull(ionReader.next());
     }
 
+    @test "Parse through struct throws error on broken input"() {
+        let invalidIonToRead = "{broken";
+
+        let ionReader = ion.makeReader(invalidIonToRead);
+        ionReader.next();
+
+        assert.equal(ion.IonTypes.STRUCT, ionReader.type());
+
+        ionReader.stepIn(); // Step into the base struct.
+
+        assert.throws(() => ionReader.next());
+    }
+
     @test "Reads an array"() {
         let ionToRead = "{ key : ['v1', 'v2'] }";
         let ionReader = ion.makeReader(ionToRead);

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -336,7 +336,7 @@ describe("Value", () => {
       assert.equal(ionSExpression.length, LARGE_CONTAINER_NUM_ENTRIES);
     });
     it("Struct", function () {
-      this.timeout(5_000);
+      this.timeout(6_000);
       let ionStruct = Value.from(largeJsObject) as any;
       assert.equal(ionStruct.getType(), IonTypes.STRUCT);
       assert.equal(ionStruct.fields().length, LARGE_CONTAINER_NUM_ENTRIES);

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -491,6 +491,9 @@ describe('DOM', () => {
       }
 
       assert.equal(2, s.fields().length)
+
+      // broken struct
+      assert.throws(() => load('{broken'));
    });
 
    it('load() Struct with duplicate fields as any', () => {


### PR DESCRIPTION
*Issue #682*

*Description of changes:*
Changes for throwing error on broken struct as input for text parser. 

*Input:*
```
{broken
```

*Output before change:*
```
Struct { _fields: [Object: null prototype] {} }  // null struct
```

*Output after change:*
```
Error: expected ':'  // throws errror
```

*Test:*
added unit tests for text reader and dom load