### PR TITLE
added changes for preserving elements() behavior to v4.1.0

### DIFF
--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -140,7 +140,11 @@ export class Struct extends Value(
   }
 
   elements(): Value[] {
-    return Object.values(this._fields);
+    let singleValueFields = Object.create(null);
+    for (const [fieldName, values] of this.allFields()) {
+      singleValueFields[fieldName] = values[values.length - 1];
+    }
+    return Object.values(singleValueFields);
   }
 
   [Symbol.iterator](): IterableIterator<[string, Value]> {

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -533,6 +533,11 @@ describe('DOM', () => {
       assert.isTrue(s1.getAll('name','middle')![1].equals("Bob"));
       assert.equal(2, s1.getAll('name','middle')!.length);
 
+      // elements returns values for given Struct where for a fieldname it only contains the last value
+      // instead of an array of all values
+      assert.equal(41, s.elements()[0]);
+      assert.isFalse(Array.isArray(s.elements()[0]));
+      assert.equal("Jessie", s1.elements()[0]['first']);
 
       // Iteration
       for (let [fieldName, value] of s) {


### PR DESCRIPTION
*Description of changes:*
This PR works on a breaking change from v4.2.0.

*Changes:*
- modified the `elements()` method from `dom.value#Struct` to return only the last value related to a duplicate fieldname when returning all values. 

*Test:*
- added tests for `elements()` changes. 