### PR TITLE
Fix issues breaking test workflow

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -37,7 +37,7 @@ jobs:
         env: 
           HEAD_URL: ${{ github.event.pull_request.head.repo.html_url }}
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
-          -i ion-js, "$HEAD_URL", ${{ github.event.pull_request.head.sha }}
+          -i "ion-js,$HEAD_URL,${{ github.event.pull_request.head.sha }}"
           --replace ion-js,https://github.com/amazon-ion/ion-js.git,$main
 
       - name: Upload result

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -41,7 +41,7 @@ jobs:
           --replace ion-js,https://github.com/amazon-ion/ion-js.git,$main
 
       - name: Upload result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ion-test-driver-result.ion
           path: output/results/ion-test-driver-results.ion
@@ -56,7 +56,7 @@ jobs:
           ion-js,$main ion-js,$cur output/results/ion-test-driver-results.ion
 
       - name: Upload analysis report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: analysis-report.ion
           path: result.ion


### PR DESCRIPTION
### Description of changes:

Version v1 and v2 of the `actions/upload-artifact` action was deprecated in June 2024. Workflows that use these versions now auto-fail. The test workflow is currently broken because it uses `actions/upload-artifact@v2`; this updates to version 4 to fix the workflow.

See: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Also, #780 unknowingly broke part of the workflow by adding some spaces in a shell command.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
