### PR TITLE
Refactors the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,13 @@ on:
     types: [created]
 
 jobs:
-  release:
+  build:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - name: set env
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
@@ -22,28 +19,69 @@ jobs:
       - run: npm install
       - name: grunt release
         run: ./node_modules/.bin/grunt release
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs/
+  publish-to-github:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: set env
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
       - name: create zip file
         run: zip -r "ion-js.$RELEASE_TAG-dist.zip" ./dist
       - name: upload zip file to github release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$RELEASE_TAG" "ion-js.$RELEASE_TAG-dist.zip"
-      - name: clean prior to publishing to npm
-        run: |
-          rm -rf .nyc_output
-          rm "ion-js.$RELEASE_TAG-dist.zip"
+  publish-to-npm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: set env
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+      - run: ls */* | cat
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: npm publish
         # skip npm publishing if running in a fork
         if: github.repository == 'amzn/ion-js'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish
-      - name: checkout gh-pages
-        uses: actions/checkout@v3
+  update-docs:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: set env
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
         with:
           ref: gh-pages
-          clean: false # keep the build outputs
-      - name: update gh-pages documentation
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: docs/
+      - name: create documentation pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -rf api browser
           cp -R ./docs/api .
@@ -52,4 +90,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -m "adds documentation for $RELEASE_TAG"
-          git push
+          git checkout -b "generated-docs-$RELEASE_TAG"
+          git push --set-upstream origin "generated-docs-$RELEASE_TAG"
+          REVIEWER="$(gh release view "$RELEASE_TAG"  --json author --jq '.author.login')"
+          gh pr create --fill --base gh-pages -r "$REVIEWER"

--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,22 @@
 # See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
 # Use `npm pack` to create a tgz file. View the contents of the .tgz to test your .npmignore
-docs
-ion-tests 
-tests
-.baseDir*
-.travis.yml
-_config.yml
-.nojekyll 
-.gitmodules
-.tscache
-.idea
-browser
-src
 *.map
+.baseDir*
+.github/
+.gitmodules
+.idea
+.nojekyll
+.nyc_output/
+.prettierignore
+.travis.yml
+.tscache
 Gruntfile.js
+_config.yml
+browser
+docs
+ion-tests
+src
+test
+test-driver
+tests
+tslint.json


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Refactors the release workflow to have separate jobs that can be independently retried. Also, the workflow now opens a pull request instead of pushing directly to the `gh-pages` branch.

You can view a test of this workflow that I ran on a separate branch in my fork.
* [release workflow run](https://github.com/popematt/ion-js/actions/runs/2310376548) for `v125.1.0` of `popematt/ion-js`.
* [v125.1.0 release](https://github.com/popematt/ion-js/releases/tag/v125.1.0) with the zip file that was added by the workflow
* https://github.com/popematt/ion-js/pull/1

I am creating this PR from a different branch than I ran the test to ensure that the v125.1.0 tag does not get merged into `amzn/ion-js` somehow by mistake.


The `.npmignore` change looks like a lot, but it is just adding `.github`, `.nyc_output/`, `.prettierignore`, `test`, `test-driver`, and `tslint.json`, and then I alphabetized the list.



*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
