### PR TITLE
added README for dom equals API

### DIFF
--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -264,3 +264,140 @@ assert.isTrue(string === "" + ionString);
 assert.isTrue(string === ionString.stringValue());
 assert.isFalse(ionString === ionString2);
 ```
+
+### `dom.Value` equivalence
+
+dom.Value object equivalence is implemented by two methods ionEquals(compares two dom.Value objects based on strict or non-strict comparison type) and equals(compares a dom.Value object with a corresponding JS object).
+
+#### `ionEquals`:
+
+This method compares a dom.Value object with another dom.Value object with either strict or non-strict comparison type. 
+
+*Strict equivalence* refers to Ion data model equivalence as defined in Ion Equivalence (https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html) and by Ion Specification (http://amzn.github.io/ion-docs/docs/spec.html)
+*Structural or non-strict equivalence* follows the same rules as strict equivalence,except that
+
+* 1. Annotations are not considered, and
+* 2. Timestamps that represent the same instant in time are always considered equivalent.
+
+#### `equals`:
+
+This method compares a dom.Value object with a corresponding JS object. 
+
+#### Integer Example:
+```javascript
+let int1: Value = load("foo::bar::7");
+let int2: Value = load("foo::bar::7");
+let int3: Value = load("7");
+
+// Equivalence between two Ion DOM Values
+int1.ionEquals(int2); // returns true
+int1.ionEquals(int3); // returns false as annotations didn't match in a strict equivalence
+int1.ionEquals(int3, {ignoreAnnotations: true}); // returns true for non-strict equivalence
+
+// Equivalence between JS Value and Ion DOM Value
+int1.equals(7); // returns true
+int1.ionEquals(7); // returns false
+```
+
+#### Float Example:
+```javascript
+let float1: Value = load("baz::qux::15e-1");
+let float2: Value = load("baz::qux::15e-1");
+let float3: Value = load("15e-1");
+let float4: Value = load("1.5");
+let float5: Value = load("12e-1");
+
+// Equivalence between two Ion DOM Values
+float1.ionEquals(float2); // returns true
+float1.ionEquals(float3); // return false as annotations didn't match in a strict equivalence
+
+float1.ionEquals(float4); // returns false as Decimal and Float values will not be equivalent
+float3.ionEquals(float5, {epsilon: 0.5}); // returns true as both values are equivalent by epsilon value
+float3.ionEquals(float5, {epsilon: 0.2}); // returns false as both values are not equivalent by epsilon value
+
+// Equivalence between JS Value and Ion DOM Value
+float1.equals(1.5); // returns true
+float1.ionEquals(1.5); // returns false
+```
+
+#### Timestamp example:
+```javascript
+let timestamp1: Value = load("DOB::2020-01-16T20:15:54.066Z");
+let timestamp2: Value = load("DOB::2020-01-16T20:15:54.066Z");
+let timestamp3: Value = load("DOB::2001T");
+let timestamp4: Value = load("DOB::2001-01-01T");
+
+// Equivalence between two Ion DOM Values
+timestamp1.ionEquals(timestamp2); // returns true 
+timestamp1.ionEquals(timestamp3); // returns false as in strict mode the precision and local offsets are also compared
+timestamp3.ionEquals(timestamp4, {ignoreTimestampPrecision: true}); // retruns true as in non strict comparison precision and local offset are ignored along with annotations
+
+// Equivalence between JS Value and Ion DOM Value
+timestamp1.equals(new Date("2020-01-16T20:15:54.066Z")); // returns true
+timestamp1.equals(new Date("2020-02-16T20:15:54.066Z")); // returns false 
+```
+
+#### List Example:
+```javascript
+let list1: Value = load('planets::["Mercury", "Venus", "Earth", "Mars"]');
+let list2: Value = load('planets::["Mercury", "Venus", "Earth", "Mars"]');
+let list3: Value = load('planets::["Mercury", "Venus"]');
+
+// Equivalence between two Ion DOM Values
+list1.ionEquals(list2) // returns true
+list1.ionEquals(list3) // returns false because the lists have different length
+
+// Equivalence between JS Value and Ion DOM Value
+list1.equals(["Mercury", "Venus", "Earth", "Mars"]); // returns true
+list1.equals(["Mercury", "Venus", "Earth"]); // returns false because the lists differ with one lement "Mars"
+```
+
+####Struct Example:
+```javascript
+let struct1: Value = load(
+  "foo::bar::{" +
+    "name: {" +
+    'first: "John", ' +
+    'middle: "Jacob", ' +
+    'last: "Jingleheimer-Schmidt",' +
+    "}," +
+    "age: 41" +
+    "}"
+);
+let struct2: Value = load(
+  "foo::bar::{" +
+    "name: {" +
+    'first: "John", ' +
+    'middle: "Jacob", ' +
+    'last: "Jingleheimer-Schmidt",' +
+    "}," +
+    "age: 41" +
+    "}"
+);
+let struct3: Value = load(
+  "foo::bar::{" +
+    "name: {" +
+    'first: "Jessica", ' +
+    'middle: "Jacob", ' +
+    'last: "Jingleheimer-Schmidt",' +
+    "}," +
+    "age: 41" +
+    "}"
+);
+
+// Equivalence between two Ion DOM Values
+struct1.ionEquals(struct2); // returns true
+struct1.ionEquals(struct3); // retruns false because name is different for both values
+
+// Equivalence between JS Value and Ion DOM Value
+struct1.equals(
+    {
+      name: {
+        first: "John",
+        middle: "Jacob",
+        last: "Jingleheimer-Schmidt",
+      },
+      age: 41,
+    }
+); // retrurns true
+```

--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -280,13 +280,13 @@ This method compares a `dom.Value` object with another `dom.Value` object with e
 * Annotations are not considered, and
 * Timestamps that represent the same instant in time are always considered equivalent.
 
-Optional parameters that can be used with this method:
+This method accepts an optional configuration object that allows you to modify how equivalence is determined. It recognizes the following properties:
 
-| option                      | description                                                                    |
-| --------------------------- | :------------------------------------------------------------------------------|
-|`epsilon`                    | used by `Float` for an equality with given epsilon precision. (Default: `null`)|
-|`ignoreAnnotations`          | specifies whether to ignore annotations or not for equality. (Default: `false`)|
-|`ignoreTimestampPrecision`   | specifies whether to ignore timestamp local offset and precision or not for equality. (Default: `false`)|
+| option                      | description                                                                           | default |
+| --------------------------- | :-------------------------------------------------------------------------------------|:--------|
+|`epsilon`                    | used by `Float` for an equality with given epsilon precision.                         | `null`  |
+|`ignoreAnnotations`          | specifies whether to ignore annotations or not for equality.                          | `false` |
+|`ignoreTimestampPrecision`   | specifies whether to ignore timestamp local offset and precision or not for equality. | `false` |
 
 #### `equals`
 
@@ -296,9 +296,7 @@ If the other object is a `dom.Value` instance then this comparison checks for st
 _NOTE:_ 
 
 * This method also provides an optional parameter `epsilon` for `Float` type comparison.
-* This method allows coerce numeric types comparison for `Decimal` and `Float` values:
-    * Comparison of `Float` with `Decimal` or `number` type is allowed.
-    * Comparison of `Decimal` with `Float` or `number` type is allowed.
+* This method allows `Decimal`, `Float`, and `number` values to be compared to one another.
 
 #### Integer Example
 ```javascript

