### PR TITLE
Fix #709 Ion binary reader.bigIntValue returning `number`s

### DIFF
--- a/src/IonParserBinaryRaw.ts
+++ b/src/IonParserBinaryRaw.ts
@@ -472,6 +472,10 @@ export class ParserBinaryRaw {
           return null;
         }
         this.load_value();
+        if (!(this._curr instanceof JSBI)) {
+          const num = this._curr!;
+          return JSBI.BigInt(num);
+        }
         return this._curr!;
       default:
         throw new Error(


### PR DESCRIPTION
*Issue #, if available:*

#709

*Description of changes:*

Fixes a bug where `IonReader.bigIntValue()` would return `number` values when reading binary ion data. See #709 for more details

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
