### PR TITLE
Added node v18 into test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-          node-version: [10.x, 12.x, 14.x, 16.x, 18x]
+          node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-          node-version: [10.x, 12.x, 14.x, 16.x]
+          node-version: [10.x, 12.x, 14.x, 16.x, 18x]
 
     steps:
         - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An implementation of [Amazon Ion](https://amzn.github.io/ion-docs/) for JavaScri
 [![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-js/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://amzn.github.io/ion-js/api/index.html)
 
-This package is tested with Node JS major versions **10**, **12**, **14**, and **16**.  While this library
+This package is tested with Node JS major versions **10**, **12**, **14**, **16**, and **18**.  While this library
 should be usable within browsers that support **ES5+**, please note that it is not currently being tested
 in any browser environments.
 


### PR DESCRIPTION
Node v18 is a new LTS version, so adding it into test matrix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
