### PR TITLE
Update release workflow to use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4.1.7
       - run: ls */* | cat
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - name: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     steps:
       - name: set env
         run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
@@ -66,8 +69,6 @@ jobs:
       - name: npm publish
         # skip npm publishing if running in a fork
         if: github.repository == 'amazon-ion/ion-js'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish
   update-docs:
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
### Description of changes:

NPM is making changes to authentication that necessitate migrating the publishing workflow to trusted publishing over using NPM tokens. This updates the workflow to use trusted publishing, getting ahead of the change.

See below:

- https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
- https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
