### PR TITLE
Drops support for Node 10.x, 12.x and adds 18.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v5.0.0-development ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v5.0.0-development ]
 
 jobs:
   build:
@@ -12,15 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-          node-version: [10.x, 12.x, 14.x, 16.x]
+          node-version: [14.x, 16.x, 18.x]
 
     steps:
         - uses: actions/checkout@v2
           with:
             submodules: recursive
         - name: Use Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v2
+          uses: actions/setup-node@v3
           with:
             node-version: ${{ matrix.node-version }}
         - run: npm install

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An implementation of [Amazon Ion](https://amzn.github.io/ion-docs/) for JavaScri
 [![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-js/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://amzn.github.io/ion-js/api/index.html)
 
-This package is tested with Node JS major versions **10**, **12**, **14**, and **16**.  While this library
+This package is tested with Node JS major versions **14**, **16**, **18**, and **20**.  While this library
 should be usable within browsers that support **ES5+**, please note that it is not currently being tested
 in any browser environments.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An implementation of [Amazon Ion](https://amzn.github.io/ion-docs/) for JavaScri
 [![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-js/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://amzn.github.io/ion-js/api/index.html)
 
-This package is tested with Node JS major versions **14**, **16**, **18**, and **20**.  While this library
+This package is tested with Node JS major versions **14**, **16**, and **18**.  While this library
 should be usable within browsers that support **ES5+**, please note that it is not currently being tested
 in any browser environments.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-js",
-  "version": "4.3.1-SNAPSHOT",
+  "version": "5.0.0-SNAPSHOT",
   "description": "A JavaScript implementation of the Ion data interchange format",
   "main": "dist/commonjs/es6/Ion.js",
   "types": "dist/commonjs/es6/Ion.d.ts",


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This updates the supported versions of Node.js and bumps the version to `5.0.0-SNAPSHOT` (since dropping support for old node is theoretically a backwards incompatible change).

Note that this PR is against the `v5.0.0-development` branch, not against master.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
