### PR TITLE
Support milliseconds when constructing from a Date

### DIFF
--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -97,12 +97,9 @@ export class Timestamp {
   ) {
     if (dateOrLocalOffset instanceof Date) {
       const date = dateOrLocalOffset;
-      const seconds = new Decimal(
-        // The coefficient is the total number of milliseconds as an integer
-        date.getSeconds() + date.getMilliseconds(),
-        // And the exponent is 0 to indicate the scale of that integer
-        0
-      );
+      const seconds = date.getMilliseconds() === 0 
+        ? new Decimal(date.getSeconds(), 0)
+        : new Decimal(date.getSeconds() * 1000 + date.getMilliseconds(), -3);
 
       this._localOffset = date.getTimezoneOffset() * -1;
       this._year = date.getFullYear();

--- a/src/IonTimestamp.ts
+++ b/src/IonTimestamp.ts
@@ -97,9 +97,10 @@ export class Timestamp {
   ) {
     if (dateOrLocalOffset instanceof Date) {
       const date = dateOrLocalOffset;
-      const seconds = date.getMilliseconds() === 0 
-        ? new Decimal(date.getSeconds(), 0)
-        : new Decimal(date.getSeconds() * 1000 + date.getMilliseconds(), -3);
+      const seconds =
+        date.getMilliseconds() === 0
+          ? new Decimal(date.getSeconds(), 0)
+          : new Decimal(date.getSeconds() * 1000 + date.getMilliseconds(), -3);
 
       this._localOffset = date.getTimezoneOffset() * -1;
       this._year = date.getFullYear();

--- a/test/IonTimestamp.ts
+++ b/test/IonTimestamp.ts
@@ -250,15 +250,10 @@ describe("Timestamp", () => {
 
         const date2 = new Date(2000, 0, 1, 12, 30, 20, 20);
         let timestamp3 = new ion.Timestamp(date2.getTimezoneOffset() * -1, 2000, 1, 1, 12, 30, new ion.Decimal(
-            40,
-            0
+            20020,
+            -3
         ));
         let timestamp4 = new ion.Timestamp(date2);
         assert.isTrue(timestamp3!.equals(timestamp4!));
-    });
-    it('constructor with Date that has milliseconds', () => {
-        const date = new Date(2000, 0, 1, 12, 30, 45, 900);
-        let timestamp = new ion.Timestamp(date);
-        assert.equal(timestamp.getSecondsDecimal(), new ion.Decimal('45.900'));
     });
 });

--- a/test/IonTimestamp.ts
+++ b/test/IonTimestamp.ts
@@ -256,4 +256,9 @@ describe("Timestamp", () => {
         let timestamp4 = new ion.Timestamp(date2);
         assert.isTrue(timestamp3!.equals(timestamp4!));
     });
+    it('constructor with Date that has milliseconds', () => {
+        const date = new Date(2000, 0, 1, 12, 30, 45, 900);
+        let timestamp = new ion.Timestamp(date);
+        assert.equal(timestamp.getSecondsDecimal(), new ion.Decimal('45.900'));
+    });
 });


### PR DESCRIPTION
*Issue #, if available: #725*

This pull request modifies the constructor behavior to correctly handle a `Date` with non-zero milliseconds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
