### PR TITLE
Updates test-driver to use `es2020`

### DIFF
--- a/test-driver/tsconfig.json
+++ b/test-driver/tsconfig.json
@@ -1,4 +1,4 @@
-// Test-driver Typscript Compiler Configuration
+// Test-driver Typescript Compiler Configuration
 // Targets CommonJS Module system and ES6 feature set.
 {
   "include": [
@@ -8,11 +8,11 @@
     "**/*.d.ts"
   ],
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "lib": ["es6", "es2017.object"],
+    "lib": ["ESNext"],
     "declaration": false,
     "inlineSources": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
-// Base Typscript Compiler Configuration
+// Base Typescript Compiler Configuration
 // Targets CommonJS Module system and ES6 feature set.
 {
   "include": ["src/**/*"],


### PR DESCRIPTION
*Issue #734*

*Description of changes:*
This PR refactors `tsconfig.json` for `test-driver` to point to `es2020`.
