### PR TITLE
Updates ion-js to be compatible with jsbi@^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "commit": "git-cz",
     "prepare": "grunt release",
-    "test": "nyc mocha",
+    "test": "npm run test-jsbi4 && npm run test-jsbi3",
+    "test-jsbi3": "npm install jsbi@3.1.1 && nyc mocha",
+    "test-jsbi4": "npm install jsbi@4.0.0 && nyc mocha",
     "release": "grunt release",
     "test-driver": "cd test-driver && npm install",
     "build-test-driver": "cd test-driver && npm run build",

--- a/src/IonTextWriter.ts
+++ b/src/IonTextWriter.ts
@@ -171,7 +171,7 @@ export class TextWriter extends AbstractWriter {
       const scale = -exponent;
 
       if (exponent == 0) {
-        s += coefficient + ".";
+        s += coefficient.toString() + ".";
       } else if (exponent < 0) {
         // Avoid printing small negative exponents using a heuristic
         // adapted from http://speleotrove.com/decimal/daconvs.html
@@ -186,15 +186,15 @@ export class TextWriter extends AbstractWriter {
         } else if (adjustedExponent >= -6) {
           s += "0.";
           s += "00000".substring(0, scale - significantDigits);
-          s += coefficient;
+          s += coefficient.toString();
         } else {
-          s += coefficient;
+          s += coefficient.toString();
           s += "d-";
           s += scale.toString();
         }
       } else {
         // exponent > 0
-        s += coefficient + "d" + exponent;
+        s += coefficient.toString() + "d" + exponent;
       }
 
       this.writeUtf8(s);

--- a/src/dom/Decimal.ts
+++ b/src/dom/Decimal.ts
@@ -31,7 +31,7 @@ export class Decimal extends Value(
    * @param annotations   An optional array of strings to associate with `value`.
    */
   constructor(value: ion.Decimal, annotations: string[] = []) {
-    super(...[value.getCoefficient(), value.getExponent(), value.isNegative()]);
+    super(value.numberValue());
     this._decimalValue = value;
     this._numberValue = value.numberValue();
     this._setAnnotations(annotations);

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -870,7 +870,7 @@ class IonListEvent extends AbsIonContainerEvent {
       ) {
         return new ComparisonResult(
           ComparisonResultType.NOT_EQUAL,
-          `${child.ionValue} vs. ${expectedContainer[1].ionValue}`,
+          `${child.ionValue} vs. ${expectedContainer[i].ionValue}`,
           i + 1,
           i + 1
         );

--- a/src/events/IonEvent.ts
+++ b/src/events/IonEvent.ts
@@ -468,7 +468,7 @@ class IonIntEvent extends AbstractIonEvent {
     }
     return new ComparisonResult(
       ComparisonResultType.NOT_EQUAL,
-      this.ionValue + " vs. " + expected.ionValue
+      `${this.ionValue} vs. ${expected.ionValue}`
     );
   }
 
@@ -870,7 +870,7 @@ class IonListEvent extends AbsIonContainerEvent {
       ) {
         return new ComparisonResult(
           ComparisonResultType.NOT_EQUAL,
-          child.ionValue + " vs. " + expectedContainer[i].ionValue,
+          `${child.ionValue} vs. ${expectedContainer[1].ionValue}`,
           i + 1,
           i + 1
         );

--- a/test/IonAnnotations.ts
+++ b/test/IonAnnotations.ts
@@ -15,6 +15,7 @@
 
 import {assert} from 'chai';
 import * as ion from '../src/Ion';
+import JSBI from "jsbi";
 
 function readerToBytes(reader) {
     let writer = ion.makeTextWriter();
@@ -33,7 +34,7 @@ describe('Annotations', () => {
         let reader = ion.makeReader(data);
         reader.next();
         assert.deepEqual(reader.annotations(), ['a', 'b']);
-        assert.equal(reader.value(), '123');
+        assert.equal(reader.value()?.toString(), '123');
         assert.equal(readerToString(reader), 'a::b::123');
     });
 

--- a/test/IonParserBinaryRaw.ts
+++ b/test/IonParserBinaryRaw.ts
@@ -17,6 +17,7 @@ import {assert} from 'chai';
 import SignAndMagnitudeInt from "../src/SignAndMagnitudeInt";
 import {BinarySpan} from "../src/IonSpan";
 import {ParserBinaryRaw} from "../src/IonParserBinaryRaw";
+import JSBI from "jsbi";
 
 /**
  * Tests for reading the UInt primitive follow.
@@ -49,7 +50,8 @@ let unsignedIntBytesMatchValue = (bytes: number[],
                                       ParserBinaryRaw._readUnsignedIntAsBigIntFrom) => {
     let binarySpan = new BinarySpan(new Uint8Array(bytes));
     let actual = readFrom(binarySpan, bytes.length);
-    assert.equal(actual, expected)
+    actual = actual instanceof JSBI ? JSBI.toNumber(actual) : actual;
+    assert.equal(actual, expected);
 };
 
 let unsignedIntReadingTests = [

--- a/test/dom/Value.ts
+++ b/test/dom/Value.ts
@@ -109,10 +109,10 @@ function domValueTest(jsValue, expectedIonType) {
   return () => {
     // Test Value.from() with and without specifying annotations
     let annotations = ["foo", "bar", "baz"];
-    it("" + jsValue, () => {
+    it(`${jsValue}`, () => {
       validateDomValue(Value.from(jsValue), []);
     });
-    it(annotations.join("::") + "::" + jsValue, () => {
+    it(annotations.join("::") + `::${jsValue}`, () => {
       validateDomValue(Value.from(jsValue, annotations), annotations);
     });
   };

--- a/test/dom/dom.ts
+++ b/test/dom/dom.ts
@@ -223,7 +223,7 @@ describe('DOM', () => {
       assert.equal(101.5, +d);
       assert.equal(101.5, d.numberValue());
       assert.isTrue(new ion.Decimal('101.5').equals(d.decimalValue()!));
-      assert.equal(1015, +d.decimalValue()!.getCoefficient());
+      assert.equal(1015, JSBI.toNumber(d.decimalValue()!.getCoefficient()));
    });
 
    it('load() Decimal as any', () => {
@@ -234,7 +234,7 @@ describe('DOM', () => {
       assert.equal(101.5, d);
       assert.equal(101.5, +d);
       assert.isTrue(new ion.Decimal('101.5').equals(d.decimalValue()));
-      assert.equal(1015, +d.decimalValue()!.getCoefficient());
+      assert.equal(1015, JSBI.toNumber(d.decimalValue()!.getCoefficient()));
    });
 
    it('load() Timestamp as Value', () => {

--- a/test/mochaSupport.ts
+++ b/test/mochaSupport.ts
@@ -7,7 +7,7 @@ export function valueName(value: any): string {
     }
     if (typeof value === "object") {
         let typeText = _hasValue(value.constructor) ? value.constructor.name : 'Object';
-        let valueText = _hasValue(value.toString) ? ''+value : JSON.stringify(value);
+        let valueText = _hasValue(value.toString) ? `${value}` : JSON.stringify(value);
 
         return `${typeText}(${valueText})`;
     }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #700 

**Description of changes:**

Updates usage of JSBI so that consumers of `ion-js` can use JSBI 3 or 4. JSBI 4 no longer allows certain built-in operators to be used with JSBI, and disallows new Number(some_jsbi) constructor calls. (See https://github.com/GoogleChromeLabs/jsbi/issues/85 and #700 for more details.) 

Anywhere that a JSBI was being coerced to a `Number` or a `string` was replaced with an explicit conversion (using `toString()`, `toNumber()`, or a template string). In the `Decimal` constructor, there was an indirect invocation of `new Number(some_jsbi)` that was updated to use `JSBI.toNumber()` instead.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