--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -10,6 +10,7 @@ simpler for developers to work with.
 - [`ion.dumpBinary()`, `ion.dumpText()`, and `ion.dumpPrettyText()`](#iondumpbinary-iondumptext-and-iondumpprettytext)
 - [`ion.dom` Data Types](#iondom-data-types)
 - [Testing Equality](#testing-equality)
+- [`dom.Value` equivalence](#domvalue-equivalence)
 
 ### `ion.load()`
 
@@ -275,7 +276,7 @@ assert.isFalse(ionString === ionString2);
 
 This method compares a `dom.Value` object with another `dom.Value` object with either strict or non-strict comparison type. 
 
-*Strict equivalence* refers to Ion data model equivalence as defined in Ion Equivalence (https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html) and by Ion Specification (http://amzn.github.io/ion-docs/docs/spec.html)
+*Strict equivalence* refers to Ion data model equivalence as defined in [Ion Equivalence](https://www.javadoc.io/doc/com.amazon.ion/ion-java/latest/com/amazon/ion/util/Equivalence.html) and by [Ion Specification](http://amzn.github.io/ion-docs/docs/spec.html)
 *Structural* (or *non-strict*) *equivalence* follows the same rules as strict equivalence,except that:
 * Annotations are not considered, and
 * Timestamps that represent the same instant in time are always considered equivalent.

--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -271,7 +271,7 @@ assert.isFalse(ionString === ionString2);
 1. `ionEquals`, which tests two `dom.Value` instances for equivalence according to the Ion data model.
 2. `equals`, which tests for value-based equality and can be used to compare a `dom.Value` with a corresponding JS object.
 
-#### `ionEquals`:
+#### `ionEquals`
 
 This method compares a `dom.Value` object with another `dom.Value` object with either strict or non-strict comparison type. 
 
@@ -288,7 +288,7 @@ Optional parameters that can be used with this method:
 |`ignoreAnnotations`          | specifies whether to ignore annotations or not for equality. (Default: `false`)|
 |`ignoreTimestampPrecision`   | specifies whether to ignore timestamp local offset and precision or not for equality. (Default: `false`)|
 
-#### `equals`:
+#### `equals`
 
 This method compares a `dom.Value` object with a corresponding JS object as defined in [Ion Data Types section](#iondom-data-types). 
 If the other object is a `dom.Value` instance then this comparison checks for structural (or "non-strict") equivalence.
@@ -300,7 +300,7 @@ _NOTE:_
     * Comparison of `Float` with `Decimal` or `number` type is allowed.
     * Comparison of `Decimal` with `Float` or `number` type is allowed.
 
-#### Integer Example:
+#### Integer Example
 ```javascript
 let intSame1: Value = load("foo::bar::7");
 let intSame2: Value = load("foo::bar::7");
@@ -316,7 +316,7 @@ intSame1.equals(7); // returns true
 intSame1.ionEquals(7); // returns false
 ```
 
-#### Float Example:
+#### Float Example
 ```javascript
 let floatSame1: Value = load("baz::qux::15e-1");
 let floatSame2: Value = load("baz::qux::15e-1");
@@ -337,7 +337,7 @@ floatSame1.equals(1.5); // returns true
 floatSame1.ionEquals(1.5); // returns false
 ```
 
-#### Timestamp example:
+#### Timestamp example
 ```javascript
 let timestampSame1: Value = load("DOB::2020-01-16T20:15:54.066Z");
 let timestampSame2: Value = load("DOB::2020-01-16T20:15:54.066Z");
@@ -354,7 +354,7 @@ timestampSame1.equals(new Date("2020-01-16T20:15:54.066Z")); // returns true
 timestampSame1.equals(new Date("2020-02-16T20:15:54.066Z")); // returns false as month is different 
 ```
 
-#### List Example:
+#### List Example
 ```javascript
 let listSame1: Value = load('planets::["Mercury", "Venus", "Earth", "Mars"]');
 let listSame2: Value = load('planets::["Mercury", "Venus", "Earth", "Mars"]');
@@ -366,10 +366,10 @@ listSame1.ionEquals(listWithDifferentLength) // returns false because the lists 
 
 // Equivalence between JS Value and Ion DOM Value
 listSame1.equals(["Mercury", "Venus", "Earth", "Mars"]); // returns true
-listSame1.equals(["Mercury", "Venus", "Earth"]); // returns false because the lists differ with one lement "Mars"
+listSame1.equals(["Mercury", "Venus", "Earth"]); // returns false because the lists differ with one element "Mars"
 ```
 
-####Struct Example:
+####Struct Example
 ```javascript
 let structSame1: Value = load(
   "foo::bar::{" +
@@ -416,5 +416,5 @@ structSame1.equals(
       },
       age: 41,
     }
-); // retrurns true
+); // returns true
 ```


### PR DESCRIPTION
*Description of changes:*
This PR adds description and usage for equals API of `dom.Value`.

*Changes:*
- description of `equals` and `ionEquals` methods for `dom.Value`.
- added examples for usage of both methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
