### PR TITLE
Adds Node 16 to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-          node-version: [10.x, 12.x, 14.x]
+          node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
         - uses: actions/checkout@v2
           with:
             submodules: recursive
         - name: Use Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v1
+          uses: actions/setup-node@v2
           with:
             node-version: ${{ matrix.node-version }}
         - run: npm install


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Adds Node 16 (current version) to the CI build workflow. Also upgrades the `setup-node` workflow action to `v2`.

You can see successful CI run [here](https://github.com/popematt/ion-js/actions/runs/1312678119).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
