### PR TITLE
Remove dependency on `global` global variable

### DIFF
--- a/src/IonUnicode.ts
+++ b/src/IonUnicode.ts
@@ -17,8 +17,10 @@ const JS_DECODER_MAX_BYTES = 512;
 
 // Check whether this runtime supports the `TextDecoder` feature
 let textDecoder;
-if (global["TextDecoder"] != null) {
-  textDecoder = new global["TextDecoder"]("utf8", { fatal: true });
+// @ts-expect-error: Typescript will complain about TextDecoder being undefined
+if (typeof TextDecoder !== "undefined") {
+  // @ts-expect-error: Typescript will complain about TextDecoder being undefined
+  textDecoder = new TextDecoder("utf8", { fatal: true });
 } else {
   textDecoder = null;
 }

--- a/src/dom/Boolean.ts
+++ b/src/dom/Boolean.ts
@@ -4,11 +4,12 @@ import {
   FromJsConstructorBuilder,
   Primitives,
 } from "./FromJsConstructor";
+import { _NativeJsBoolean } from "./JsValueConversion";
 import { Value } from "./Value";
 
 const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
   .withPrimitives(Primitives.Boolean)
-  .withClassesToUnbox(global.Boolean)
+  .withClassesToUnbox(_NativeJsBoolean)
   .build();
 
 /**
@@ -36,7 +37,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
  * [2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Description
  */
 export class Boolean extends Value(
-  global.Boolean,
+  _NativeJsBoolean,
   IonTypes.BOOL,
   _fromJsConstructor
 ) {
@@ -81,7 +82,7 @@ export class Boolean extends Value(
       valueToCompare = other.booleanValue();
     } else if (!options.onlyCompareIon) {
       // We will consider other Boolean-ish types
-      if (typeof other === "boolean" || other instanceof global.Boolean) {
+      if (typeof other === "boolean" || other instanceof _NativeJsBoolean) {
         isSupportedType = true;
         valueToCompare = other.valueOf();
       }

--- a/src/dom/Float.ts
+++ b/src/dom/Float.ts
@@ -66,7 +66,7 @@ export class Float extends Value(Number, IonTypes.FLOAT, _fromJsConstructor) {
       return thisValue!.equals(other.decimalValue());
     } else if (!options.onlyCompareIon) {
       // We will consider other Float-ish types
-      if (other instanceof global.Number || typeof other === "number") {
+      if (other instanceof Number || typeof other === "number") {
         isSupportedType = true;
         valueToCompare = other.valueOf();
       }

--- a/src/dom/Integer.ts
+++ b/src/dom/Integer.ts
@@ -108,7 +108,7 @@ export class Integer extends Value(Number, IonTypes.INT, _fromJsConstructor) {
       }
     } else if (!options.onlyCompareIon) {
       // We will consider other Integer-ish types
-      if (other instanceof global.Number || typeof other === "number") {
+      if (other instanceof Number || typeof other === "number") {
         isSupportedType = true;
         if (this.bigIntValue == null) {
           valueToCompare = other.valueOf();

--- a/src/dom/JsValueConversion.ts
+++ b/src/dom/JsValueConversion.ts
@@ -5,6 +5,13 @@ import { IonTypes } from "../IonTypes";
 import { _hasValue } from "../util";
 import { Value } from "./Value";
 
+// In ./Boolean.ts and ./String.ts, the native Boolean and String types
+// are shadowed by the export class defined in the file, but said class
+// definitions still need to reference the original class definitions.
+// This provides a mechanism for doing so.
+export const _NativeJsBoolean = Boolean;
+export const _NativeJsString = String;
+
 // Typescript interfaces can be used to describe classes' static methods; this can
 // be a bit surprising as the methods in the interface are not marked 'static' and
 // the class definition does not need to indicate that it implements this interface.

--- a/src/dom/Lob.ts
+++ b/src/dom/Lob.ts
@@ -61,7 +61,7 @@ export function Lob(ionType: IonType) {
         }
       } else {
         // We will consider other Lob-ish types
-        if (other instanceof global.Uint8Array) {
+        if (other instanceof Uint8Array) {
           isSupportedType = true;
           valueToCompare = other.valueOf();
         }

--- a/src/dom/Sequence.ts
+++ b/src/dom/Sequence.ts
@@ -102,7 +102,7 @@ export function Sequence(ionType: IonType) {
         }
       } else {
         // We will consider other Sequence-ish types
-        if (other instanceof global.Array) {
+        if (other instanceof Array) {
           isSupportedType = true;
           valueToCompare = other;
         }

--- a/src/dom/String.ts
+++ b/src/dom/String.ts
@@ -4,11 +4,12 @@ import {
   FromJsConstructorBuilder,
   Primitives,
 } from "./FromJsConstructor";
+import { _NativeJsString } from "./JsValueConversion";
 import { Value } from "./Value";
 
 const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
   .withPrimitives(Primitives.String)
-  .withClassesToUnbox(global.String)
+  .withClassesToUnbox(_NativeJsString)
   .build();
 
 /**
@@ -17,7 +18,7 @@ const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
  * [1] http://amzn.github.io/ion-docs/docs/spec.html#string
  */
 export class String extends Value(
-  global.String,
+  _NativeJsString,
   IonTypes.STRING,
   _fromJsConstructor
 ) {
@@ -63,7 +64,7 @@ export class String extends Value(
       valueToCompare = other.stringValue();
     } else if (!options.onlyCompareIon) {
       // We will consider other String-ish types
-      if (typeof other === "string" || other instanceof global.String) {
+      if (typeof other === "string" || other instanceof _NativeJsString) {
         isSupportedType = true;
         valueToCompare = other.valueOf();
       }

--- a/src/dom/Struct.ts
+++ b/src/dom/Struct.ts
@@ -222,7 +222,7 @@ export class Struct extends Value(
       valueToCompare = other.allFields();
     } else if (!options.onlyCompareIon) {
       // We will consider other Struct-ish types
-      if (typeof other === "object" || other instanceof global.Object) {
+      if (typeof other === "object" || other instanceof Object) {
         isSupportedType = true;
         valueToCompare = Value.from(other).allFields();
       }

--- a/src/dom/Symbol.ts
+++ b/src/dom/Symbol.ts
@@ -8,7 +8,7 @@ import { Value } from "./Value";
 
 const _fromJsConstructor: FromJsConstructor = new FromJsConstructorBuilder()
   .withPrimitives(Primitives.String)
-  .withClassesToUnbox(global.String)
+  .withClassesToUnbox(String)
   .build();
 
 // TODO:
@@ -63,7 +63,7 @@ export class Symbol extends Value(String, IonTypes.SYMBOL, _fromJsConstructor) {
       valueToCompare = other.stringValue();
     } else if (!options.onlyCompareIon) {
       // We will consider other Symbol-ish types
-      if (typeof other === "string" || other instanceof global.String) {
+      if (typeof other === "string" || other instanceof String) {
         isSupportedType = true;
         valueToCompare = other.valueOf();
       }

--- a/src/dom/Timestamp.ts
+++ b/src/dom/Timestamp.ts
@@ -110,7 +110,7 @@ export class Timestamp extends Value(
         // expectedValue is a non-DOM Timestamp
         isSupportedType = true;
         valueToCompare = other;
-      } else if (other instanceof global.Date) {
+      } else if (other instanceof Date) {
         if (this.dateValue().getTime() === other.getTime()) {
           return true;
         } else {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The `global` global variable [1] is a node-ism, and is not available on
browsers and other js runtime environments. Browser bundlers typically overcome this with a polyfill that defines `global` as a reference to the `window` variable [2], but not all runtimes have an equivalent option. As a result, use of `global` tends to cause headaches:

https://github.com/aws/aws-sdk-js/issues/2141

https://github.com/angular/angular-cli/issues/8160

https://stackoverflow.com/questions/57361546/referenceerror-global-is-not-defined-with-web3

https://dev.to/richardbray/how-to-fix-the-referenceerror-global-is-not-defined-error-in-sveltekitvite-2i49

Therefore, this change replaces all references to `global` with behavior that is guaranteed by the ECMA spec, which should be available in any runtime.

[1]: https://nodejs.org/docs/latest/api/all.html#all_globals_global
[2]: https://github.com/browserify/browserify-handbook#global

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
